### PR TITLE
refactor: unify cmd/ command style across all runners

### DIFF
--- a/cmd/account/create.go
+++ b/cmd/account/create.go
@@ -41,7 +41,10 @@ four basic accounts, e.g. create an Asset account called Bank.
 
 Advanced users can also create Equity (C) accounts.
 
-Example: kea account create -t A -n Bank -b 100000`,
+Example:
+  kea account create --type A --name Bank --balance 100000
+  
+  kea account create --parent Assets:Bank --name Bank1 --balance 100000`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner := &createRunner{
 				defaultCurrency: svc.Config().Defaults.Currency,
@@ -53,11 +56,11 @@ Example: kea account create -t A -n Bank -b 100000`,
 		},
 	}
 	cmd.Flags().StringVarP(&flags.Name, "name", "n", "", "Account name")
-	cmd.Flags().StringVarP(&flags.Type, "type", "t", "", "Account type: A, L, R, E, C")
+	cmd.Flags().StringVarP(&flags.Type, "type", "t", "", "Account type: A, L, R, E, C (no need when creating subaccount)")
 	cmd.Flags().StringVarP(&flags.Parent, "parent", "p", "", "Parent account full name")
 	cmd.Flags().StringVarP(&flags.BalanceStr, "balance", "b", "0", "Initial balance")
 	cmd.Flags().StringVar(&flags.Currency, "currency", "", "Currency code")
-	cmd.Flags().StringVarP(&flags.Description, "description", "d", "", "Account description")
+	cmd.Flags().StringVarP(&flags.Description, "desc", "d", "", "Account description")
 
 	return cmd
 }

--- a/cmd/account/create.go
+++ b/cmd/account/create.go
@@ -61,6 +61,7 @@ Example:
 	cmd.Flags().StringVarP(&flags.BalanceStr, "balance", "b", "0", "Initial balance")
 	cmd.Flags().StringVar(&flags.Currency, "currency", "", "Currency code")
 	cmd.Flags().StringVarP(&flags.Description, "desc", "d", "", "Account description")
+	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output created account as JSON")
 
 	return cmd
 }
@@ -69,6 +70,10 @@ func (r *createRunner) Run(flags *createFlags, cmd *cobra.Command) error {
 	hasFlags := cmd.Flags().Changed("name") ||
 		cmd.Flags().Changed("type") ||
 		cmd.Flags().Changed("parent")
+
+	if flags.JSON && !hasFlags {
+		return fmt.Errorf("--json requires flags: --name and one of --type or --parent")
+	}
 
 	if hasFlags {
 		err := r.runFromFlags(flags)
@@ -136,6 +141,13 @@ func (r *createRunner) runFromFlags(flags *createFlags) error {
 		return err
 	}
 
+	if flags.JSON {
+		bal, err := r.accSvc.GetAccountBalance(newAccount.ID)
+		if err != nil {
+			return err
+		}
+		return views.WriteJSON(views.ToJSONAccount(newAccount, bal))
+	}
 	r.view.ShowSuccess(fmt.Sprintf("Account create successfully ! (ID: %d)", newAccount.ID))
 	return nil
 }

--- a/cmd/account/create.go
+++ b/cmd/account/create.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/service"
 	"github.com/hance08/kea/internal/store"
 	"github.com/hance08/kea/internal/utils"
@@ -15,17 +14,9 @@ import (
 )
 
 type createRunner struct {
-	name            string
-	fullName        string
-	parentID        *int64
-	accountType     model.AccountType
-	currency        string
-	balanceCents    int64
-	description     string
 	defaultCurrency string
-
-	accSvc CreateProvider
-	view   CreateView
+	accSvc          CreateProvider
+	view            CreateView
 }
 
 func NewCreateCmd(svc *service.Service) *cobra.Command {
@@ -43,7 +34,7 @@ Advanced users can also create Equity (C) accounts.
 
 Example:
   kea account create --type A --name Bank --balance 100000
-  
+
   kea account create --parent Assets:Bank --name Bank1 --balance 100000`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner := &createRunner{
@@ -69,77 +60,33 @@ Example:
 func (r *createRunner) Run(flags *createFlags, cmd *cobra.Command) error {
 	hasFlags := cmd.Flags().Changed("name") ||
 		cmd.Flags().Changed("type") ||
-		cmd.Flags().Changed("parent")
+		cmd.Flags().Changed("parent") || cmd.Flags().Changed("balance") ||
+		cmd.Flags().Changed("currency") || cmd.Flags().Changed("desc")
 
 	if flags.JSON && !hasFlags {
 		return fmt.Errorf("--json requires flags: --name and one of --type or --parent")
 	}
 
-	if hasFlags {
-		err := r.runFromFlags(flags)
-		if err != nil {
-			if errors.Is(err, store.ErrAccountExists) {
-				if flags.JSON {
-					return err
-				}
-				pterm.Error.Println("Account already exists")
-				return nil
-			}
-			return err
-		}
-		return nil
-	}
+	var input createInput
+	var err error
 
-	err := r.runInteractive()
+	if hasFlags {
+		input, err = r.runFromFlags(flags)
+	} else {
+		input, err = r.runInteractive()
+	}
 	if err != nil {
+		if errors.Is(err, store.ErrAccountExists) {
+			if flags.JSON {
+				return err
+			}
+			pterm.Error.Println("Account already exists")
+			return nil
+		}
 		return err
 	}
-	return nil
-}
 
-func (r *createRunner) runFromFlags(flags *createFlags) error {
-	// Validate flag combinations
-	if flags.Parent == "" && flags.Type == "" {
-		return fmt.Errorf("must enter at least one of --type or --parent flag")
-	}
-	if flags.Parent != "" && flags.Type != "" {
-		return fmt.Errorf("--type and --parent flags cannot be used at the same time")
-	}
-
-	// Validate account name (before combining with parent/root)
-	if err := r.accSvc.ValidateAccountName(flags.Name); err != nil {
-		return fmt.Errorf("invalid account name: %w", err)
-	}
-
-	r.name = flags.Name
-	r.description = flags.Description
-
-	// Build account based on parent or type
-	if flags.Parent != "" {
-		if err := r.buildFromParentName(flags.Parent, flags.Currency); err != nil {
-			return err
-		}
-	} else {
-		if err := r.buildFromTypeFlag(flags.Type, flags.Currency); err != nil {
-			return err
-		}
-	}
-
-	// Validate final name using validation package
-	if err := r.accSvc.ValidateFullAccountName(r.fullName); err != nil {
-		return fmt.Errorf("validate account name: %w", err)
-	}
-
-	// Handle balance (Parse the balance into cent format, e.g. "150" -> "15000")
-	balanceCents, err := utils.ParseAmount(flags.BalanceStr)
-	if err != nil {
-		return fmt.Errorf("invalid balance format '%s': please enter a number (e.g. 100 or 100.50)", flags.BalanceStr)
-	}
-
-	r.balanceCents = balanceCents
-
-	// createAccount account
-	newAccount, err := r.createAccount()
+	newAccount, err := r.createAccount(input)
 	if err != nil {
 		return err
 	}
@@ -151,102 +98,122 @@ func (r *createRunner) runFromFlags(flags *createFlags) error {
 		}
 		return views.WriteJSON(views.ToJSONAccount(newAccount, bal))
 	}
-	r.view.ShowSuccess(fmt.Sprintf("Account create successfully ! (ID: %d)", newAccount.ID))
+	r.view.ShowSuccess(fmt.Sprintf("Account created successfully (ID: %d)", newAccount.ID))
 	return nil
 }
 
-func (r *createRunner) runInteractive() error {
-	// Step 1: Check if is subaccount
+func (r *createRunner) runFromFlags(flags *createFlags) (createInput, error) {
+	if flags.Parent == "" && flags.Type == "" {
+		return createInput{}, fmt.Errorf("must enter at least one of --type or --parent flag")
+	}
+	if flags.Parent != "" && flags.Type != "" {
+		return createInput{}, fmt.Errorf("--type and --parent flags cannot be used at the same time")
+	}
+
+	if err := r.accSvc.ValidateAccountName(flags.Name); err != nil {
+		return createInput{}, fmt.Errorf("invalid account name: %w", err)
+	}
+
+	var input createInput
+	input.description = flags.Description
+
+	if flags.Parent != "" {
+		if err := r.buildFromParentName(flags.Parent, flags.Currency, &input); err != nil {
+			return createInput{}, err
+		}
+	} else {
+		if err := r.buildFromTypeFlag(flags.Type, flags.Currency, &input); err != nil {
+			return createInput{}, err
+		}
+	}
+
+	// input.fullName is now the prefix (parentAccount.Name or rootName)
+	// FormatAccountName combines prefix + flags.Name to get the full path
+	input.fullName = r.accSvc.FormatAccountName(input.fullName, flags.Name)
+	if err := r.accSvc.ValidateFullAccountName(input.fullName); err != nil {
+		return createInput{}, fmt.Errorf("validate account name: %w", err)
+	}
+
+	balanceCents, err := utils.ParseAmount(flags.BalanceStr)
+	if err != nil {
+		return createInput{}, fmt.Errorf("invalid balance format '%s': please enter a number (e.g. 100 or 100.50)", flags.BalanceStr)
+	}
+	input.balanceCents = balanceCents
+
+	return input, nil
+}
+
+func (r *createRunner) runInteractive() (createInput, error) {
+	var input createInput
+
 	isSubAccount, err := prompts.PromptIsSubAccount()
 	if err != nil {
-		return err
+		return createInput{}, err
 	}
 
 	if isSubAccount {
-		// Step 2: Select parent account
 		parentAccount, err := r.promptParent()
 		if err != nil {
-			return err
+			return createInput{}, err
 		}
-
-		// Step 3: Enter account name
 		nameInput, err := r.promptName(parentAccount.Name)
 		if err != nil {
-			return err
+			return createInput{}, err
 		}
-
-		r.name = nameInput
-
-		r.applyParentSettings(parentAccount, parentAccount.Currency)
-
+		r.applyParentSettings(parentAccount, parentAccount.Currency, &input)
+		input.fullName = r.accSvc.FormatAccountName(parentAccount.Name, nameInput)
 	} else {
-		// Step 2: Select account type
 		accType, err := r.promptType()
 		if err != nil {
-			return err
+			return createInput{}, err
 		}
-
 		rootName, err := r.accSvc.GetRootNameByType(accType)
 		if err != nil {
-			return err
+			return createInput{}, err
 		}
-
-		// Step 3: Enter account name
 		nameInput, err := r.promptName(rootName)
 		if err != nil {
-			return err
+			return createInput{}, err
 		}
-
-		r.name = nameInput
-
-		if err := r.applyTypeSettings(rootName, accType, ""); err != nil {
-			return err
+		if err := r.applyTypeSettings(rootName, accType, "", &input); err != nil {
+			return createInput{}, err
 		}
+		input.fullName = r.accSvc.FormatAccountName(rootName, nameInput)
 	}
 
-	// Step 4: Currency setting
-	currency, err := r.promptCurrency()
+	currency, err := r.promptCurrency(input)
 	if err != nil {
-		return err
+		return createInput{}, err
 	}
-	r.currency = currency
+	input.currency = currency
 
-	// Step 5: Initial balance setting
-	if r.accountType == "A" || r.accountType == "L" {
+	if input.accountType == "A" || input.accountType == "L" {
 		balanceCents, err := r.promptBalance()
 		if err != nil {
-			return err
+			return createInput{}, err
 		}
-		r.balanceCents = balanceCents
+		input.balanceCents = balanceCents
 	}
 
-	// Step 6: Description setting
 	desc, err := r.promptDescription()
 	if err != nil {
-		return err
+		return createInput{}, err
 	}
+	input.description = desc
 
-	r.description = desc
 	if err := r.view.RenderSummary(views.AccountSummaryItem{
-		FullName:    r.fullName,
-		Type:        r.accountType,
-		Currency:    r.currency,
-		Balance:     r.balanceCents,
-		Description: r.description}); err != nil {
-		return err
+		FullName:    input.fullName,
+		Type:        input.accountType,
+		Currency:    input.currency,
+		Balance:     input.balanceCents,
+		Description: input.description,
+	}); err != nil {
+		return createInput{}, err
 	}
 
-	// Confirm proceed with creation
 	if err := r.confirm(); err != nil {
-		return err
+		return createInput{}, err
 	}
 
-	// createAccount account
-	newAccount, err := r.createAccount()
-	if err != nil {
-		return err
-	}
-
-	r.view.ShowSuccess(fmt.Sprintf("Account create successfully ! (ID: %d)", newAccount.ID))
-	return nil
+	return input, nil
 }

--- a/cmd/account/create.go
+++ b/cmd/account/create.go
@@ -79,10 +79,13 @@ func (r *createRunner) Run(flags *createFlags, cmd *cobra.Command) error {
 		err := r.runFromFlags(flags)
 		if err != nil {
 			if errors.Is(err, store.ErrAccountExists) {
+				if flags.JSON {
+					return err
+				}
 				pterm.Error.Println("Account already exists")
-			} else {
-				return err
+				return nil
 			}
+			return err
 		}
 		return nil
 	}

--- a/cmd/account/create_actions.go
+++ b/cmd/account/create_actions.go
@@ -9,63 +9,60 @@ import (
 	"github.com/hance08/kea/ui/prompts"
 )
 
-func (r *createRunner) createAccount() (*model.Account, error) {
-
+func (r *createRunner) createAccount(input createInput) (*model.Account, error) {
 	return r.accSvc.CreateAccountWithBalance(
-		r.fullName,
-		r.accountType,
-		r.currency,
-		r.description,
-		r.parentID,
-		r.balanceCents,
+		input.fullName,
+		input.accountType,
+		input.currency,
+		input.description,
+		input.parentID,
+		input.balanceCents,
 	)
-
 }
 
-func (r *createRunner) applyTypeSettings(rootName, accType, currencyOverride string) error {
-	r.fullName = r.accSvc.FormatAccountName(rootName, r.name)
-	r.accountType = model.AccountType(accType)
-
+func (r *createRunner) applyTypeSettings(rootName, accType, currencyOverride string, input *createInput) error {
+	input.accountType = model.AccountType(accType)
 	if currencyOverride != "" {
 		if err := r.accSvc.ValidateCurrency(currencyOverride); err != nil {
 			return err
 		}
-		r.currency = strings.ToUpper(strings.TrimSpace(currencyOverride))
+		input.currency = strings.ToUpper(strings.TrimSpace(currencyOverride))
 	} else {
-		r.currency = r.defaultCurrency
+		input.currency = r.defaultCurrency
 	}
 	return nil
 }
 
-func (r *createRunner) applyParentSettings(parent *model.Account, currencyOverride string) {
-	r.fullName = r.accSvc.FormatAccountName(parent.Name, r.name)
-	r.accountType = parent.Type
-	r.parentID = &parent.ID
-
+func (r *createRunner) applyParentSettings(parent *model.Account, currencyOverride string, input *createInput) {
+	input.accountType = parent.Type
+	input.parentID = &parent.ID
 	if currencyOverride != "" {
-		r.currency = currencyOverride
+		input.currency = currencyOverride
 	} else {
-		r.currency = parent.Currency
+		input.currency = parent.Currency
 	}
 }
 
-func (r *createRunner) buildFromParentName(parentName, currency string) error {
+func (r *createRunner) buildFromParentName(parentName, currency string, input *createInput) error {
 	parentAccount, err := r.accSvc.GetAccountByName(parentName)
 	if err != nil {
 		return err
 	}
-
-	r.applyParentSettings(parentAccount, currency)
+	r.applyParentSettings(parentAccount, currency, input)
+	input.fullName = parentAccount.Name // prefix for FormatAccountName in runFromFlags
 	return nil
 }
 
-func (r *createRunner) buildFromTypeFlag(accType, currency string) error {
+func (r *createRunner) buildFromTypeFlag(accType, currency string, input *createInput) error {
 	rootName, err := r.accSvc.GetRootNameByType(accType)
 	if err != nil {
 		return fmt.Errorf("get root name: %w", err)
 	}
-
-	return r.applyTypeSettings(rootName, accType, currency)
+	if err := r.applyTypeSettings(rootName, accType, currency, input); err != nil {
+		return err
+	}
+	input.fullName = rootName // prefix for FormatAccountName in runFromFlags
+	return nil
 }
 
 func (r *createRunner) promptType() (string, error) {
@@ -110,18 +107,13 @@ func (r *createRunner) promptName(prefix string) (string, error) {
 	return prompts.PromptAccountName(surveyValidator)
 }
 
-func (r *createRunner) promptCurrency() (string, error) {
-	defaultCurrency := r.currency
-
+func (r *createRunner) promptCurrency(input createInput) (string, error) {
+	defaultCurrency := input.currency
 	if defaultCurrency == "" {
-		//TODO: Validate the string in the config file
 		defaultCurrency = r.defaultCurrency
 	}
-
-	isInherited := r.parentID != nil
-
+	isInherited := input.parentID != nil
 	return prompts.PromptCurrency(defaultCurrency, isInherited, r.accSvc.ValidateCurrency)
-
 }
 
 func (r *createRunner) promptBalance() (int64, error) {

--- a/cmd/account/create_types.go
+++ b/cmd/account/create_types.go
@@ -24,11 +24,11 @@ type CreateProvider interface {
 }
 
 type createInput struct {
-	fullName    string
-	accountType model.AccountType
-	currency    string
-	description string
-	parentID    *int64
+	fullName     string
+	accountType  model.AccountType
+	currency     string
+	description  string
+	parentID     *int64
 	balanceCents int64
 }
 

--- a/cmd/account/create_types.go
+++ b/cmd/account/create_types.go
@@ -20,6 +20,7 @@ type CreateProvider interface {
 	ValidateAccountName(name string) error
 	ValidateFullAccountName(name string) error
 	ValidateCurrency(currency string) error
+	GetAccountBalance(id int64) (int64, error)
 }
 
 type createFlags struct {
@@ -29,4 +30,5 @@ type createFlags struct {
 	BalanceStr  string
 	Currency    string
 	Description string
+	JSON        bool
 }

--- a/cmd/account/create_types.go
+++ b/cmd/account/create_types.go
@@ -23,6 +23,15 @@ type CreateProvider interface {
 	GetAccountBalance(id int64) (int64, error)
 }
 
+type createInput struct {
+	fullName    string
+	accountType model.AccountType
+	currency    string
+	description string
+	parentID    *int64
+	balanceCents int64
+}
+
 type createFlags struct {
 	Name        string
 	Type        string

--- a/cmd/account/delete.go
+++ b/cmd/account/delete.go
@@ -9,9 +9,9 @@ import (
 )
 
 type deleteRunner struct {
-	svc  *service.Service
-	yes  bool
-	json bool
+	svc     *service.Service
+	yes     bool
+	jsonOut bool
 }
 
 func NewDeleteCmd(svc *service.Service) *cobra.Command {
@@ -25,7 +25,7 @@ func NewDeleteCmd(svc *service.Service) *cobra.Command {
 		Long:    "Delete an account that has no transactions, no child accounts, and is not the system opening balance account.",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runner := &deleteRunner{svc: svc, yes: yes || jsonOut, json: jsonOut}
+			runner := &deleteRunner{svc: svc, yes: yes || jsonOut, jsonOut: jsonOut}
 			return runner.Run(args[0])
 		},
 	}
@@ -43,7 +43,7 @@ func (r *deleteRunner) Run(name string) error {
 		return nil
 	}
 
-	if !r.json {
+	if !r.jsonOut {
 		pterm.Info.Printf("Account: %s | Type: %s | Currency: %s | Hidden: %t\n", acc.Name, acc.Type, acc.Currency, acc.IsHidden)
 	}
 
@@ -64,7 +64,7 @@ func (r *deleteRunner) Run(name string) error {
 		return nil
 	}
 
-	if r.json {
+	if r.jsonOut {
 		return views.WriteJSON(map[string]any{"name": acc.Name, "deleted": true})
 	}
 	pterm.Success.Printf("Account %q deleted\n", acc.Name)

--- a/cmd/account/delete.go
+++ b/cmd/account/delete.go
@@ -18,7 +18,7 @@ type AccountDeleteProvider interface {
 
 type deleteFlags struct {
 	Yes     bool
-	JSONOut bool
+	JSON    bool
 }
 
 type deleteRunner struct {
@@ -37,13 +37,13 @@ func NewDeleteCmd(svc *service.Service) *cobra.Command {
 		Long:    "Delete an account that has no transactions, no child accounts, and is not the system opening balance account.",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runner := &deleteRunner{svc: svc.Account(), yes: flags.Yes || flags.JSONOut, json: flags.JSONOut}
+			runner := &deleteRunner{svc: svc.Account(), yes: flags.Yes || flags.JSON, json: flags.JSON}
 			return runner.Run(args[0])
 		},
 	}
 
 	cmd.Flags().BoolVarP(&flags.Yes, "yes", "y", false, "confirm deletion without interactive prompt")
-	cmd.Flags().BoolVarP(&flags.JSONOut, "json", "j", false, "output result as JSON")
+	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output result as JSON")
 
 	return cmd
 }

--- a/cmd/account/delete.go
+++ b/cmd/account/delete.go
@@ -1,6 +1,9 @@
 package account
 
 import (
+	"fmt"
+
+	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/service"
 	"github.com/hance08/kea/ui/prompts"
 	"github.com/hance08/kea/ui/views"
@@ -8,15 +11,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type AccountDeleteProvider interface {
+	GetAccountByName(name string) (*model.Account, error)
+	DeleteAccountByName(name string) error
+}
+
+type deleteFlags struct {
+	Yes     bool
+	JSONOut bool
+}
+
 type deleteRunner struct {
-	svc     *service.Service
-	yes     bool
-	jsonOut bool
+	svc  AccountDeleteProvider
+	yes  bool
+	json bool
 }
 
 func NewDeleteCmd(svc *service.Service) *cobra.Command {
-	var yes bool
-	var jsonOut bool
+	flags := &deleteFlags{}
 
 	cmd := &cobra.Command{
 		Use:     "delete <account-name>",
@@ -25,28 +37,24 @@ func NewDeleteCmd(svc *service.Service) *cobra.Command {
 		Long:    "Delete an account that has no transactions, no child accounts, and is not the system opening balance account.",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runner := &deleteRunner{svc: svc, yes: yes || jsonOut, jsonOut: jsonOut}
+			runner := &deleteRunner{svc: svc.Account(), yes: flags.Yes || flags.JSONOut, json: flags.JSONOut}
 			return runner.Run(args[0])
 		},
 	}
 
-	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "confirm deletion without interactive prompt")
-	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "output result as JSON")
+	cmd.Flags().BoolVarP(&flags.Yes, "yes", "y", false, "confirm deletion without interactive prompt")
+	cmd.Flags().BoolVarP(&flags.JSONOut, "json", "j", false, "output result as JSON")
 
 	return cmd
 }
 
 func (r *deleteRunner) Run(name string) error {
-	acc, err := r.svc.Account().GetAccountByName(name)
+	acc, err := r.svc.GetAccountByName(name)
 	if err != nil {
-		if r.jsonOut {
-			return err
-		}
-		pterm.Error.Printf("Failed to delete account: %v\n", err)
-		return nil
+		return fmt.Errorf("failed to find account: %w", err)
 	}
 
-	if !r.jsonOut {
+	if !r.json {
 		pterm.Info.Printf("Account: %s | Type: %s | Currency: %s | Hidden: %t\n", acc.Name, acc.Type, acc.Currency, acc.IsHidden)
 	}
 
@@ -55,22 +63,17 @@ func (r *deleteRunner) Run(name string) error {
 		if err != nil {
 			return err
 		}
-
 		if !confirm {
 			pterm.Info.Println("Deletion cancelled")
 			return nil
 		}
 	}
 
-	if err := r.svc.Account().DeleteAccountByName(acc.Name); err != nil {
-		if r.jsonOut {
-			return err
-		}
-		pterm.Error.Printf("Failed to delete account: %v\n", err)
-		return nil
+	if err := r.svc.DeleteAccountByName(acc.Name); err != nil {
+		return fmt.Errorf("failed to delete account: %w", err)
 	}
 
-	if r.jsonOut {
+	if r.json {
 		return views.WriteJSON(map[string]any{"name": acc.Name, "deleted": true})
 	}
 	pterm.Success.Printf("Account %q deleted\n", acc.Name)

--- a/cmd/account/delete.go
+++ b/cmd/account/delete.go
@@ -3,17 +3,20 @@ package account
 import (
 	"github.com/hance08/kea/internal/service"
 	"github.com/hance08/kea/ui/prompts"
+	"github.com/hance08/kea/ui/views"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
 
 type deleteRunner struct {
-	svc *service.Service
-	yes bool
+	svc  *service.Service
+	yes  bool
+	json bool
 }
 
 func NewDeleteCmd(svc *service.Service) *cobra.Command {
 	var yes bool
+	var jsonOut bool
 
 	cmd := &cobra.Command{
 		Use:     "delete <account-name>",
@@ -22,12 +25,13 @@ func NewDeleteCmd(svc *service.Service) *cobra.Command {
 		Long:    "Delete an account that has no transactions, no child accounts, and is not the system opening balance account.",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runner := &deleteRunner{svc: svc, yes: yes}
+			runner := &deleteRunner{svc: svc, yes: yes || jsonOut, json: jsonOut}
 			return runner.Run(args[0])
 		},
 	}
 
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "confirm deletion without interactive prompt")
+	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "output result as JSON")
 
 	return cmd
 }
@@ -39,7 +43,9 @@ func (r *deleteRunner) Run(name string) error {
 		return nil
 	}
 
-	pterm.Info.Printf("Account: %s | Type: %s | Currency: %s | Hidden: %t\n", acc.Name, acc.Type, acc.Currency, acc.IsHidden)
+	if !r.json {
+		pterm.Info.Printf("Account: %s | Type: %s | Currency: %s | Hidden: %t\n", acc.Name, acc.Type, acc.Currency, acc.IsHidden)
+	}
 
 	if !r.yes {
 		confirm, err := prompts.PromptConfirm("This will permanently delete the account. Continue?", false)
@@ -58,6 +64,9 @@ func (r *deleteRunner) Run(name string) error {
 		return nil
 	}
 
+	if r.json {
+		return views.WriteJSON(map[string]any{"name": acc.Name, "deleted": true})
+	}
 	pterm.Success.Printf("Account %q deleted\n", acc.Name)
 	return nil
 }

--- a/cmd/account/delete.go
+++ b/cmd/account/delete.go
@@ -39,6 +39,9 @@ func NewDeleteCmd(svc *service.Service) *cobra.Command {
 func (r *deleteRunner) Run(name string) error {
 	acc, err := r.svc.Account().GetAccountByName(name)
 	if err != nil {
+		if r.jsonOut {
+			return err
+		}
 		pterm.Error.Printf("Failed to delete account: %v\n", err)
 		return nil
 	}
@@ -60,6 +63,9 @@ func (r *deleteRunner) Run(name string) error {
 	}
 
 	if err := r.svc.Account().DeleteAccountByName(acc.Name); err != nil {
+		if r.jsonOut {
+			return err
+		}
 		pterm.Error.Printf("Failed to delete account: %v\n", err)
 		return nil
 	}

--- a/cmd/account/delete.go
+++ b/cmd/account/delete.go
@@ -17,7 +17,7 @@ func NewDeleteCmd(svc *service.Service) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "delete <account-name>",
-		Aliases: []string{"d", "del"},
+		Aliases: []string{"del", "d"},
 		Short:   "Delete an account with no transactions",
 		Long:    "Delete an account that has no transactions, no child accounts, and is not the system opening balance account.",
 		Args:    cobra.ExactArgs(1),

--- a/cmd/account/list.go
+++ b/cmd/account/list.go
@@ -12,6 +12,7 @@ import (
 type listFlags struct {
 	Type       string
 	ShowHidden bool
+	JSON       bool
 }
 
 type listRunner struct {
@@ -39,6 +40,7 @@ You can filter by account type or show hidden accounts.`,
 
 	cmd.Flags().StringVarP(&flags.Type, "type", "t", "", "Filter accounts by type (A, L, C, R, E)")
 	cmd.Flags().BoolVar(&flags.ShowHidden, "show-hidden", false, "Show hidden accounts")
+	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output as JSON")
 
 	return cmd
 }
@@ -62,11 +64,18 @@ func (r *listRunner) Run() error {
 		accounts = r.filterHiddenAccounts(accounts)
 	}
 
-	if err := views.NewAccountListView().Render(accounts, r.svc.Account().GetAccountBalanceFormatted); err != nil {
-		return err
+	if r.flags.JSON {
+		items := make([]views.JSONAccount, 0, len(accounts))
+		for _, acc := range accounts {
+			bal, err := r.svc.Account().GetAccountBalance(acc.ID)
+			if err != nil {
+				return fmt.Errorf("failed to get balance for %s: %w", acc.Name, err)
+			}
+			items = append(items, views.ToJSONAccount(acc, bal))
+		}
+		return views.WriteJSON(items)
 	}
-
-	return nil
+	return views.NewAccountListView().Render(accounts, r.svc.Account().GetAccountBalanceFormatted)
 }
 
 func (r *listRunner) filterHiddenAccounts(accounts []*model.Account) []*model.Account {

--- a/cmd/account/list.go
+++ b/cmd/account/list.go
@@ -15,8 +15,15 @@ type listFlags struct {
 	JSON       bool
 }
 
+type AccountListProvider interface {
+	GetAccountsByType(accType model.AccountType) ([]*model.Account, error)
+	GetAllAccounts() ([]*model.Account, error)
+	GetAccountBalance(id int64) (int64, error)
+	GetAccountBalanceFormatted(id int64) (string, error)
+}
+
 type listRunner struct {
-	svc   *service.Service
+	svc   AccountListProvider
 	flags *listFlags
 }
 
@@ -31,7 +38,7 @@ func NewListCmd(svc *service.Service) *cobra.Command {
 You can filter by account type or show hidden accounts.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner := &listRunner{
-				svc:   svc,
+				svc:   svc.Account(),
 				flags: flags,
 			}
 			return runner.Run()
@@ -51,9 +58,9 @@ func (r *listRunner) Run() error {
 	var err error
 
 	if r.flags.Type != "" {
-		accounts, err = r.svc.Account().GetAccountsByType(model.AccountType(r.flags.Type))
+		accounts, err = r.svc.GetAccountsByType(model.AccountType(r.flags.Type))
 	} else {
-		accounts, err = r.svc.Account().GetAllAccounts()
+		accounts, err = r.svc.GetAllAccounts()
 	}
 
 	if err != nil {
@@ -67,7 +74,7 @@ func (r *listRunner) Run() error {
 	if r.flags.JSON {
 		items := make([]views.JSONAccount, 0, len(accounts))
 		for _, acc := range accounts {
-			bal, err := r.svc.Account().GetAccountBalance(acc.ID)
+			bal, err := r.svc.GetAccountBalance(acc.ID)
 			if err != nil {
 				return fmt.Errorf("failed to get balance for %s: %w", acc.Name, err)
 			}
@@ -75,7 +82,7 @@ func (r *listRunner) Run() error {
 		}
 		return views.WriteJSON(items)
 	}
-	return views.NewAccountListView().Render(accounts, r.svc.Account().GetAccountBalanceFormatted)
+	return views.NewAccountListView().Render(accounts, r.svc.GetAccountBalanceFormatted)
 }
 
 func (r *listRunner) filterHiddenAccounts(accounts []*model.Account) []*model.Account {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -24,18 +24,13 @@ func NewAddCmd(svc *service.Service) *cobra.Command {
 		Short: "Add a new transaction",
 		Long: `Add a new transaction to your accounting system.
 
-	This command allows you to record financial transactions using double-entry bookkeeping.
-	You can use flags for quick entry or interactive mode for guided input.
+This command allows you to record financial transactions using double-entry bookkeeping.
+You can use flags for quick entry or interactive mode for guided input.
 
-	Examples:
-	# Interactive mode (recommended for beginners)
-	kea add
+Examples:
+  kea add (recommended for beginners)
 
-	# Quick mode with flags
-	kea add --description "Buy Coffee" --amount 150 --from "Assets:Cash" --to "Expenses:Food:Coffee"
-	
-	# With pending status (default is cleared)
-	kea add --description "Pending cost" --amount 500 --from "Assets:Bank" --to "Expenses:Shopping" --status pending`,
+  kea add --desc "Buy Coffee" --amount 150 --from "Assets:Cash" --to "Expenses:Food:Coffee"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner := &addRunner{
 				accSvc:  svc.Account(),

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -49,6 +49,7 @@ Examples:
 	cmd.Flags().StringVarP(&flags.Status, "status", "s", "cleared", "Transaction status: pending or cleared")
 	cmd.Flags().StringVar(&flags.Timestamp, "date", "", "Transaction date (YYYY-MM-DD), default is today")
 	cmd.Flags().StringVarP(&flags.Type, "type", "T", "", "Transaction type: expense, income, or transfer (validates account types when provided)")
+	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output created transaction as JSON")
 
 	return cmd
 }
@@ -61,6 +62,10 @@ func (r *addRunner) Run() error {
 	hasFlags := r.cmd.Flags().Changed("desc") || r.cmd.Flags().Changed("amount") ||
 		r.cmd.Flags().Changed("from") || r.cmd.Flags().Changed("to") ||
 		r.cmd.Flags().Changed("type")
+
+	if r.flags.JSON && !hasFlags {
+		return fmt.Errorf("--json requires flags: --desc, --amount, --from, --to")
+	}
 
 	if hasFlags {
 		// Flag mode: validate all required flags
@@ -86,9 +91,8 @@ func (r *addRunner) Run() error {
 	}
 
 	// Display transaction summary
-	if err := r.addView.Render(&result, true); err != nil {
-		return err
+	if r.flags.JSON {
+		return views.WriteJSON(views.ToJSONTxDetail(&result))
 	}
-
-	return nil
+	return r.addView.Render(&result, true)
 }

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -9,11 +9,9 @@ import (
 )
 
 type addRunner struct {
-	accSvc  AddProvider
-	txSvc   TransactionProvider
-	addView AddView
-	flags   *addFlags
-	cmd     *cobra.Command
+	accSvc AddProvider
+	txSvc  TransactionProvider
+	view   AddView
 }
 
 func NewAddCmd(svc *service.Service) *cobra.Command {
@@ -33,13 +31,12 @@ Examples:
   kea add --desc "Buy Coffee" --amount 150 --from "Assets:Cash" --to "Expenses:Food:Coffee"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner := &addRunner{
-				accSvc:  svc.Account(),
-				txSvc:   svc.Transaction(),
-				addView: views.NewTransactionDetailView(),
-				flags:   flags,
-				cmd:     cmd,
+				accSvc: svc.Account(),
+				txSvc:  svc.Transaction(),
+				view:   views.NewTransactionDetailView(),
 			}
-			return runner.Run()
+
+			return runner.Run(flags, cmd)
 		},
 	}
 	cmd.Flags().StringVarP(&flags.Description, "desc", "d", "", "Transaction description")
@@ -54,22 +51,22 @@ Examples:
 	return cmd
 }
 
-func (r *addRunner) Run() error {
+func (r *addRunner) Run(flags *addFlags, cmd *cobra.Command) error {
 	var input addTransactionInput
 	var err error
 
 	// Check if using flag mode or interactive mode
-	hasFlags := r.cmd.Flags().Changed("desc") || r.cmd.Flags().Changed("amount") ||
-		r.cmd.Flags().Changed("from") || r.cmd.Flags().Changed("to") ||
-		r.cmd.Flags().Changed("type")
+	hasFlags := cmd.Flags().Changed("desc") || cmd.Flags().Changed("amount") ||
+		cmd.Flags().Changed("from") || cmd.Flags().Changed("to") ||
+		cmd.Flags().Changed("type")
 
-	if r.flags.JSON && !hasFlags {
-		return fmt.Errorf("--json requires flags: --desc, --amount, --from, --to")
+	if flags.JSON && !hasFlags {
+		return fmt.Errorf("--json requires flags: --type, --amount, --from, --to")
 	}
 
 	if hasFlags {
 		// Flag mode: validate all required flags
-		input, err = r.runFromFlags()
+		input, err = r.runFromFlags(flags)
 	} else {
 		// Interactive mode
 		input, err = r.runInteractive()
@@ -91,8 +88,8 @@ func (r *addRunner) Run() error {
 	}
 
 	// Display transaction summary
-	if r.flags.JSON {
+	if flags.JSON {
 		return views.WriteJSON(views.ToJSONTxDetail(&result))
 	}
-	return r.addView.Render(&result, true)
+	return r.view.Render(&result, true)
 }

--- a/cmd/add_actions.go
+++ b/cmd/add_actions.go
@@ -10,19 +10,19 @@ import (
 	"github.com/hance08/kea/ui/prompts"
 )
 
-func (r *addRunner) runFromFlags() (addTransactionInput, error) {
+func (r *addRunner) runFromFlags(flags *addFlags) (addTransactionInput, error) {
 	// Flag mode: validate all required flags
-	if r.flags.Amount == "" || r.flags.From == "" || r.flags.To == "" {
+	if flags.Amount == "" || flags.From == "" || flags.To == "" {
 		return addTransactionInput{}, fmt.Errorf("when using flags, --amount, --from, and --to are all required")
 	}
 
 	var srcAllowedTypes, dstAllowedTypes []string
 
 	// Validate account types if --type is provided
-	if r.flags.Type != "" {
-		mode := r.determineMode(r.flags.Type)
+	if flags.Type != "" {
+		mode := r.determineMode(flags.Type)
 		if mode != model.TxTypeExpense && mode != model.TxTypeIncome && mode != model.TxTypeTransfer {
-			return addTransactionInput{}, fmt.Errorf("invalid type %q: must be expense, income, or transfer", r.flags.Type)
+			return addTransactionInput{}, fmt.Errorf("invalid type %q: must be expense, income, or transfer", flags.Type)
 		}
 		rule, err := r.txSvc.GetTransactionRule(mode)
 		if err != nil {
@@ -32,40 +32,40 @@ func (r *addRunner) runFromFlags() (addTransactionInput, error) {
 		dstAllowedTypes = rule.DestTypes
 	}
 
-	description := r.flags.Description
+	description := flags.Description
 	if description == "" {
 		description = "-"
 	}
 
 	// Parse amount
-	amountCents, err := utils.ParseAmount(r.flags.Amount)
+	amountCents, err := utils.ParseAmount(flags.Amount)
 	if err != nil {
 		return addTransactionInput{}, fmt.Errorf("invalid amount: %w", err)
 	}
 
 	// Parse status
 	status := model.StatusCleared
-	if strings.ToLower(r.flags.Status) == "pending" {
+	if strings.ToLower(flags.Status) == "pending" {
 		status = model.StatusPending
 	}
 
 	// Parse timestamp
-	timestamp, err := r.parseDate(r.flags.Timestamp)
+	timestamp, err := r.parseDate(flags.Timestamp)
 	if err != nil {
 		return addTransactionInput{}, err
 	}
 
-	if err := r.validateAccountSelectable(r.flags.From, srcAllowedTypes, "--from"); err != nil {
+	if err := r.validateAccountSelectable(flags.From, srcAllowedTypes, "--from"); err != nil {
 		return addTransactionInput{}, err
 	}
 
-	if err := r.validateAccountSelectable(r.flags.To, dstAllowedTypes, "--to"); err != nil {
+	if err := r.validateAccountSelectable(flags.To, dstAllowedTypes, "--to"); err != nil {
 		return addTransactionInput{}, err
 	}
 
 	return addTransactionInput{
-		FromAccountID: r.flags.From,
-		ToAccountID:   r.flags.To,
+		FromAccountID: flags.From,
+		ToAccountID:   flags.To,
 		AmountCents:   amountCents,
 		Description:   description,
 		Timestamp:     timestamp,
@@ -201,4 +201,10 @@ func (r *addRunner) parseDate(dateStr string) (int64, error) {
 		return 0, fmt.Errorf("invalid date format, use %s: %w", model.DateFormat, err)
 	}
 	return t.Unix(), nil
+}
+
+var modeUIConfigs = map[model.TransactionType]struct{ Src, Dst string }{
+	model.ModeExpense:  {"Payment Source:", "Expense Type:"},
+	model.ModeIncome:   {"Revenue Type:", "Deposit To:"},
+	model.ModeTransfer: {"From Account:", "To Account:"},
 }

--- a/cmd/add_types.go
+++ b/cmd/add_types.go
@@ -34,6 +34,7 @@ type addFlags struct {
 	Status      string
 	Timestamp   string
 	Type        string
+	JSON        bool
 }
 
 type addTransactionInput struct {

--- a/cmd/add_types.go
+++ b/cmd/add_types.go
@@ -20,12 +20,6 @@ type TransactionProvider interface {
 	CreateSimpleTransaction(fromAccount string, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus) (model.TransactionDetail, error)
 }
 
-var modeUIConfigs = map[model.TransactionType]struct{ Src, Dst string }{
-	model.ModeExpense:  {"Payment Source:", "Expense Type:"},
-	model.ModeIncome:   {"Revenue Type:", "Deposit To:"},
-	model.ModeTransfer: {"From Account:", "To Account:"},
-}
-
 type addFlags struct {
 	Description string
 	Amount      string

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -4,33 +4,42 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/hance08/kea/internal/config"
 	"github.com/hance08/kea/internal/service"
 	"github.com/hance08/kea/ui/views"
 	"github.com/spf13/cobra"
 )
 
+type InfoProvider interface {
+	Config() *config.Config
+}
+
 type SystemInfoView interface {
 	Render(data views.SystemInfo) error
 }
 
+type infoFlags struct {
+	JSONOut bool
+}
+
 type infoRunner struct {
-	svc     *service.Service
-	view    SystemInfoView
-	jsonOut bool
+	svc  InfoProvider
+	view SystemInfoView
+	json bool
 }
 
 func NewInfoCmd(svc *service.Service) *cobra.Command {
-	var jsonOut bool
+	flags := &infoFlags{}
 	cmd := &cobra.Command{
 		Use:   "info",
 		Short: "Display application information",
 		Long:  `Display current configuration, database path, and system details.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runner := &infoRunner{svc: svc, view: views.NewSystemInfoView(), jsonOut: jsonOut}
+			runner := &infoRunner{svc: svc, view: views.NewSystemInfoView(), json: flags.JSONOut}
 			return runner.Run()
 		},
 	}
-	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "output as JSON")
+	cmd.Flags().BoolVarP(&flags.JSONOut, "json", "j", false, "output as JSON")
 	return cmd
 }
 
@@ -60,7 +69,7 @@ func (r *infoRunner) Run() error {
 		AppDataDir:      getAppDataDirOrPanic(),
 	}
 
-	if r.jsonOut {
+	if r.json {
 		return views.WriteJSON(views.ToJSONSystemInfo(info))
 	}
 	return r.view.Render(info)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -19,7 +19,7 @@ type SystemInfoView interface {
 }
 
 type infoFlags struct {
-	JSONOut bool
+	JSON    bool
 }
 
 type infoRunner struct {
@@ -35,11 +35,11 @@ func NewInfoCmd(svc *service.Service) *cobra.Command {
 		Short: "Display application information",
 		Long:  `Display current configuration, database path, and system details.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runner := &infoRunner{svc: svc, view: views.NewSystemInfoView(), json: flags.JSONOut}
+			runner := &infoRunner{svc: svc, view: views.NewSystemInfoView(), json: flags.JSON}
 			return runner.Run()
 		},
 	}
-	cmd.Flags().BoolVarP(&flags.JSONOut, "json", "j", false, "output as JSON")
+	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output as JSON")
 	return cmd
 }
 

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -16,22 +16,22 @@ type SystemInfoView interface {
 type infoRunner struct {
 	svc  *service.Service
 	view SystemInfoView
+	json bool
 }
 
 func NewInfoCmd(svc *service.Service) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "info",
 		Short: "Display application information",
 		Long:  `Display current configuration, database path, and system details.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runner := &infoRunner{
-				svc:  svc,
-				view: views.NewSystemInfoView(),
-			}
-
+			runner := &infoRunner{svc: svc, view: views.NewSystemInfoView(), json: jsonOut}
 			return runner.Run()
 		},
 	}
+	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "output as JSON")
+	return cmd
 }
 
 func (r *infoRunner) Run() error {
@@ -60,10 +60,10 @@ func (r *infoRunner) Run() error {
 		AppDataDir:      getAppDataDirOrPanic(),
 	}
 
-	if err := r.view.Render(info); err != nil {
-		return err
+	if r.json {
+		return views.WriteJSON(views.ToJSONSystemInfo(info))
 	}
-	return nil
+	return r.view.Render(info)
 }
 
 func getAppDataDirOrPanic() string {

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -14,9 +14,9 @@ type SystemInfoView interface {
 }
 
 type infoRunner struct {
-	svc  *service.Service
-	view SystemInfoView
-	json bool
+	svc     *service.Service
+	view    SystemInfoView
+	jsonOut bool
 }
 
 func NewInfoCmd(svc *service.Service) *cobra.Command {
@@ -26,7 +26,7 @@ func NewInfoCmd(svc *service.Service) *cobra.Command {
 		Short: "Display application information",
 		Long:  `Display current configuration, database path, and system details.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runner := &infoRunner{svc: svc, view: views.NewSystemInfoView(), json: jsonOut}
+			runner := &infoRunner{svc: svc, view: views.NewSystemInfoView(), jsonOut: jsonOut}
 			return runner.Run()
 		},
 	}
@@ -60,7 +60,7 @@ func (r *infoRunner) Run() error {
 		AppDataDir:      getAppDataDirOrPanic(),
 	}
 
-	if r.json {
+	if r.jsonOut {
 		return views.WriteJSON(views.ToJSONSystemInfo(info))
 	}
 	return r.view.Render(info)

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/hance08/kea/internal/service"
 	"github.com/hance08/kea/ui/views"
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
 
@@ -35,15 +34,12 @@ Examples:
   kea report --type eb --from 2026-01-01 --to 2026-01-31
   kea report --type bs`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			r := &reportRunner{
+			runner := &reportRunner{
 				flags:    flags,
 				provider: svc.Transaction(),
 				view:     newReportView(flags),
 			}
-			if err := r.run(); err != nil {
-				pterm.Error.Println(err)
-			}
-			return nil
+			return runner.run()
 		},
 	}
 

--- a/cmd/transaction/clear.go
+++ b/cmd/transaction/clear.go
@@ -10,24 +10,32 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type ClearProvider interface {
+	UpdateTransactionStatus(txID int64, status model.TransactionStatus) error
+}
+
+type clearFlags struct {
+	JSONOut bool
+}
+
 type clearRunner struct {
-	svc     *service.Service
-	jsonOut bool
+	svc  ClearProvider
+	json bool
 }
 
 func NewClearCmd(svc *service.Service) *cobra.Command {
-	var jsonOut bool
+	flags := &clearFlags{}
 	cmd := &cobra.Command{
 		Use:   "clear <transaction-id>",
 		Short: "Mark transaction as cleared",
 		Long:  `Mark a pending transaction as cleared (confirmed).`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runner := &clearRunner{svc: svc, jsonOut: jsonOut}
+			runner := &clearRunner{svc: svc.Transaction(), json: flags.JSONOut}
 			return runner.Run(args)
 		},
 	}
-	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "output result as JSON")
+	cmd.Flags().BoolVarP(&flags.JSONOut, "json", "j", false, "output result as JSON")
 	return cmd
 }
 
@@ -37,16 +45,11 @@ func (r *clearRunner) Run(args []string) error {
 		return fmt.Errorf("invalid transaction ID: %s", args[0])
 	}
 
-	// Update status to cleared (1)
-	if err := r.svc.Transaction().UpdateTransactionStatus(txID, 1); err != nil {
-		if r.jsonOut {
-			return err
-		}
-		pterm.Error.Printf("Failed to update transaction status: %v\n", err)
-		return nil
+	if err := r.svc.UpdateTransactionStatus(txID, model.StatusCleared); err != nil {
+		return fmt.Errorf("failed to update transaction status: %w", err)
 	}
 
-	if r.jsonOut {
+	if r.json {
 		return views.WriteJSON(map[string]any{"id": txID, "status": model.StatusCleared.String()})
 	}
 	pterm.Success.Printf("Transaction (ID: %d) marked as cleared\n", txID)

--- a/cmd/transaction/clear.go
+++ b/cmd/transaction/clear.go
@@ -15,7 +15,7 @@ type ClearProvider interface {
 }
 
 type clearFlags struct {
-	JSONOut bool
+	JSON    bool
 }
 
 type clearRunner struct {
@@ -31,11 +31,11 @@ func NewClearCmd(svc *service.Service) *cobra.Command {
 		Long:  `Mark a pending transaction as cleared (confirmed).`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runner := &clearRunner{svc: svc.Transaction(), json: flags.JSONOut}
+			runner := &clearRunner{svc: svc.Transaction(), json: flags.JSON}
 			return runner.Run(args)
 		},
 	}
-	cmd.Flags().BoolVarP(&flags.JSONOut, "json", "j", false, "output result as JSON")
+	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output result as JSON")
 	return cmd
 }
 

--- a/cmd/transaction/clear.go
+++ b/cmd/transaction/clear.go
@@ -11,8 +11,8 @@ import (
 )
 
 type clearRunner struct {
-	svc  *service.Service
-	json bool
+	svc     *service.Service
+	jsonOut bool
 }
 
 func NewClearCmd(svc *service.Service) *cobra.Command {
@@ -23,7 +23,7 @@ func NewClearCmd(svc *service.Service) *cobra.Command {
 		Long:  `Mark a pending transaction as cleared (confirmed).`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runner := &clearRunner{svc: svc, json: jsonOut}
+			runner := &clearRunner{svc: svc, jsonOut: jsonOut}
 			return runner.Run(args)
 		},
 	}
@@ -39,11 +39,14 @@ func (r *clearRunner) Run(args []string) error {
 
 	// Update status to cleared (1)
 	if err := r.svc.Transaction().UpdateTransactionStatus(txID, 1); err != nil {
+		if r.jsonOut {
+			return err
+		}
 		pterm.Error.Printf("Failed to update transaction status: %v\n", err)
 		return nil
 	}
 
-	if r.json {
+	if r.jsonOut {
 		return views.WriteJSON(map[string]any{"id": txID, "status": model.StatusCleared.String()})
 	}
 	pterm.Success.Printf("Transaction (ID: %d) marked as cleared\n", txID)

--- a/cmd/transaction/clear.go
+++ b/cmd/transaction/clear.go
@@ -3,26 +3,32 @@ package transaction
 import (
 	"fmt"
 
+	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/service"
+	"github.com/hance08/kea/ui/views"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
 
 type clearRunner struct {
-	svc *service.Service
+	svc  *service.Service
+	json bool
 }
 
 func NewClearCmd(svc *service.Service) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "clear <transaction-id>",
 		Short: "Mark transaction as cleared",
 		Long:  `Mark a pending transaction as cleared (confirmed).`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runner := &clearRunner{svc: svc}
+			runner := &clearRunner{svc: svc, json: jsonOut}
 			return runner.Run(args)
 		},
 	}
+	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "output result as JSON")
+	return cmd
 }
 
 func (r *clearRunner) Run(args []string) error {
@@ -37,6 +43,9 @@ func (r *clearRunner) Run(args []string) error {
 		return nil
 	}
 
+	if r.json {
+		return views.WriteJSON(map[string]any{"id": txID, "status": model.StatusCleared.String()})
+	}
 	pterm.Success.Printf("Transaction (ID: %d) marked as cleared\n", txID)
 	return nil
 }

--- a/cmd/transaction/delete.go
+++ b/cmd/transaction/delete.go
@@ -58,6 +58,9 @@ func (r *deleteRunner) Run(args []string) error {
 	// Get transaction details first to show what will be deleted
 	detail, err := r.svc.Transaction().GetTransactionByID(txID)
 	if err != nil {
+		if r.jsonOut {
+			return err
+		}
 		pterm.Error.Printf("Failed to delete transaction: %v\n", err)
 		return nil
 	}
@@ -87,6 +90,9 @@ func (r *deleteRunner) Run(args []string) error {
 
 	// Delete transaction
 	if err := r.svc.Transaction().DeleteTransaction(txID); err != nil {
+		if r.jsonOut {
+			return err
+		}
 		pterm.Error.Printf("Failed to delete transaction: %v\n", err)
 		return nil
 	}

--- a/cmd/transaction/delete.go
+++ b/cmd/transaction/delete.go
@@ -19,10 +19,12 @@ type deleteRunner struct {
 	svc  *service.Service
 	view TransactionDeleteView
 	yes  bool
+	json bool
 }
 
 func NewDeleteCmd(svc *service.Service) *cobra.Command {
 	var yes bool
+	var jsonOut bool
 
 	cmd := &cobra.Command{
 		Use:     "delete <transaction-id>",
@@ -34,13 +36,15 @@ func NewDeleteCmd(svc *service.Service) *cobra.Command {
 			runner := &deleteRunner{
 				svc:  svc,
 				view: views.NewTransactionDeleteView(),
-				yes:  yes,
+				yes:  yes || jsonOut,
+				json: jsonOut,
 			}
 			return runner.Run(args)
 		},
 	}
 
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "confirm deletion without interactive prompt")
+	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "output result as JSON")
 
 	return cmd
 }
@@ -58,13 +62,15 @@ func (r *deleteRunner) Run(args []string) error {
 		return nil
 	}
 
-	if err := r.view.RenderPreview(views.TransactionDeletePreview{
-		ID:          detail.ID,
-		Timestamp:   detail.Timestamp,
-		Description: detail.Description,
-		SplitCount:  len(detail.Splits),
-	}); err != nil {
-		return err
+	if !r.json {
+		if err := r.view.RenderPreview(views.TransactionDeletePreview{
+			ID:          detail.ID,
+			Timestamp:   detail.Timestamp,
+			Description: detail.Description,
+			SplitCount:  len(detail.Splits),
+		}); err != nil {
+			return err
+		}
 	}
 
 	if !r.yes {
@@ -85,6 +91,9 @@ func (r *deleteRunner) Run(args []string) error {
 		return nil
 	}
 
+	if r.json {
+		return views.WriteJSON(map[string]any{"id": txID, "deleted": true})
+	}
 	r.view.ShowSuccess(txID)
 	return nil
 }

--- a/cmd/transaction/delete.go
+++ b/cmd/transaction/delete.go
@@ -18,23 +18,31 @@ type TransactionDeleteView interface {
 type deleteRunner struct {
 	svc  *service.Service
 	view TransactionDeleteView
+	yes  bool
 }
 
 func NewDeleteCmd(svc *service.Service) *cobra.Command {
-	return &cobra.Command{
+	var yes bool
+
+	cmd := &cobra.Command{
 		Use:     "delete <transaction-id>",
 		Short:   "Delete a transaction",
 		Long:    `Delete a transaction and all its associated splits. This action cannot be undone.`,
-		Aliases: []string{"d"},
+		Aliases: []string{"del", "d"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner := &deleteRunner{
 				svc:  svc,
 				view: views.NewTransactionDeleteView(),
+				yes:  yes,
 			}
 			return runner.Run(args)
 		},
 	}
+
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "confirm deletion without interactive prompt")
+
+	return cmd
 }
 
 func (r *deleteRunner) Run(args []string) error {
@@ -59,14 +67,16 @@ func (r *deleteRunner) Run(args []string) error {
 		return err
 	}
 
-	confirmation, err := prompts.PromptConfirm("Do you want to delete this transaction?", false)
-	if err != nil {
-		return err
-	}
+	if !r.yes {
+		confirmation, err := prompts.PromptConfirm("Do you want to delete this transaction?", false)
+		if err != nil {
+			return err
+		}
 
-	if !confirmation {
-		pterm.Info.Println("Deletion cancelled")
-		return nil
+		if !confirmation {
+			pterm.Info.Println("Deletion cancelled")
+			return nil
+		}
 	}
 
 	// Delete transaction

--- a/cmd/transaction/delete.go
+++ b/cmd/transaction/delete.go
@@ -3,6 +3,7 @@ package transaction
 import (
 	"fmt"
 
+	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/service"
 	"github.com/hance08/kea/ui/prompts"
 	"github.com/hance08/kea/ui/views"
@@ -15,16 +16,25 @@ type TransactionDeleteView interface {
 	ShowSuccess(id int64)
 }
 
+type TxDeleteProvider interface {
+	GetTransactionByID(txID int64) (*model.TransactionDetail, error)
+	DeleteTransaction(txID int64) error
+}
+
+type deleteFlags struct {
+	Yes     bool
+	JSONOut bool
+}
+
 type deleteRunner struct {
-	svc     *service.Service
-	view    TransactionDeleteView
-	yes     bool
-	jsonOut bool
+	svc  TxDeleteProvider
+	view TransactionDeleteView
+	yes  bool
+	json bool
 }
 
 func NewDeleteCmd(svc *service.Service) *cobra.Command {
-	var yes bool
-	var jsonOut bool
+	flags := &deleteFlags{}
 
 	cmd := &cobra.Command{
 		Use:     "delete <transaction-id>",
@@ -34,17 +44,17 @@ func NewDeleteCmd(svc *service.Service) *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner := &deleteRunner{
-				svc:     svc,
-				view:    views.NewTransactionDeleteView(),
-				yes:     yes || jsonOut,
-				jsonOut: jsonOut,
+				svc:  svc.Transaction(),
+				view: views.NewTransactionDeleteView(),
+				yes:  flags.Yes || flags.JSONOut,
+				json: flags.JSONOut,
 			}
 			return runner.Run(args)
 		},
 	}
 
-	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "confirm deletion without interactive prompt")
-	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "output result as JSON")
+	cmd.Flags().BoolVarP(&flags.Yes, "yes", "y", false, "confirm deletion without interactive prompt")
+	cmd.Flags().BoolVarP(&flags.JSONOut, "json", "j", false, "output result as JSON")
 
 	return cmd
 }
@@ -55,17 +65,12 @@ func (r *deleteRunner) Run(args []string) error {
 		return fmt.Errorf("invalid transaction ID: %s", args[0])
 	}
 
-	// Get transaction details first to show what will be deleted
-	detail, err := r.svc.Transaction().GetTransactionByID(txID)
+	detail, err := r.svc.GetTransactionByID(txID)
 	if err != nil {
-		if r.jsonOut {
-			return err
-		}
-		pterm.Error.Printf("Failed to delete transaction: %v\n", err)
-		return nil
+		return fmt.Errorf("failed to get transaction: %w", err)
 	}
 
-	if !r.jsonOut {
+	if !r.json {
 		if err := r.view.RenderPreview(views.TransactionDeletePreview{
 			ID:          detail.ID,
 			Timestamp:   detail.Timestamp,
@@ -81,23 +86,17 @@ func (r *deleteRunner) Run(args []string) error {
 		if err != nil {
 			return err
 		}
-
 		if !confirmation {
 			pterm.Info.Println("Deletion cancelled")
 			return nil
 		}
 	}
 
-	// Delete transaction
-	if err := r.svc.Transaction().DeleteTransaction(txID); err != nil {
-		if r.jsonOut {
-			return err
-		}
-		pterm.Error.Printf("Failed to delete transaction: %v\n", err)
-		return nil
+	if err := r.svc.DeleteTransaction(txID); err != nil {
+		return fmt.Errorf("failed to delete transaction: %w", err)
 	}
 
-	if r.jsonOut {
+	if r.json {
 		return views.WriteJSON(map[string]any{"id": txID, "deleted": true})
 	}
 	r.view.ShowSuccess(txID)

--- a/cmd/transaction/delete.go
+++ b/cmd/transaction/delete.go
@@ -23,7 +23,7 @@ type TxDeleteProvider interface {
 
 type deleteFlags struct {
 	Yes     bool
-	JSONOut bool
+	JSON    bool
 }
 
 type deleteRunner struct {
@@ -46,15 +46,15 @@ func NewDeleteCmd(svc *service.Service) *cobra.Command {
 			runner := &deleteRunner{
 				svc:  svc.Transaction(),
 				view: views.NewTransactionDeleteView(),
-				yes:  flags.Yes || flags.JSONOut,
-				json: flags.JSONOut,
+				yes:  flags.Yes || flags.JSON,
+				json: flags.JSON,
 			}
 			return runner.Run(args)
 		},
 	}
 
 	cmd.Flags().BoolVarP(&flags.Yes, "yes", "y", false, "confirm deletion without interactive prompt")
-	cmd.Flags().BoolVarP(&flags.JSONOut, "json", "j", false, "output result as JSON")
+	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output result as JSON")
 
 	return cmd
 }

--- a/cmd/transaction/delete.go
+++ b/cmd/transaction/delete.go
@@ -16,10 +16,10 @@ type TransactionDeleteView interface {
 }
 
 type deleteRunner struct {
-	svc  *service.Service
-	view TransactionDeleteView
-	yes  bool
-	json bool
+	svc     *service.Service
+	view    TransactionDeleteView
+	yes     bool
+	jsonOut bool
 }
 
 func NewDeleteCmd(svc *service.Service) *cobra.Command {
@@ -34,10 +34,10 @@ func NewDeleteCmd(svc *service.Service) *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner := &deleteRunner{
-				svc:  svc,
-				view: views.NewTransactionDeleteView(),
-				yes:  yes || jsonOut,
-				json: jsonOut,
+				svc:     svc,
+				view:    views.NewTransactionDeleteView(),
+				yes:     yes || jsonOut,
+				jsonOut: jsonOut,
 			}
 			return runner.Run(args)
 		},
@@ -62,7 +62,7 @@ func (r *deleteRunner) Run(args []string) error {
 		return nil
 	}
 
-	if !r.json {
+	if !r.jsonOut {
 		if err := r.view.RenderPreview(views.TransactionDeletePreview{
 			ID:          detail.ID,
 			Timestamp:   detail.Timestamp,
@@ -91,7 +91,7 @@ func (r *deleteRunner) Run(args []string) error {
 		return nil
 	}
 
-	if r.json {
+	if r.jsonOut {
 		return views.WriteJSON(map[string]any{"id": txID, "deleted": true})
 	}
 	r.view.ShowSuccess(txID)

--- a/cmd/transaction/list.go
+++ b/cmd/transaction/list.go
@@ -30,6 +30,7 @@ type ListProvider interface {
 type listFlags struct {
 	Account string
 	Limit   int
+	JSON    bool
 }
 
 type listRunner struct {
@@ -61,6 +62,7 @@ date, type, account, description, amount, and status.`,
 
 	cmd.Flags().StringVarP(&flags.Account, "account", "a", "", "Filter transactions by account name")
 	cmd.Flags().IntVarP(&flags.Limit, "limit", "l", 20, "Maximum number of transactions to display")
+	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output as JSON")
 
 	return cmd
 }
@@ -76,6 +78,13 @@ func (r *listRunner) Run() error {
 	viewItems := r.buildViewItems(transactions)
 
 	// 3. Render
+	if r.flags.JSON {
+		jsonItems := make([]views.JSONTxListItem, len(viewItems))
+		for i, item := range viewItems {
+			jsonItems[i] = views.ToJSONTxListItem(item)
+		}
+		return views.WriteJSON(jsonItems)
+	}
 	return r.view.Render(viewItems, r.flags.Limit)
 }
 

--- a/cmd/transaction/list.go
+++ b/cmd/transaction/list.go
@@ -13,7 +13,7 @@ import (
 //TODO: Efficiency optimize
 
 type ListView interface {
-	ShowWarning(format string, a ...interface{})
+	ShowWarning(format string, a ...any)
 	Render(items []views.TransactionListItem, limit int) error
 }
 
@@ -101,7 +101,9 @@ func (r *listRunner) buildViewItems(transactions []*model.Transaction) []views.T
 	for _, tx := range transactions {
 		detail, err := r.svc.GetTransactionByID(tx.ID)
 		if err != nil {
-			r.view.ShowWarning("Skipping transaction %d: %v\n", tx.ID, err)
+			if !r.flags.JSON {
+				r.view.ShowWarning("Skipping transaction %d: %v\n", tx.ID, err)
+			}
 			continue
 		}
 

--- a/cmd/transaction/show.go
+++ b/cmd/transaction/show.go
@@ -21,10 +21,12 @@ type ShowProvider interface {
 type showRunner struct {
 	svc  ShowProvider
 	view ShowView
+	json bool
 }
 
 func NewShowCmd(svc *service.Service) *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "show <transaction-id>",
 		Short: "Show transaction details",
 		Args:  cobra.ExactArgs(1),
@@ -32,10 +34,13 @@ func NewShowCmd(svc *service.Service) *cobra.Command {
 			runner := &showRunner{
 				svc:  svc.Transaction(),
 				view: views.NewTransactionDetailView(),
+				json: jsonOut,
 			}
 			return runner.Run(args)
 		},
 	}
+	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "output as JSON")
+	return cmd
 }
 
 func (r *showRunner) Run(args []string) error {
@@ -50,8 +55,8 @@ func (r *showRunner) Run(args []string) error {
 		return nil
 	}
 
-	if err := r.view.Render(detail, false); err != nil {
-		return err
+	if r.json {
+		return views.WriteJSON(views.ToJSONTxDetail(detail))
 	}
-	return nil
+	return r.view.Render(detail, false)
 }

--- a/cmd/transaction/show.go
+++ b/cmd/transaction/show.go
@@ -19,9 +19,9 @@ type ShowProvider interface {
 }
 
 type showRunner struct {
-	svc  ShowProvider
-	view ShowView
-	json bool
+	svc     ShowProvider
+	view    ShowView
+	jsonOut bool
 }
 
 func NewShowCmd(svc *service.Service) *cobra.Command {
@@ -32,9 +32,9 @@ func NewShowCmd(svc *service.Service) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner := &showRunner{
-				svc:  svc.Transaction(),
-				view: views.NewTransactionDetailView(),
-				json: jsonOut,
+				svc:     svc.Transaction(),
+				view:    views.NewTransactionDetailView(),
+				jsonOut: jsonOut,
 			}
 			return runner.Run(args)
 		},
@@ -51,11 +51,14 @@ func (r *showRunner) Run(args []string) error {
 
 	detail, err := r.svc.GetTransactionByID(txID)
 	if err != nil {
+		if r.jsonOut {
+			return err
+		}
 		pterm.Error.Printf("Failed to get transaction: %v\n", err)
 		return nil
 	}
 
-	if r.json {
+	if r.jsonOut {
 		return views.WriteJSON(views.ToJSONTxDetail(detail))
 	}
 	return r.view.Render(detail, false)

--- a/cmd/transaction/show.go
+++ b/cmd/transaction/show.go
@@ -22,9 +22,9 @@ type showFlags struct {
 }
 
 type showRunner struct {
-	svc     ShowProvider
-	view    ShowView
-	jsonOut bool
+	svc  ShowProvider
+	view ShowView
+	json bool
 }
 
 func NewShowCmd(svc *service.Service) *cobra.Command {
@@ -35,9 +35,9 @@ func NewShowCmd(svc *service.Service) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner := &showRunner{
-				svc:     svc.Transaction(),
-				view:    views.NewTransactionDetailView(),
-				jsonOut: flags.JSONOut,
+				svc:  svc.Transaction(),
+				view: views.NewTransactionDetailView(),
+				json: flags.JSONOut,
 			}
 			return runner.Run(args)
 		},
@@ -57,7 +57,7 @@ func (r *showRunner) Run(args []string) error {
 		return fmt.Errorf("failed to get transaction: %w", err)
 	}
 
-	if r.jsonOut {
+	if r.json {
 		return views.WriteJSON(views.ToJSONTxDetail(detail))
 	}
 	return r.view.Render(detail, false)

--- a/cmd/transaction/show.go
+++ b/cmd/transaction/show.go
@@ -18,7 +18,7 @@ type ShowProvider interface {
 }
 
 type showFlags struct {
-	JSONOut bool
+	JSON    bool
 }
 
 type showRunner struct {
@@ -37,12 +37,12 @@ func NewShowCmd(svc *service.Service) *cobra.Command {
 			runner := &showRunner{
 				svc:  svc.Transaction(),
 				view: views.NewTransactionDetailView(),
-				json: flags.JSONOut,
+				json: flags.JSON,
 			}
 			return runner.Run(args)
 		},
 	}
-	cmd.Flags().BoolVarP(&flags.JSONOut, "json", "j", false, "output as JSON")
+	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output as JSON")
 	return cmd
 }
 

--- a/cmd/transaction/show.go
+++ b/cmd/transaction/show.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/service"
 	"github.com/hance08/kea/ui/views"
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
 
@@ -18,6 +17,10 @@ type ShowProvider interface {
 	GetTransactionByID(txID int64) (*model.TransactionDetail, error)
 }
 
+type showFlags struct {
+	JSONOut bool
+}
+
 type showRunner struct {
 	svc     ShowProvider
 	view    ShowView
@@ -25,7 +28,7 @@ type showRunner struct {
 }
 
 func NewShowCmd(svc *service.Service) *cobra.Command {
-	var jsonOut bool
+	flags := &showFlags{}
 	cmd := &cobra.Command{
 		Use:   "show <transaction-id>",
 		Short: "Show transaction details",
@@ -34,12 +37,12 @@ func NewShowCmd(svc *service.Service) *cobra.Command {
 			runner := &showRunner{
 				svc:     svc.Transaction(),
 				view:    views.NewTransactionDetailView(),
-				jsonOut: jsonOut,
+				jsonOut: flags.JSONOut,
 			}
 			return runner.Run(args)
 		},
 	}
-	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "output as JSON")
+	cmd.Flags().BoolVarP(&flags.JSONOut, "json", "j", false, "output as JSON")
 	return cmd
 }
 
@@ -51,11 +54,7 @@ func (r *showRunner) Run(args []string) error {
 
 	detail, err := r.svc.GetTransactionByID(txID)
 	if err != nil {
-		if r.jsonOut {
-			return err
-		}
-		pterm.Error.Printf("Failed to get transaction: %v\n", err)
-		return nil
+		return fmt.Errorf("failed to get transaction: %w", err)
 	}
 
 	if r.jsonOut {

--- a/docs/superpowers/plans/2026-03-24-json-output.md
+++ b/docs/superpowers/plans/2026-03-24-json-output.md
@@ -1,0 +1,1084 @@
+# JSON Output Flag Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `--json / -j` flag to 9 commands so they emit machine-readable JSON output for scripting and automation.
+
+**Architecture:** A shared `WriteJSON` helper and JSON DTO structs live in `ui/views/`. Each command branches on the `JSON` flag: text path unchanged, JSON path calls `WriteJSON(toJSONXxx(...))`. One service method is added to expose raw balance cents.
+
+**Tech Stack:** Go, Cobra, `encoding/json`, existing `model` and `service` packages, testify for assertions.
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Create | `ui/views/json.go` | Exported `WriteJSON` + `CentsToUnit` helpers |
+| Create | `ui/views/json_types.go` | JSON DTOs + converter functions |
+| Create | `ui/views/json_test.go` | Unit tests for DTOs and converters |
+| Modify | `ui/views/report_json.go` | Remove private `writeJSON`/`centsToUnit`; call shared versions |
+| Modify | `internal/service/account_service.go` | Add `GetAccountBalance(id int64) (int64, error)` |
+| Modify | `internal/service/account_ops_test.go` | Test `GetAccountBalance` |
+| Modify | `cmd/account/list.go` | Add `--json` flag |
+| Modify | `cmd/account/create.go` | Add `--json` flag; guard interactive mode |
+| Modify | `cmd/account/create_types.go` | Add `JSON bool` to `createFlags` |
+| Modify | `cmd/account/delete.go` | Add `--json` flag; suppress TUI when set |
+| Modify | `cmd/add.go` | Add `--json` flag |
+| Modify | `cmd/add_types.go` | Add `JSON bool` to `addFlags` |
+| Modify | `cmd/transaction/list.go` | Add `--json` flag |
+| Modify | `cmd/transaction/show.go` | Add `--json` flag |
+| Modify | `cmd/transaction/delete.go` | Add `--json` flag |
+| Modify | `cmd/transaction/clear.go` | Add `--json` flag |
+| Modify | `cmd/info.go` | Add `--json` flag |
+
+---
+
+## Task 1: Shared JSON infrastructure
+
+**Files:**
+- Create: `ui/views/json.go`
+- Create: `ui/views/json_types.go`
+- Create: `ui/views/json_test.go`
+- Modify: `ui/views/report_json.go`
+
+- [ ] **Step 1: Write failing tests for helpers and converters**
+
+Create `ui/views/json_test.go`:
+
+```go
+package views
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/hance08/kea/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCentsToUnit(t *testing.T) {
+	assert.Equal(t, 1.0, CentsToUnit(100))
+	assert.Equal(t, 1.5, CentsToUnit(150))
+	assert.Equal(t, 0.0, CentsToUnit(0))
+	assert.Equal(t, -1.5, CentsToUnit(-150))
+}
+
+func TestToJSONAccount(t *testing.T) {
+	parentID := int64(1)
+	acc := &model.Account{
+		ID:          2,
+		Name:        "Assets:Bank",
+		Type:        model.AccountTypeAsset,
+		ParentID:    &parentID,
+		Currency:    "TWD",
+		Description: "Main bank",
+		IsHidden:    false,
+	}
+	got := ToJSONAccount(acc, 15000)
+	assert.Equal(t, int64(2), got.ID)
+	assert.Equal(t, "Assets:Bank", got.Name)
+	assert.Equal(t, "A", got.Type)
+	assert.Equal(t, &parentID, got.ParentID)
+	assert.Equal(t, "TWD", got.Currency)
+	assert.Equal(t, "Main bank", got.Description)
+	assert.False(t, got.IsHidden)
+	assert.Equal(t, 150.0, got.Balance)
+}
+
+func TestToJSONTxDetail(t *testing.T) {
+	detail := &model.TransactionDetail{
+		ID:          42,
+		Timestamp:   1711238400, // 2024-03-24
+		Description: "Buy coffee",
+		Status:      model.StatusCleared,
+		Splits: []model.SplitDetail{
+			{ID: 1, AccountID: 10, AccountName: "Assets:Cash", AccountType: model.AccountTypeAsset, Amount: -500, Currency: "TWD", Memo: ""},
+			{ID: 2, AccountID: 20, AccountName: "Expenses:Food", AccountType: model.AccountTypeExpense, Amount: 500, Currency: "TWD", Memo: "lunch"},
+		},
+	}
+	got := ToJSONTxDetail(detail)
+	assert.Equal(t, int64(42), got.ID)
+	assert.Equal(t, "Cleared", got.Status)
+	assert.Len(t, got.Splits, 2)
+	assert.Equal(t, -5.0, got.Splits[0].Amount)
+	assert.Equal(t, 5.0, got.Splits[1].Amount)
+	assert.Equal(t, "lunch", got.Splits[1].Memo)
+}
+
+func TestToJSONTxListItem(t *testing.T) {
+	item := TransactionListItem{
+		ID: 7, Date: "2024-03-24", Type: "Expense",
+		Account: "Assets:Cash", Offset: "Expenses:Food",
+		Description: "lunch", Amount: "5.00", Currency: "TWD", Status: "Cleared",
+	}
+	got := ToJSONTxListItem(item)
+	assert.Equal(t, int64(7), got.ID)
+	assert.Equal(t, 5.0, got.Amount)
+	assert.Equal(t, "TWD", got.Currency)
+}
+
+func TestWriteJSON_validOutput(t *testing.T) {
+	// Redirect stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := WriteJSON(map[string]string{"key": "value"})
+	require.NoError(t, err)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+
+	var result map[string]string
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
+	assert.Equal(t, "value", result["key"])
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+go test ./ui/views/... -run "TestCentsToUnit|TestToJSON|TestWriteJSON" -v
+```
+
+Expected: compilation error (functions not defined yet).
+
+- [ ] **Step 3: Create `ui/views/json.go`**
+
+```go
+package views
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/hance08/kea/internal/model"
+)
+
+// WriteJSON encodes v as indented JSON to stdout.
+func WriteJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		return fmt.Errorf("failed to encode JSON: %w", err)
+	}
+	return nil
+}
+
+// CentsToUnit converts int64 cents to float64 currency units (÷ model.CentsPerUnit).
+func CentsToUnit(cents int64) float64 {
+	return float64(cents) / float64(model.CentsPerUnit)
+}
+```
+
+- [ ] **Step 4: Create `ui/views/json_types.go`**
+
+All DTO structs and converter functions are **exported** (uppercase first letter) so they can be used from `cmd/` packages.
+
+```go
+package views
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hance08/kea/internal/model"
+)
+
+// ── JSON DTOs ─────────────────────────────────────────────────────────────────
+// Amounts are float64 currency units (not cents). Dates are YYYY-MM-DD strings.
+// TransactionStatus is serialized via .String(). AccountType as single-letter code.
+
+type JSONAccount struct {
+	ID          int64   `json:"id"`
+	Name        string  `json:"name"`
+	Type        string  `json:"type"`
+	ParentID    *int64  `json:"parent_id"`
+	Currency    string  `json:"currency"`
+	Description string  `json:"description"`
+	IsHidden    bool    `json:"is_hidden"`
+	Balance     float64 `json:"balance"`
+}
+
+type JSONSplitDetail struct {
+	ID          int64   `json:"id"`
+	AccountID   int64   `json:"account_id"`
+	AccountName string  `json:"account_name"`
+	AccountType string  `json:"account_type"`
+	Amount      float64 `json:"amount"`
+	Currency    string  `json:"currency"`
+	Memo        string  `json:"memo"`
+}
+
+type JSONTxDetail struct {
+	ID          int64             `json:"id"`
+	Date        string            `json:"date"`
+	Description string            `json:"description"`
+	Status      string            `json:"status"`
+	Splits      []JSONSplitDetail `json:"splits"`
+}
+
+type JSONTxListItem struct {
+	ID          int64   `json:"id"`
+	Date        string  `json:"date"`
+	Type        string  `json:"type"`
+	Account     string  `json:"account"`
+	Offset      string  `json:"offset"`
+	Description string  `json:"description"`
+	Amount      float64 `json:"amount"`
+	Currency    string  `json:"currency"`
+	Status      string  `json:"status"`
+}
+
+type JSONSystemInfo struct {
+	ConfigPath      string `json:"config_path"`
+	DBPath          string `json:"db_path"`
+	// false means DB does not yet exist; it will be created on first use.
+	DBExists        bool   `json:"db_exists"`
+	DefaultCurrency string `json:"default_currency"`
+	AppDataDir      string `json:"app_data_dir"`
+}
+
+// ── Converters ────────────────────────────────────────────────────────────────
+
+func ToJSONAccount(acc *model.Account, balanceCents int64) JSONAccount {
+	return JSONAccount{
+		ID:          acc.ID,
+		Name:        acc.Name,
+		Type:        string(acc.Type),
+		ParentID:    acc.ParentID,
+		Currency:    acc.Currency,
+		Description: acc.Description,
+		IsHidden:    acc.IsHidden,
+		Balance:     CentsToUnit(balanceCents),
+	}
+}
+
+func toJSONSplit(s model.SplitDetail) JSONSplitDetail {
+	return JSONSplitDetail{
+		ID:          s.ID,
+		AccountID:   s.AccountID,
+		AccountName: s.AccountName,
+		AccountType: string(s.AccountType),
+		Amount:      CentsToUnit(s.Amount),
+		Currency:    s.Currency,
+		Memo:        s.Memo,
+	}
+}
+
+func ToJSONTxDetail(d *model.TransactionDetail) JSONTxDetail {
+	splits := make([]JSONSplitDetail, len(d.Splits))
+	for i, s := range d.Splits {
+		splits[i] = toJSONSplit(s)
+	}
+	return JSONTxDetail{
+		ID:          d.ID,
+		Date:        time.Unix(d.Timestamp, 0).UTC().Format("2006-01-02"),
+		Description: d.Description,
+		Status:      d.Status.String(),
+		Splits:      splits,
+	}
+}
+
+func ToJSONTxListItem(item TransactionListItem) JSONTxListItem {
+	var amount float64
+	fmt.Sscanf(item.Amount, "%f", &amount)
+	return JSONTxListItem{
+		ID:          item.ID,
+		Date:        item.Date,
+		Type:        item.Type,
+		Account:     item.Account,
+		Offset:      item.Offset,
+		Description: item.Description,
+		Amount:      amount,
+		Currency:    item.Currency,
+		Status:      item.Status,
+	}
+}
+
+func ToJSONSystemInfo(info SystemInfo) JSONSystemInfo {
+	return JSONSystemInfo{
+		ConfigPath:      info.ConfigPath,
+		DBPath:          info.DBPath,
+		DBExists:        info.DBExists,
+		DefaultCurrency: info.DefaultCurrency,
+		AppDataDir:      info.AppDataDir,
+	}
+}
+```
+
+- [ ] **Step 5: Update `ui/views/report_json.go` — remove private duplicates**
+
+Replace the private `writeJSON` and `centsToUnit` functions with calls to the shared exported versions. Find these two functions in `report_json.go` and delete them. Then update every call site in the same file:
+- `writeJSON(...)` → `WriteJSON(...)`
+- `centsToUnit(...)` → `CentsToUnit(...)`
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+go test ./ui/views/... -run "TestCentsToUnit|TestToJSON|TestWriteJSON" -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Run full test suite to confirm no regressions**
+
+```bash
+go test ./...
+```
+
+Expected: all PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ui/views/json.go ui/views/json_types.go ui/views/json_test.go ui/views/report_json.go
+git commit -m "feat: add shared WriteJSON/CentsToUnit helpers and JSON DTOs"
+```
+
+---
+
+## Task 2: AccountService.GetAccountBalance
+
+**Files:**
+- Modify: `internal/service/account_service.go`
+- Modify: `internal/service/account_ops_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `internal/service/account_ops_test.go`:
+
+```go
+func TestGetAccountBalance(t *testing.T) {
+	repo := newMockAccountRepo()
+	svc := newTestAccountService(repo, newMockTransactionRepo())
+
+	repo.addAccount(&model.Account{ID: 1, Name: "Assets:Cash", Type: model.AccountTypeAsset})
+	repo.balances[1] = 5000 // 50.00 in cents
+
+	t.Run("returns raw cents", func(t *testing.T) {
+		got, err := svc.GetAccountBalance(1)
+		require.NoError(t, err)
+		assert.Equal(t, int64(5000), got)
+	})
+
+	t.Run("propagates repo error", func(t *testing.T) {
+		repo.getBalanceErr[99] = errors.New("not found")
+		_, err := svc.GetAccountBalance(99)
+		assert.Error(t, err)
+	})
+}
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```bash
+go test ./internal/service/... -run TestGetAccountBalance -v
+```
+
+Expected: FAIL — `svc.GetAccountBalance undefined`.
+
+- [ ] **Step 3: Add method to AccountService**
+
+In `internal/service/account_service.go`, add after `GetAccountBalanceFormatted`:
+
+```go
+func (as *AccountService) GetAccountBalance(accountID int64) (int64, error) {
+	return as.repo.GetAccountBalance(accountID)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/service/... -run TestGetAccountBalance -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/account_service.go internal/service/account_ops_test.go
+git commit -m "feat: expose GetAccountBalance on AccountService"
+```
+
+---
+
+## Task 3: account list --json
+
+**Files:**
+- Modify: `cmd/account/list.go`
+
+- [ ] **Step 1: Add JSON flag and branch**
+
+In `cmd/account/list.go`:
+
+1. Add `JSON bool` to `listFlags`:
+```go
+type listFlags struct {
+	Type       string
+	ShowHidden bool
+	JSON       bool
+}
+```
+
+2. Register the flag in `NewListCmd` before `return cmd`:
+```go
+cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output as JSON")
+```
+
+3. In `Run()`, replace the view render call with a branch. Note: all DTO structs and converters are exported (Task 1 Step 4), so they are accessible from this package:
+```go
+func (r *listRunner) Run() error {
+	// ... existing fetch and filter logic unchanged ...
+
+	if r.flags.JSON {
+		items := make([]views.JSONAccount, 0, len(accounts))
+		for _, acc := range accounts {
+			bal, err := r.svc.Account().GetAccountBalance(acc.ID)
+			if err != nil {
+				return fmt.Errorf("failed to get balance for %s: %w", acc.Name, err)
+			}
+			items = append(items, views.ToJSONAccount(acc, bal))
+		}
+		return views.WriteJSON(items)
+	}
+
+	return views.NewAccountListView().Render(accounts, r.svc.Account().GetAccountBalanceFormatted)
+}
+```
+
+- [ ] **Step 2: Verify build and run**
+
+```bash
+go build ./...
+```
+
+Expected: compiles cleanly.
+
+- [ ] **Step 3: Manual smoke test**
+
+```bash
+./kea_test account list --json
+```
+
+Expected: valid JSON array of account objects with `balance` as float.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/account/list.go ui/views/json_types.go ui/views/json_test.go
+git commit -m "feat: add --json to account list"
+```
+
+---
+
+## Task 4: account create --json
+
+**Files:**
+- Modify: `cmd/account/create_types.go`
+- Modify: `cmd/account/create.go`
+
+- [ ] **Step 1: Add `GetAccountBalance` to `CreateProvider` interface**
+
+In `cmd/account/create_types.go`, add the method to `CreateProvider`:
+
+```go
+type CreateProvider interface {
+	// ... all existing methods unchanged ...
+	GetAccountBalance(id int64) (int64, error)
+}
+```
+
+- [ ] **Step 2: Add JSON field to createFlags**
+
+In `cmd/account/create_types.go`, add `JSON bool` to `createFlags`:
+
+```go
+type createFlags struct {
+	Name        string
+	Type        string
+	Parent      string
+	BalanceStr  string
+	Currency    string
+	Description string
+	JSON        bool
+}
+```
+
+- [ ] **Step 3: Register flag and guard interactive mode**
+
+In `cmd/account/create.go`:
+
+1. In `NewCreateCmd`, add flag registration before `return cmd`:
+```go
+cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output created account as JSON")
+```
+
+2. In `Run()`, add a guard after the `hasFlags` check:
+```go
+func (r *createRunner) Run(flags *createFlags, cmd *cobra.Command) error {
+	hasFlags := cmd.Flags().Changed("name") ||
+		cmd.Flags().Changed("type") ||
+		cmd.Flags().Changed("parent")
+
+	if flags.JSON && !hasFlags {
+		return fmt.Errorf("--json requires flags: --name and one of --type or --parent")
+	}
+
+	if hasFlags {
+		err := r.runFromFlags(flags)
+		// ... existing error handling (ErrAccountExists check) unchanged ...
+		return nil
+	}
+	// interactive path unchanged
+	return r.runInteractive()
+}
+```
+
+3. In `runFromFlags`, replace `r.view.ShowSuccess(...)` with a JSON/text branch:
+```go
+	newAccount, err := r.createAccount()
+	if err != nil {
+		return err
+	}
+
+	if flags.JSON {
+		bal, err := r.accSvc.GetAccountBalance(newAccount.ID)
+		if err != nil {
+			return err
+		}
+		return views.WriteJSON(views.ToJSONAccount(newAccount, bal))
+	}
+
+	r.view.ShowSuccess(fmt.Sprintf("Account create successfully ! (ID: %d)", newAccount.ID))
+	return nil
+```
+
+- [ ] **Step 4: Verify build**
+
+```bash
+go build ./...
+```
+
+- [ ] **Step 5: Manual smoke test**
+
+```bash
+./kea_test account create --name TestJSON --type E --json
+```
+
+Expected: JSON object with the created account.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/account/create_types.go cmd/account/create.go
+git commit -m "feat: add --json to account create"
+```
+
+---
+
+## Task 5: account delete --json
+
+**Files:**
+- Modify: `cmd/account/delete.go`
+
+- [ ] **Step 1: Add JSON flag and suppress TUI**
+
+In `cmd/account/delete.go`:
+
+1. Add `json bool` to `deleteRunner`:
+```go
+type deleteRunner struct {
+	svc  *service.Service
+	yes  bool
+	json bool
+}
+```
+
+2. In `NewDeleteCmd`, add flag and pass to runner:
+```go
+var jsonOut bool
+cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "output result as JSON")
+// in RunE:
+runner := &deleteRunner{svc: svc, yes: yes || jsonOut, json: jsonOut}
+```
+
+Note: `yes: yes || jsonOut` ensures `--json` implies skip-confirmation.
+
+3. In `Run()`, suppress the pterm info line and confirmation when `json` is true, and emit JSON on success:
+```go
+func (r *deleteRunner) Run(name string) error {
+	acc, err := r.svc.Account().GetAccountByName(name)
+	if err != nil {
+		pterm.Error.Printf("Failed to delete account: %v\n", err)
+		return nil
+	}
+
+	if !r.json {
+		pterm.Info.Printf("Account: %s | Type: %s | Currency: %s | Hidden: %t\n",
+			acc.Name, acc.Type, acc.Currency, acc.IsHidden)
+	}
+
+	if !r.yes {
+		confirm, err := prompts.PromptConfirm("This will permanently delete the account. Continue?", false)
+		if err != nil {
+			return err
+		}
+		if !confirm {
+			pterm.Info.Println("Deletion cancelled")
+			return nil
+		}
+	}
+
+	if err := r.svc.Account().DeleteAccountByName(acc.Name); err != nil {
+		pterm.Error.Printf("Failed to delete account: %v\n", err)
+		return nil
+	}
+
+	if r.json {
+		return views.WriteJSON(map[string]any{"name": acc.Name, "deleted": true})
+	}
+	pterm.Success.Printf("Account %q deleted\n", acc.Name)
+	return nil
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+go build ./...
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/account/delete.go
+git commit -m "feat: add --json to account delete"
+```
+
+---
+
+## Task 6: add --json
+
+**Files:**
+- Modify: `cmd/add_types.go`
+- Modify: `cmd/add.go`
+
+- [ ] **Step 1: Add JSON field to addFlags**
+
+In `cmd/add_types.go`, add `JSON bool` to `addFlags`:
+
+```go
+type addFlags struct {
+	Description string
+	Amount      string
+	From        string
+	To          string
+	Status      string
+	Timestamp   string
+	Type        string
+	JSON        bool
+}
+```
+
+- [ ] **Step 2: Register flag**
+
+In `cmd/add.go` `NewAddCmd`, add before `return cmd`:
+```go
+cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output created transaction as JSON")
+```
+
+- [ ] **Step 3: Guard interactive mode and branch output**
+
+In `cmd/add.go` `Run()`, add the `--json` guard and output branch. The actual `Run()` calls `r.txSvc.CreateSimpleTransaction(...)` inline — preserve that call exactly and add the JSON branch after it:
+
+```go
+func (r *addRunner) Run() error {
+	hasFlags := r.cmd.Flags().Changed("desc") || r.cmd.Flags().Changed("amount") ||
+		r.cmd.Flags().Changed("from") || r.cmd.Flags().Changed("to") ||
+		r.cmd.Flags().Changed("type")
+
+	if r.flags.JSON && !hasFlags {
+		return fmt.Errorf("--json requires flags: --desc, --amount, --from, --to")
+	}
+
+	var input addTransactionInput
+	var err error
+	if hasFlags {
+		input, err = r.runFromFlags()
+	} else {
+		input, err = r.runInteractive()
+	}
+	if err != nil {
+		return err
+	}
+
+	result, err := r.txSvc.CreateSimpleTransaction(
+		input.FromAccountID,
+		input.ToAccountID,
+		input.AmountCents,
+		input.Description,
+		input.Timestamp,
+		input.Status,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create transaction: %w", err)
+	}
+
+	if r.flags.JSON {
+		return views.WriteJSON(views.ToJSONTxDetail(&result))
+	}
+	return r.addView.Render(&result, true)
+}
+```
+
+- [ ] **Step 4: Verify build**
+
+```bash
+go build ./...
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/add_types.go cmd/add.go
+git commit -m "feat: add --json to add command"
+```
+
+---
+
+## Task 7: transaction list --json
+
+**Files:**
+- Modify: `cmd/transaction/list.go`
+
+- [ ] **Step 1: Add JSON flag and branch**
+
+In `cmd/transaction/list.go`:
+
+1. Add `JSON bool` to `listFlags`.
+2. Register flag in `NewListCmd`.
+3. In `Run()`, after `buildViewItems`, add branch:
+
+```go
+func (r *listRunner) Run() error {
+	transactions, err := r.fetchTransactions()
+	if err != nil {
+		return err
+	}
+
+	viewItems := r.buildViewItems(transactions)
+
+	if r.flags.JSON {
+		jsonItems := make([]views.JSONTxListItem, len(viewItems))
+		for i, item := range viewItems {
+			jsonItems[i] = views.ToJSONTxListItem(item)
+		}
+		return views.WriteJSON(jsonItems)
+	}
+
+	return r.view.Render(viewItems, r.flags.Limit)
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+go build ./...
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/transaction/list.go
+git commit -m "feat: add --json to transaction list"
+```
+
+---
+
+## Task 8: transaction show --json
+
+**Files:**
+- Modify: `cmd/transaction/show.go`
+
+- [ ] **Step 1: Add JSON flag and branch**
+
+In `cmd/transaction/show.go`:
+
+1. Add `json bool` to `showRunner`.
+2. In `NewShowCmd`, turn the command into a two-step setup:
+
+```go
+func NewShowCmd(svc *service.Service) *cobra.Command {
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "show <transaction-id>",
+		Short: "Show transaction details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			runner := &showRunner{
+				svc:  svc.Transaction(),
+				view: views.NewTransactionDetailView(),
+				json: jsonOut,
+			}
+			return runner.Run(args)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "output as JSON")
+	return cmd
+}
+```
+
+3. In `Run()`, add branch after fetching `detail`:
+
+```go
+	if r.json {
+		return views.WriteJSON(views.ToJSONTxDetail(detail))
+	}
+	return r.view.Render(detail, false)
+```
+
+- [ ] **Step 2: Verify build and commit**
+
+```bash
+go build ./...
+git add cmd/transaction/show.go
+git commit -m "feat: add --json to transaction show"
+```
+
+---
+
+## Task 9: transaction delete --json
+
+**Files:**
+- Modify: `cmd/transaction/delete.go`
+
+- [ ] **Step 1: Add JSON flag**
+
+In `cmd/transaction/delete.go`:
+
+1. Add `json bool` to `deleteRunner`.
+2. In `NewDeleteCmd`, add flag and set `yes: yes || jsonOut` in runner construction (same pattern as account delete).
+3. In `Run()`, when `r.json` is set: skip `RenderPreview` and confirmation, and emit JSON on success:
+
+```go
+func (r *deleteRunner) Run(args []string) error {
+	var txID int64
+	if _, err := fmt.Sscanf(args[0], "%d", &txID); err != nil {
+		return fmt.Errorf("invalid transaction ID: %s", args[0])
+	}
+
+	detail, err := r.svc.Transaction().GetTransactionByID(txID)
+	if err != nil {
+		pterm.Error.Printf("Failed to delete transaction: %v\n", err)
+		return nil
+	}
+
+	if !r.json {
+		if err := r.view.RenderPreview(views.TransactionDeletePreview{
+			ID: detail.ID, Timestamp: detail.Timestamp,
+			Description: detail.Description, SplitCount: len(detail.Splits),
+		}); err != nil {
+			return err
+		}
+	}
+
+	if !r.yes {
+		confirmation, err := prompts.PromptConfirm("Do you want to delete this transaction?", false)
+		if err != nil {
+			return err
+		}
+		if !confirmation {
+			pterm.Info.Println("Deletion cancelled")
+			return nil
+		}
+	}
+
+	if err := r.svc.Transaction().DeleteTransaction(txID); err != nil {
+		pterm.Error.Printf("Failed to delete transaction: %v\n", err)
+		return nil
+	}
+
+	if r.json {
+		return views.WriteJSON(map[string]any{"id": txID, "deleted": true})
+	}
+	r.view.ShowSuccess(txID)
+	return nil
+}
+```
+
+- [ ] **Step 2: Verify build and commit**
+
+```bash
+go build ./...
+git add cmd/transaction/delete.go
+git commit -m "feat: add --json to transaction delete"
+```
+
+---
+
+## Task 10: transaction clear --json
+
+**Files:**
+- Modify: `cmd/transaction/clear.go`
+
+- [ ] **Step 1: Add JSON flag and branch**
+
+In `cmd/transaction/clear.go`:
+
+1. Add `json bool` to `clearRunner`.
+2. In `NewClearCmd`, convert to two-step setup with flag:
+
+```go
+func NewClearCmd(svc *service.Service) *cobra.Command {
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "clear <transaction-id>",
+		Short: "Mark transaction as cleared",
+		Long:  `Mark a pending transaction as cleared (confirmed).`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			runner := &clearRunner{svc: svc, json: jsonOut}
+			return runner.Run(args)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "output result as JSON")
+	return cmd
+}
+```
+
+3. In `Run()`, add branch after successful update:
+
+```go
+	if err := r.svc.Transaction().UpdateTransactionStatus(txID, 1); err != nil {
+		pterm.Error.Printf("Failed to update transaction status: %v\n", err)
+		return nil
+	}
+
+	if r.json {
+		return views.WriteJSON(map[string]any{"id": txID, "status": model.StatusCleared.String()})
+	}
+	pterm.Success.Printf("Transaction (ID: %d) marked as cleared\n", txID)
+	return nil
+```
+
+Add import for `model` package to `clear.go`.
+
+- [ ] **Step 2: Verify build and commit**
+
+```bash
+go build ./...
+git add cmd/transaction/clear.go
+git commit -m "feat: add --json to transaction clear"
+```
+
+---
+
+## Task 11: info --json
+
+**Files:**
+- Modify: `cmd/info.go`
+
+- [ ] **Step 1: Add JSON flag and branch**
+
+In `cmd/info.go`:
+
+1. Add `json bool` to `infoRunner`.
+2. In `NewInfoCmd`, convert to two-step setup:
+
+```go
+func NewInfoCmd(svc *service.Service) *cobra.Command {
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "info",
+		Short: "Display application information",
+		Long:  `Display current configuration, database path, and system details.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			runner := &infoRunner{svc: svc, view: views.NewSystemInfoView(), json: jsonOut}
+			return runner.Run()
+		},
+	}
+
+	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "output as JSON")
+	return cmd
+}
+```
+
+3. In `Run()`, add branch at the end:
+
+```go
+	if r.json {
+		return views.WriteJSON(views.ToJSONSystemInfo(info))
+	}
+	return r.view.Render(info)
+```
+
+- [ ] **Step 2: Verify full build and test suite**
+
+```bash
+go build ./...
+go test ./...
+```
+
+Expected: all PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/info.go
+git commit -m "feat: add --json to info command"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Build the binary**
+
+```bash
+make build
+```
+
+- [ ] **Smoke test each command**
+
+```bash
+./kea_test account list --json
+./kea_test account create --name SmokeTest --type E --json
+./kea_test account delete SmokeTest --json
+./kea_test add --desc "Test" --amount 10 --from "Assets:Cash" --to "Expenses:Food" --json
+./kea_test transaction list --json
+./kea_test transaction show 2 --json
+./kea_test transaction clear 2 --json
+./kea_test transaction delete 2 --json
+./kea_test info --json
+```
+
+- [ ] **Verify --json errors when no flags on guarded commands**
+
+```bash
+./kea_test account create --json   # should error
+./kea_test add --json              # should error
+```
+
+- [ ] **Run full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: all PASS.

--- a/docs/superpowers/specs/2026-03-24-json-output-design.md
+++ b/docs/superpowers/specs/2026-03-24-json-output-design.md
@@ -17,26 +17,34 @@ Only `report` has this today; this spec brings all remaining commands up to pari
 
 ### `ui/views/json.go` (new)
 
-Extract the existing pattern from `ui/views/report_json.go` into reusable helpers:
+Extract and export the pattern already present in `ui/views/report_json.go`:
 
 ```go
-func WriteJSON(v any) error          // indented JSON to stdout
-func CentsToUnit(cents int64) float64 // cents → float64 (÷ 100)
+// WriteJSON encodes v as indented JSON to stdout.
+func WriteJSON(v any) error
+
+// CentsToUnit converts int64 cents to float64 units (÷ 100).
+func CentsToUnit(cents int64) float64
 ```
+
+The existing unexported `writeJSON` and `centsToUnit` in `report_json.go` must be removed and replaced with calls to the new shared functions, eliminating the duplication.
 
 ### `ui/views/json_types.go` (new)
 
 JSON DTO structs with `json` tags. Amounts are `float64` (units, not cents).
+`TransactionStatus` is serialized via its `.String()` method (`"pending"`, `"cleared"`, `"reconciled"`).
+`AccountType` is serialized as its single-letter code (`"A"`, `"L"`, `"C"`, `"R"`, `"E"`).
 
 ```go
 type jsonAccount struct {
-    ID          int64  `json:"id"`
-    Name        string `json:"name"`
-    Type        string `json:"type"`
-    ParentID    *int64 `json:"parent_id"`
-    Currency    string `json:"currency"`
-    Description string `json:"description"`
-    IsHidden    bool   `json:"is_hidden"`
+    ID          int64   `json:"id"`
+    Name        string  `json:"name"`
+    Type        string  `json:"type"`
+    ParentID    *int64  `json:"parent_id"`
+    Currency    string  `json:"currency"`
+    Description string  `json:"description"`
+    IsHidden    bool    `json:"is_hidden"`
+    Balance     float64 `json:"balance"` // via GetAccountBalance → CentsToUnit
 }
 
 type jsonSplitDetail struct {
@@ -50,10 +58,10 @@ type jsonSplitDetail struct {
 }
 
 type jsonTxDetail struct {
-    ID          int64            `json:"id"`
-    Date        string           `json:"date"`       // YYYY-MM-DD
-    Description string           `json:"description"`
-    Status      string           `json:"status"`     // "pending" | "cleared" | "reconciled"
+    ID          int64             `json:"id"`
+    Date        string            `json:"date"`        // YYYY-MM-DD
+    Description string            `json:"description"`
+    Status      string            `json:"status"`      // via TransactionStatus.String()
     Splits      []jsonSplitDetail `json:"splits"`
 }
 
@@ -72,13 +80,15 @@ type jsonTxListItem struct {
 type jsonSystemInfo struct {
     ConfigPath      string `json:"config_path"`
     DBPath          string `json:"db_path"`
-    DBExists        bool   `json:"db_exists"`
+    DBExists        bool   `json:"db_exists"`    // false = DB not yet created (created on first use)
     DefaultCurrency string `json:"default_currency"`
     AppDataDir      string `json:"app_data_dir"`
 }
 ```
 
-Converter functions (`toJSON*`) live in the same file alongside the structs.
+Converter functions (`toJSONAccount`, `toJSONTxDetail`, etc.) live alongside the structs in the same file.
+
+For `jsonAccount.Balance`: `AccountService` exposes only `GetAccountBalanceFormatted` today. A new method `GetAccountBalance(id int64) (int64, error)` must be added to `AccountService` (delegating to the existing repository method of the same name). The "What Is NOT Changing" constraint about no service-layer changes does not apply to this one targeted addition. Apply `CentsToUnit` to the returned cents value. If the call fails, surface the error.
 
 ---
 
@@ -86,46 +96,50 @@ Converter functions (`toJSON*`) live in the same file alongside the structs.
 
 ### `account list`
 - Add `--json / -j` flag to `listFlags`
-- In `Run()`: if JSON → `WriteJSON(toJSONAccounts(accounts))`
+- In `Run()`: if JSON → fetch balances per account via `GetAccountBalance`, build `[]jsonAccount`, call `WriteJSON`
 - Output: `[]jsonAccount`
 
 ### `account create`
 - Add `--json / -j` flag to `createFlags`
-- Skip interactive confirmation when `--json` is set (scripting mode)
-- In `Run()` after account created: if JSON → `WriteJSON(toJSONAccount(acc))`
-- Output: `jsonAccount`
+- `--json` is only valid in flag mode. If `--json` is set but none of the identifying flags (`--name`, `--type`, `--parent`) are changed, return an error: `--json requires flags (--name, --type, ...)`
+- Skip the final confirmation prompt when `--json` is set
+- After account created: `WriteJSON(toJSONAccount(acc))`
+- Output: `jsonAccount` (balance will be the opening balance provided)
 
 ### `account delete`
 - Add `--json / -j` flag
-- `--json` implies `--yes` (skip confirmation)
-- Output: `{"name": "...", "deleted": true}`
+- `--json` implies `--yes`: skip the inline `pterm.Info.Printf` account-info line and the confirmation prompt (all pterm output before deletion is suppressed)
+- Output: `{"name": "Expenses:Food", "deleted": true}`
 
 ### `add`
 - Add `--json / -j` flag to `addFlags`
-- In `Run()` after transaction created: if JSON → `WriteJSON(toJSONTxDetail(detail))`
+- `--json` is only valid in flag mode. If `--json` is set but no identifying flags (`--desc`, `--amount`, `--from`, `--to`) are changed, return an error: `--json requires flags (--desc, --amount, --from, --to)`
+- After transaction created: `WriteJSON(toJSONTxDetail(detail))`
 - Output: `jsonTxDetail`
 
 ### `transaction list`
 - Add `--json / -j` flag to `listFlags`
-- In `Run()`: if JSON → `WriteJSON(toJSONTxListItems(items))`
+- In `Run()`: if JSON → build `[]jsonTxListItem` from the same data used for the table, call `WriteJSON`
 - Output: `[]jsonTxListItem`
 
 ### `transaction show`
-- Add `--json / -j` flag
+- Add `--json / -j` flag to `showRunner`
 - In `Run()`: if JSON → `WriteJSON(toJSONTxDetail(detail))`
 - Output: `jsonTxDetail`
 
 ### `transaction delete`
-- Add `--json / -j` flag
-- `--json` implies `--yes` (skip confirmation)
+- Add `--json / -j` flag to `deleteRunner`
+- `--json` implies `--yes`: skip both the preview render and the confirmation prompt
 - Output: `{"id": 42, "deleted": true}`
 
 ### `transaction clear`
-- Add `--json / -j` flag
-- Output: `{"id": 42, "status": "cleared"}`
+- Add `--json / -j` flag to `clearRunner`
+- No confirmation prompt exists; `--json` only affects output format
+- The status value is hardcoded as `"Cleared"` (matching `model.StatusCleared.String()`) based on the command's known effect; no re-fetch required
+- Output: `{"id": 42, "status": "Cleared"}`
 
 ### `info`
-- Add `--json / -j` flag
+- Add `--json / -j` flag to `infoRunner`
 - In `Run()`: if JSON → `WriteJSON(toJSONSystemInfo(data))`
 - Output: `jsonSystemInfo`
 
@@ -133,13 +147,14 @@ Converter functions (`toJSON*`) live in the same file alongside the structs.
 
 ## Behaviour Rules
 
-1. `--json` suppresses all TUI output (tables, colored messages) — only JSON goes to stdout.
-2. For delete commands, `--json` implies `--yes`; no separate flag needed.
-3. For `account create`, `--json` skips the final confirmation prompt.
+1. `--json` suppresses all TUI output (tables, colored pterm messages) — only JSON goes to stdout.
+2. For delete commands (`account delete`, `transaction delete`), `--json` implies `--yes`: both the preview render and the confirmation prompt are suppressed.
+3. For `account create` and `add`, `--json` requires flag mode. If no identifying flags are provided, the command returns a non-zero exit code with a descriptive error message instead of entering interactive mode.
 4. All amounts serialized as `float64` units (÷ 100), consistent with `report --json`.
 5. Dates serialized as `YYYY-MM-DD` strings.
-6. `TransactionStatus` serialized as human-readable string: `"pending"`, `"cleared"`, `"reconciled"`.
+6. `TransactionStatus` serialized via `.String()`: `"Pending"`, `"Cleared"`, `"Reconciled"`.
 7. `AccountType` serialized as single-letter code: `"A"`, `"L"`, `"C"`, `"R"`, `"E"`.
+8. `transaction clear` has no confirmation prompt; `--json` on this command only changes output format, not flow.
 
 ---
 
@@ -147,5 +162,8 @@ Converter functions (`toJSON*`) live in the same file alongside the structs.
 
 - `transaction edit` — excluded from this spec (tracked separately in issue #6).
 - All interactive flows remain unchanged when `--json` is not set.
-- No changes to model layer, service layer, or repository layer.
+- No changes to model layer or repository layer.
+- One targeted addition to service layer: `AccountService.GetAccountBalance(id int64) (int64, error)`.
 - No new view interface methods required.
+- `WriteJSON` and `CentsToUnit` in `ui/views/json.go` are exported (uppercase). The private equivalents in `report_json.go` are removed and replaced with calls to the new shared functions.
+- `jsonTxListItem` does not reuse `TransactionListItem` (which stores `Amount` as a formatted string); it maps from it with `Amount` as `float64`.

--- a/docs/superpowers/specs/2026-03-24-json-output-design.md
+++ b/docs/superpowers/specs/2026-03-24-json-output-design.md
@@ -1,0 +1,151 @@
+# JSON Output Flag Design
+
+**Date:** 2026-03-24
+**Issue:** #5 — add `--json` flag to remaining commands for machine-readable output
+**Scope:** All output-producing commands except `transaction edit`
+
+---
+
+## Goal
+
+Enable scripting and automation by adding `--json / -j` to every command that produces output.
+Only `report` has this today; this spec brings all remaining commands up to parity.
+
+---
+
+## Shared Infrastructure
+
+### `ui/views/json.go` (new)
+
+Extract the existing pattern from `ui/views/report_json.go` into reusable helpers:
+
+```go
+func WriteJSON(v any) error          // indented JSON to stdout
+func CentsToUnit(cents int64) float64 // cents → float64 (÷ 100)
+```
+
+### `ui/views/json_types.go` (new)
+
+JSON DTO structs with `json` tags. Amounts are `float64` (units, not cents).
+
+```go
+type jsonAccount struct {
+    ID          int64  `json:"id"`
+    Name        string `json:"name"`
+    Type        string `json:"type"`
+    ParentID    *int64 `json:"parent_id"`
+    Currency    string `json:"currency"`
+    Description string `json:"description"`
+    IsHidden    bool   `json:"is_hidden"`
+}
+
+type jsonSplitDetail struct {
+    ID          int64   `json:"id"`
+    AccountID   int64   `json:"account_id"`
+    AccountName string  `json:"account_name"`
+    AccountType string  `json:"account_type"`
+    Amount      float64 `json:"amount"`
+    Currency    string  `json:"currency"`
+    Memo        string  `json:"memo"`
+}
+
+type jsonTxDetail struct {
+    ID          int64            `json:"id"`
+    Date        string           `json:"date"`       // YYYY-MM-DD
+    Description string           `json:"description"`
+    Status      string           `json:"status"`     // "pending" | "cleared" | "reconciled"
+    Splits      []jsonSplitDetail `json:"splits"`
+}
+
+type jsonTxListItem struct {
+    ID          int64   `json:"id"`
+    Date        string  `json:"date"`
+    Type        string  `json:"type"`
+    Account     string  `json:"account"`
+    Offset      string  `json:"offset"`
+    Description string  `json:"description"`
+    Amount      float64 `json:"amount"`
+    Currency    string  `json:"currency"`
+    Status      string  `json:"status"`
+}
+
+type jsonSystemInfo struct {
+    ConfigPath      string `json:"config_path"`
+    DBPath          string `json:"db_path"`
+    DBExists        bool   `json:"db_exists"`
+    DefaultCurrency string `json:"default_currency"`
+    AppDataDir      string `json:"app_data_dir"`
+}
+```
+
+Converter functions (`toJSON*`) live in the same file alongside the structs.
+
+---
+
+## Per-Command Changes
+
+### `account list`
+- Add `--json / -j` flag to `listFlags`
+- In `Run()`: if JSON → `WriteJSON(toJSONAccounts(accounts))`
+- Output: `[]jsonAccount`
+
+### `account create`
+- Add `--json / -j` flag to `createFlags`
+- Skip interactive confirmation when `--json` is set (scripting mode)
+- In `Run()` after account created: if JSON → `WriteJSON(toJSONAccount(acc))`
+- Output: `jsonAccount`
+
+### `account delete`
+- Add `--json / -j` flag
+- `--json` implies `--yes` (skip confirmation)
+- Output: `{"name": "...", "deleted": true}`
+
+### `add`
+- Add `--json / -j` flag to `addFlags`
+- In `Run()` after transaction created: if JSON → `WriteJSON(toJSONTxDetail(detail))`
+- Output: `jsonTxDetail`
+
+### `transaction list`
+- Add `--json / -j` flag to `listFlags`
+- In `Run()`: if JSON → `WriteJSON(toJSONTxListItems(items))`
+- Output: `[]jsonTxListItem`
+
+### `transaction show`
+- Add `--json / -j` flag
+- In `Run()`: if JSON → `WriteJSON(toJSONTxDetail(detail))`
+- Output: `jsonTxDetail`
+
+### `transaction delete`
+- Add `--json / -j` flag
+- `--json` implies `--yes` (skip confirmation)
+- Output: `{"id": 42, "deleted": true}`
+
+### `transaction clear`
+- Add `--json / -j` flag
+- Output: `{"id": 42, "status": "cleared"}`
+
+### `info`
+- Add `--json / -j` flag
+- In `Run()`: if JSON → `WriteJSON(toJSONSystemInfo(data))`
+- Output: `jsonSystemInfo`
+
+---
+
+## Behaviour Rules
+
+1. `--json` suppresses all TUI output (tables, colored messages) — only JSON goes to stdout.
+2. For delete commands, `--json` implies `--yes`; no separate flag needed.
+3. For `account create`, `--json` skips the final confirmation prompt.
+4. All amounts serialized as `float64` units (÷ 100), consistent with `report --json`.
+5. Dates serialized as `YYYY-MM-DD` strings.
+6. `TransactionStatus` serialized as human-readable string: `"pending"`, `"cleared"`, `"reconciled"`.
+7. `AccountType` serialized as single-letter code: `"A"`, `"L"`, `"C"`, `"R"`, `"E"`.
+
+---
+
+## What Is NOT Changing
+
+- `transaction edit` — excluded from this spec (tracked separately in issue #6).
+- All interactive flows remain unchanged when `--json` is not set.
+- No changes to model layer, service layer, or repository layer.
+- No new view interface methods required.

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -39,6 +39,10 @@ type TransactionRepository interface {
 	// transactions in the given Unix time range, keyed by transaction ID.
 	// Designed for bulk report queries to avoid N+1 patterns.
 	GetSplitsWithAccountsByDateRange(startTime, endTime int64) (map[int64][]model.SplitDetail, error)
+
+	// GetSplitsWithAccountsByTransaction returns all splits (with account info) for
+	// a single transaction in one JOIN query.
+	GetSplitsWithAccountsByTransaction(txID int64) ([]model.SplitDetail, error)
 }
 
 type Repository interface {

--- a/internal/service/account_ops_test.go
+++ b/internal/service/account_ops_test.go
@@ -388,3 +388,27 @@ func TestFormatAccountName(t *testing.T) {
 		})
 	}
 }
+
+// ──────────────────────────────────────────────
+// GetAccountBalance
+// ──────────────────────────────────────────────
+
+func TestGetAccountBalance(t *testing.T) {
+	repo := newMockAccountRepo()
+	svc := newTestAccountService(repo, newMockTransactionRepo())
+
+	repo.addAccount(&model.Account{ID: 1, Name: "Assets:Cash", Type: model.AccountTypeAsset})
+	repo.balances[1] = 5000 // 50.00 in cents
+
+	t.Run("returns raw cents", func(t *testing.T) {
+		got, err := svc.GetAccountBalance(1)
+		require.NoError(t, err)
+		assert.Equal(t, int64(5000), got)
+	})
+
+	t.Run("propagates repo error", func(t *testing.T) {
+		repo.getBalanceErr[99] = errors.New("not found")
+		_, err := svc.GetAccountBalance(99)
+		assert.Error(t, err)
+	})
+}

--- a/internal/service/account_service.go
+++ b/internal/service/account_service.go
@@ -32,6 +32,10 @@ func (as *AccountService) GetAccountsByType(accType model.AccountType) ([]*model
 	return as.repo.GetAccountsByType(accType)
 }
 
+func (as *AccountService) GetAccountBalance(accountID int64) (int64, error) {
+	return as.repo.GetAccountBalance(accountID)
+}
+
 func (as *AccountService) GetAccountBalanceFormatted(accountID int64) (string, error) {
 	balance, err := as.repo.GetAccountBalance(accountID)
 	if err != nil {

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -309,6 +309,21 @@ func (m *mockTransactionRepo) GetSplitsWithAccountsByDateRange(startTime, endTim
 	return m.splitsWithAccts, nil
 }
 
+func (m *mockTransactionRepo) GetSplitsWithAccountsByTransaction(txID int64) ([]model.SplitDetail, error) {
+	splits := m.splits[txID]
+	result := make([]model.SplitDetail, 0, len(splits))
+	for _, s := range splits {
+		result = append(result, model.SplitDetail{
+			ID:        s.ID,
+			AccountID: s.AccountID,
+			Amount:    s.Amount,
+			Currency:  s.Currency,
+			Memo:      s.Memo,
+		})
+	}
+	return result, nil
+}
+
 // ──────────────────────────────────────────────
 // mockCombinedRepo (implements repository.Repository)
 // ──────────────────────────────────────────────

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -276,10 +276,9 @@ func (ts *TransactionService) IsEditable(detail *model.TransactionDetail) bool {
 		return false
 	}
 
-	// (Future feature)
-	// if detail.Status == model.StatusReconciled {
-	//     return false
-	// }
+	if detail.Status == model.StatusReconciled {
+		return false
+	}
 
 	return true
 }

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -569,4 +569,9 @@ func TestIsEditable(t *testing.T) {
 		detail := &model.TransactionDetail{ID: 2}
 		assert.True(t, svc.IsEditable(detail))
 	})
+
+	t.Run("reconciled transaction is not editable", func(t *testing.T) {
+		detail := &model.TransactionDetail{ID: 5, Status: model.StatusReconciled}
+		assert.False(t, svc.IsEditable(detail))
+	})
 }

--- a/internal/service/transaction_service.go
+++ b/internal/service/transaction_service.go
@@ -46,40 +46,23 @@ func (ts *TransactionService) GetTransactionRule(txType model.TransactionType) (
 
 // GetTransactionByID retrieves a transaction with all split details
 func (ts *TransactionService) GetTransactionByID(txID int64) (*model.TransactionDetail, error) {
-	tx, splits, err := ts.txRepo.GetTransactionByID(txID)
+	tx, _, err := ts.txRepo.GetTransactionByID(txID)
 	if err != nil {
 		return nil, err
 	}
 
-	// Convert to detail format with account names
-	detail := &model.TransactionDetail{
+	splits, err := ts.txRepo.GetSplitsWithAccountsByTransaction(txID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get splits for transaction: %w", err)
+	}
+
+	return &model.TransactionDetail{
 		ID:          tx.ID,
 		Timestamp:   tx.Timestamp,
 		Description: tx.Description,
 		Status:      tx.Status,
-		Splits:      make([]model.SplitDetail, 0, len(splits)),
-	}
-
-	for _, split := range splits {
-		// Get account name by ID
-		account, err := ts.accRepo.GetAccountByID(split.AccountID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get account for split: %w", err)
-		}
-
-		splitDetail := model.SplitDetail{
-			ID:          split.ID,
-			AccountID:   split.AccountID,
-			AccountName: account.Name,
-			AccountType: account.Type,
-			Amount:      split.Amount,
-			Currency:    split.Currency,
-			Memo:        split.Memo,
-		}
-		detail.Splits = append(detail.Splits, splitDetail)
-	}
-
-	return detail, nil
+		Splits:      splits,
+	}, nil
 }
 
 // GetRecentTransactions retrieves recent transactions across all accounts

--- a/internal/store/sqlite_transaction.go
+++ b/internal/store/sqlite_transaction.go
@@ -364,6 +364,38 @@ func (s *Store) GetSplitsWithAccountsByDateRange(startTime, endTime int64) (map[
 	return result, nil
 }
 
+func (s *Store) GetSplitsWithAccountsByTransaction(txID int64) ([]model.SplitDetail, error) {
+	rows, err := s.db.Query(`
+        SELECT
+            s.id, s.account_id, s.amount, s.currency, s.memo,
+            a.name, a.type
+        FROM splits s
+        JOIN accounts a ON s.account_id = a.id
+        WHERE s.transaction_id = ?
+        ORDER BY s.id
+    `, txID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query splits with accounts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []model.SplitDetail
+	for rows.Next() {
+		var d model.SplitDetail
+		if err := rows.Scan(
+			&d.ID, &d.AccountID, &d.Amount, &d.Currency, &d.Memo,
+			&d.AccountName, &d.AccountType,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan split with account: %w", err)
+		}
+		result = append(result, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows iteration error: %w", err)
+	}
+	return result, nil
+}
+
 func (s *Store) scanTransactions(rows *sql.Rows) ([]*model.Transaction, error) {
 	var transactions []*model.Transaction
 	for rows.Next() {

--- a/internal/utils/amount.go
+++ b/internal/utils/amount.go
@@ -16,6 +16,9 @@ func FormatAmount(cents int64) string {
 
 func ParseAmount(amountStr string) (int64, error) {
 	isNegative := false
+	if amountStr == "" || amountStr == "-" {
+		return 0, fmt.Errorf("%q", amountStr)
+	}
 	if strings.HasPrefix(amountStr, "-") {
 		isNegative = true
 		amountStr = strings.TrimPrefix(amountStr, "-")
@@ -25,14 +28,14 @@ func ParseAmount(amountStr string) (int64, error) {
 	parts := strings.Split(amountStr, ".")
 
 	if len(parts) > 2 {
-		return 0, fmt.Errorf("invalid amount format: %s", amountStr)
+		return 0, fmt.Errorf("invalid format: %s", amountStr)
 	}
 
 	// Parse dollar part
 	if parts[0] != "" {
 		parsed, err := parseDigitsStrict(parts[0])
 		if err != nil {
-			return 0, fmt.Errorf("invalid amount: %s", amountStr)
+			return 0, fmt.Errorf("%w: %s", err, amountStr)
 		}
 		dollars = parsed
 	}
@@ -85,10 +88,6 @@ func ParseAmount(amountStr string) (int64, error) {
 }
 
 func parseDigitsStrict(value string) (int64, error) {
-	if value == "" {
-		return 0, fmt.Errorf("empty numeric value")
-	}
-
 	for i := 0; i < len(value); i++ {
 		if value[i] < '0' || value[i] > '9' {
 			return 0, fmt.Errorf("non-digit character found")

--- a/internal/utils/amount_test.go
+++ b/internal/utils/amount_test.go
@@ -84,9 +84,6 @@ func TestParseAmount_Valid(t *testing.T) {
 // ParseAmount — invalid inputs
 // ──────────────────────────────────────────────
 
-// Confirmed edge-case behavior (production code, not test bugs):
-// - ParseAmount("") → (0, nil): empty string treated as 0, potential bug
-// - ParseAmount("-") → (0, nil): bare minus treated as -0 = 0, potential bug
 func TestParseAmount_Invalid(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -98,6 +95,8 @@ func TestParseAmount_Invalid(t *testing.T) {
 		{"letters only", "abc"},
 		{"minus sign with letters", "-abc"},
 		{"whitespace", " "},
+		{"empty string", ""},
+		{"just -", "-"},
 	}
 
 	for _, tt := range tests {

--- a/ui/views/json.go
+++ b/ui/views/json.go
@@ -1,0 +1,24 @@
+package views
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/hance08/kea/internal/model"
+)
+
+// WriteJSON encodes v as indented JSON to stdout.
+func WriteJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		return fmt.Errorf("failed to encode JSON: %w", err)
+	}
+	return nil
+}
+
+// CentsToUnit converts int64 cents to float64 currency units (÷ model.CentsPerUnit).
+func CentsToUnit(cents int64) float64 {
+	return float64(cents) / float64(model.CentsPerUnit)
+}

--- a/ui/views/json_test.go
+++ b/ui/views/json_test.go
@@ -1,0 +1,93 @@
+package views
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/hance08/kea/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCentsToUnit(t *testing.T) {
+	assert.Equal(t, 1.0, CentsToUnit(100))
+	assert.Equal(t, 1.5, CentsToUnit(150))
+	assert.Equal(t, 0.0, CentsToUnit(0))
+	assert.Equal(t, -1.5, CentsToUnit(-150))
+}
+
+func TestToJSONAccount(t *testing.T) {
+	parentID := int64(1)
+	acc := &model.Account{
+		ID:          2,
+		Name:        "Assets:Bank",
+		Type:        model.AccountTypeAsset,
+		ParentID:    &parentID,
+		Currency:    "TWD",
+		Description: "Main bank",
+		IsHidden:    false,
+	}
+	got := ToJSONAccount(acc, 15000)
+	assert.Equal(t, int64(2), got.ID)
+	assert.Equal(t, "Assets:Bank", got.Name)
+	assert.Equal(t, "A", got.Type)
+	assert.Equal(t, &parentID, got.ParentID)
+	assert.Equal(t, "TWD", got.Currency)
+	assert.Equal(t, "Main bank", got.Description)
+	assert.False(t, got.IsHidden)
+	assert.Equal(t, 150.0, got.Balance)
+}
+
+func TestToJSONTxDetail(t *testing.T) {
+	detail := &model.TransactionDetail{
+		ID:          42,
+		Timestamp:   1711238400, // 2024-03-24
+		Description: "Buy coffee",
+		Status:      model.StatusCleared,
+		Splits: []model.SplitDetail{
+			{ID: 1, AccountID: 10, AccountName: "Assets:Cash", AccountType: model.AccountTypeAsset, Amount: -500, Currency: "TWD", Memo: ""},
+			{ID: 2, AccountID: 20, AccountName: "Expenses:Food", AccountType: model.AccountTypeExpense, Amount: 500, Currency: "TWD", Memo: "lunch"},
+		},
+	}
+	got := ToJSONTxDetail(detail)
+	assert.Equal(t, int64(42), got.ID)
+	assert.Equal(t, "Cleared", got.Status)
+	assert.Len(t, got.Splits, 2)
+	assert.Equal(t, -5.0, got.Splits[0].Amount)
+	assert.Equal(t, 5.0, got.Splits[1].Amount)
+	assert.Equal(t, "lunch", got.Splits[1].Memo)
+}
+
+func TestToJSONTxListItem(t *testing.T) {
+	item := TransactionListItem{
+		ID: 7, Date: "2024-03-24", Type: "Expense",
+		Account: "Assets:Cash", Offset: "Expenses:Food",
+		Description: "lunch", Amount: "5.00", Currency: "TWD", Status: "Cleared",
+	}
+	got := ToJSONTxListItem(item)
+	assert.Equal(t, int64(7), got.ID)
+	assert.Equal(t, 5.0, got.Amount)
+	assert.Equal(t, "TWD", got.Currency)
+}
+
+func TestWriteJSON_validOutput(t *testing.T) {
+	// Redirect stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := WriteJSON(map[string]string{"key": "value"})
+	require.NoError(t, err)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+
+	var result map[string]string
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
+	assert.Equal(t, "value", result["key"])
+}

--- a/ui/views/json_test.go
+++ b/ui/views/json_test.go
@@ -64,12 +64,13 @@ func TestToJSONTxListItem(t *testing.T) {
 	item := TransactionListItem{
 		ID: 7, Date: "2024-03-24", Type: "Expense",
 		Account: "Assets:Cash", Offset: "Expenses:Food",
-		Description: "lunch", Amount: "5.00", Currency: "TWD", Status: "Cleared",
+		Description: "lunch", Amount: "5.50", Currency: "TWD", Status: "Cleared",
 	}
 	got := ToJSONTxListItem(item)
 	assert.Equal(t, int64(7), got.ID)
-	assert.Equal(t, 5.0, got.Amount)
+	assert.Equal(t, 5.5, got.Amount)
 	assert.Equal(t, "TWD", got.Currency)
+	assert.Equal(t, "Cleared", got.Status)
 }
 
 func TestWriteJSON_validOutput(t *testing.T) {

--- a/ui/views/json_types.go
+++ b/ui/views/json_types.go
@@ -1,7 +1,7 @@
 package views
 
 import (
-	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/hance08/kea/internal/model"
@@ -103,8 +103,7 @@ func ToJSONTxDetail(d *model.TransactionDetail) JSONTxDetail {
 }
 
 func ToJSONTxListItem(item TransactionListItem) JSONTxListItem {
-	var amount float64
-	fmt.Sscanf(item.Amount, "%f", &amount)
+	amount, _ := strconv.ParseFloat(item.Amount, 64)
 	return JSONTxListItem{
 		ID:          item.ID,
 		Date:        item.Date,

--- a/ui/views/json_types.go
+++ b/ui/views/json_types.go
@@ -1,0 +1,129 @@
+package views
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hance08/kea/internal/model"
+)
+
+// ── JSON DTOs ─────────────────────────────────────────────────────────────────
+// Amounts are float64 currency units (not cents). Dates are YYYY-MM-DD strings.
+// TransactionStatus is serialized via .String(). AccountType as single-letter code.
+
+type JSONAccount struct {
+	ID          int64   `json:"id"`
+	Name        string  `json:"name"`
+	Type        string  `json:"type"`
+	ParentID    *int64  `json:"parent_id"`
+	Currency    string  `json:"currency"`
+	Description string  `json:"description"`
+	IsHidden    bool    `json:"is_hidden"`
+	Balance     float64 `json:"balance"`
+}
+
+type JSONSplitDetail struct {
+	ID          int64   `json:"id"`
+	AccountID   int64   `json:"account_id"`
+	AccountName string  `json:"account_name"`
+	AccountType string  `json:"account_type"`
+	Amount      float64 `json:"amount"`
+	Currency    string  `json:"currency"`
+	Memo        string  `json:"memo"`
+}
+
+type JSONTxDetail struct {
+	ID          int64             `json:"id"`
+	Date        string            `json:"date"`
+	Description string            `json:"description"`
+	Status      string            `json:"status"`
+	Splits      []JSONSplitDetail `json:"splits"`
+}
+
+type JSONTxListItem struct {
+	ID          int64   `json:"id"`
+	Date        string  `json:"date"`
+	Type        string  `json:"type"`
+	Account     string  `json:"account"`
+	Offset      string  `json:"offset"`
+	Description string  `json:"description"`
+	Amount      float64 `json:"amount"`
+	Currency    string  `json:"currency"`
+	Status      string  `json:"status"`
+}
+
+type JSONSystemInfo struct {
+	ConfigPath      string `json:"config_path"`
+	DBPath          string `json:"db_path"`
+	// false means DB does not yet exist; it will be created on first use.
+	DBExists        bool   `json:"db_exists"`
+	DefaultCurrency string `json:"default_currency"`
+	AppDataDir      string `json:"app_data_dir"`
+}
+
+// ── Converters ────────────────────────────────────────────────────────────────
+
+func ToJSONAccount(acc *model.Account, balanceCents int64) JSONAccount {
+	return JSONAccount{
+		ID:          acc.ID,
+		Name:        acc.Name,
+		Type:        string(acc.Type),
+		ParentID:    acc.ParentID,
+		Currency:    acc.Currency,
+		Description: acc.Description,
+		IsHidden:    acc.IsHidden,
+		Balance:     CentsToUnit(balanceCents),
+	}
+}
+
+func toJSONSplit(s model.SplitDetail) JSONSplitDetail {
+	return JSONSplitDetail{
+		ID:          s.ID,
+		AccountID:   s.AccountID,
+		AccountName: s.AccountName,
+		AccountType: string(s.AccountType),
+		Amount:      CentsToUnit(s.Amount),
+		Currency:    s.Currency,
+		Memo:        s.Memo,
+	}
+}
+
+func ToJSONTxDetail(d *model.TransactionDetail) JSONTxDetail {
+	splits := make([]JSONSplitDetail, len(d.Splits))
+	for i, s := range d.Splits {
+		splits[i] = toJSONSplit(s)
+	}
+	return JSONTxDetail{
+		ID:          d.ID,
+		Date:        time.Unix(d.Timestamp, 0).UTC().Format("2006-01-02"),
+		Description: d.Description,
+		Status:      d.Status.String(),
+		Splits:      splits,
+	}
+}
+
+func ToJSONTxListItem(item TransactionListItem) JSONTxListItem {
+	var amount float64
+	fmt.Sscanf(item.Amount, "%f", &amount)
+	return JSONTxListItem{
+		ID:          item.ID,
+		Date:        item.Date,
+		Type:        item.Type,
+		Account:     item.Account,
+		Offset:      item.Offset,
+		Description: item.Description,
+		Amount:      amount,
+		Currency:    item.Currency,
+		Status:      item.Status,
+	}
+}
+
+func ToJSONSystemInfo(info SystemInfo) JSONSystemInfo {
+	return JSONSystemInfo{
+		ConfigPath:      info.ConfigPath,
+		DBPath:          info.DBPath,
+		DBExists:        info.DBExists,
+		DefaultCurrency: info.DefaultCurrency,
+		AppDataDir:      info.AppDataDir,
+	}
+}

--- a/ui/views/report_json.go
+++ b/ui/views/report_json.go
@@ -1,10 +1,6 @@
 package views
 
 import (
-	"encoding/json"
-	"fmt"
-	"os"
-
 	"github.com/hance08/kea/internal/model"
 )
 
@@ -18,29 +14,19 @@ func NewJSONReportView() *JSONReportView {
 }
 
 func (v *JSONReportView) RenderIncomeStatement(result *model.ReportResult) error {
-	return writeJSON(toJSONReportResult(result))
+	return WriteJSON(toJSONReportResult(result))
 }
 
 func (v *JSONReportView) RenderIncomeBreakdown(result *model.ReportResult) error {
-	return writeJSON(toJSONReportResult(result))
+	return WriteJSON(toJSONReportResult(result))
 }
 
 func (v *JSONReportView) RenderExpenseBreakdown(result *model.ReportResult) error {
-	return writeJSON(toJSONReportResult(result))
+	return WriteJSON(toJSONReportResult(result))
 }
 
 func (v *JSONReportView) RenderBalanceSheet(result *model.BalanceSheetResult) error {
-	return writeJSON(toJSONBalanceSheetResult(result))
-}
-
-// writeJSON marshals v to indented JSON and writes it to stdout followed by a newline.
-func writeJSON(v any) error {
-	enc := json.NewEncoder(os.Stdout)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(v); err != nil {
-		return fmt.Errorf("failed to encode JSON: %w", err)
-	}
-	return nil
+	return WriteJSON(toJSONBalanceSheetResult(result))
 }
 
 // ── JSON-specific DTOs ────────────────────────────────────────────────────────
@@ -82,15 +68,11 @@ type jsonBalanceSheetResult struct {
 	Currency          string          `json:"currency"`
 }
 
-func centsToUnit(cents int64) float64 {
-	return float64(cents) / float64(model.CentsPerUnit)
-}
-
 func toJSONRow(r model.ReportRow) jsonReportRow {
 	return jsonReportRow{
 		AccountName:   r.AccountName,
 		OffsetAccount: r.OffsetAccount,
-		Amount:        centsToUnit(r.Amount),
+		Amount:        CentsToUnit(r.Amount),
 		Currency:      r.Currency,
 		TxCount:       r.TxCount,
 	}
@@ -107,16 +89,16 @@ func toJSONRows(rows []model.ReportRow) []jsonReportRow {
 func toJSONReportResult(r *model.ReportResult) jsonReportResult {
 	var previousNetWorth *float64
 	if r.PreviousNetWorth != nil {
-		v := centsToUnit(*r.PreviousNetWorth)
+		v := CentsToUnit(*r.PreviousNetWorth)
 		previousNetWorth = &v
 	}
 
 	return jsonReportResult{
 		Period:            r.Period,
-		TotalIncome:       centsToUnit(r.TotalIncome),
-		TotalExpense:      centsToUnit(r.TotalExpense),
-		NetAmount:         centsToUnit(r.NetAmount),
-		NetWorth:          centsToUnit(r.NetWorth),
+		TotalIncome:       CentsToUnit(r.TotalIncome),
+		TotalExpense:      CentsToUnit(r.TotalExpense),
+		NetAmount:         CentsToUnit(r.NetAmount),
+		NetWorth:          CentsToUnit(r.NetWorth),
 		PreviousNetWorth:  previousNetWorth,
 		NetWorthGrowthPct: r.NetWorthGrowthPct,
 		Currency:          r.Currency,
@@ -128,7 +110,7 @@ func toJSONReportResult(r *model.ReportResult) jsonReportResult {
 func toJSONBalanceSheetResult(r *model.BalanceSheetResult) jsonBalanceSheetResult {
 	var previousNetWorth *float64
 	if r.PreviousNetWorth != nil {
-		v := centsToUnit(*r.PreviousNetWorth)
+		v := CentsToUnit(*r.PreviousNetWorth)
 		previousNetWorth = &v
 	}
 
@@ -136,10 +118,10 @@ func toJSONBalanceSheetResult(r *model.BalanceSheetResult) jsonBalanceSheetResul
 		Assets:            toJSONRows(r.Assets),
 		Liabilities:       toJSONRows(r.Liabilities),
 		Equity:            toJSONRows(r.Equity),
-		TotalAssets:       centsToUnit(r.TotalAssets),
-		TotalLiabilities:  centsToUnit(r.TotalLiabilities),
-		TotalEquity:       centsToUnit(r.TotalEquity),
-		NetWorth:          centsToUnit(r.NetWorth),
+		TotalAssets:       CentsToUnit(r.TotalAssets),
+		TotalLiabilities:  CentsToUnit(r.TotalLiabilities),
+		TotalEquity:       CentsToUnit(r.TotalEquity),
+		NetWorth:          CentsToUnit(r.NetWorth),
 		PreviousNetWorth:  previousNetWorth,
 		NetWorthGrowthPct: r.NetWorthGrowthPct,
 		Currency:          r.Currency,

--- a/ui/views/transaction_list.go
+++ b/ui/views/transaction_list.go
@@ -109,6 +109,6 @@ func (v *TransactionListView) Render(items []TransactionListItem, limit int) err
 	return nil
 }
 
-func (v *TransactionListView) ShowWarning(format string, a ...interface{}) {
+func (v *TransactionListView) ShowWarning(format string, a ...any) {
 	pterm.Warning.Printf(format+"\n", a...)
 }


### PR DESCRIPTION
## Summary
- Standardize all cmd/ runners with a consistent pattern: flags struct, provider interface, and value-type inputs
- Remove mutable state from runners; replace with immutable `createInput`/similar value types
- Propagate errors through `RunE` instead of silently swallowing them

## Test Plan
- [ ] `go test ./...` passes
- [ ] Manual smoke test: `kea account create`, `kea account list`, `kea account delete`, `kea add`, `kea tx show`, `kea tx delete`, `kea tx clear`, `kea info`, `kea report`