### PR TITLE
feat: automatic daily/weekly/monthly DB backup on startup

### DIFF
--- a/docs/superpowers/plans/2026-04-14-db-backup.md
+++ b/docs/superpowers/plans/2026-04-14-db-backup.md
@@ -1,0 +1,810 @@
+# DB Backup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add automatic daily/weekly/monthly SQLite DB backup on startup, stored in a `backups/` subdirectory next to the DB file, with fixed retention limits.
+
+**Architecture:** A new `internal/backup` package exposes `Run(dbPath string) error`. `app.NewApp()` calls it after resolving the DB path, before opening the store. All tier logic, file copying, and rotation are self-contained in this package with an injectable `clock` interface for deterministic tests.
+
+**Tech Stack:** Go stdlib only (`os`, `io`, `path/filepath`, `time`, `sort`). Tests use `github.com/stretchr/testify`.
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `internal/backup/backup.go` | `Run`, `run`, tier definitions, label helpers, `copyFile`, `rotate` |
+| Create | `internal/backup/backup_test.go` | All backup tests using `t.TempDir()` and `fakeClock` |
+| Modify | `internal/app/app.go` | Call `backup.Run(dbPathRaw)` before `store.NewStore()` |
+
+---
+
+## Task 1: Package skeleton — `Run` no-ops when DB is absent
+
+**Files:**
+- Create: `internal/backup/backup.go`
+- Create: `internal/backup/backup_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/backup/backup_test.go`:
+
+```go
+package backup
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeClock lets tests control "now".
+type fakeClock struct{ t time.Time }
+
+func (f fakeClock) Now() time.Time { return f.t }
+
+func fixedTime(s string) time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+// TestRun_NoDBFile: when the DB does not exist, Run is a no-op.
+func TestRun_NoDBFile(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+
+	err := run(dbPath, fakeClock{t: fixedTime("2026-04-14")})
+
+	require.NoError(t, err)
+	_, statErr := os.Stat(filepath.Join(dir, "backups"))
+	assert.True(t, os.IsNotExist(statErr), "backups/ dir should not be created when DB is absent")
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+go test ./internal/backup/... -run TestRun_NoDBFile -v
+```
+
+Expected: compile error — package does not exist yet.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `internal/backup/backup.go`:
+
+```go
+package backup
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+// Run backs up dbPath if any tier is due. It is a no-op when dbPath does not
+// exist. Errors are non-fatal: the caller should log and continue startup.
+func Run(dbPath string) error {
+	return run(dbPath, realClock{})
+}
+
+func run(dbPath string, clk clock) error {
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return nil
+	}
+	return nil // remaining logic added in later tasks
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+go test ./internal/backup/... -run TestRun_NoDBFile -v
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/backup/backup.go internal/backup/backup_test.go
+git commit -m "feat(backup): add package skeleton with no-DB no-op"
+```
+
+---
+
+## Task 2: Label helpers and filename generation
+
+**Files:**
+- Modify: `internal/backup/backup.go`
+- Modify: `internal/backup/backup_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/backup/backup_test.go`:
+
+```go
+func TestDailyLabel(t *testing.T) {
+	assert.Equal(t, "2026-04-14", dailyLabel(fixedTime("2026-04-14")))
+	assert.Equal(t, "2026-01-01", dailyLabel(fixedTime("2026-01-01")))
+}
+
+func TestWeeklyLabel(t *testing.T) {
+	// 2026-04-14 is in ISO week 16 of 2026
+	assert.Equal(t, "2026-W16", weeklyLabel(fixedTime("2026-04-14")))
+	// 2026-01-01 is in ISO week 1 of 2026
+	assert.Equal(t, "2026-W01", weeklyLabel(fixedTime("2026-01-01")))
+}
+
+func TestMonthlyLabel(t *testing.T) {
+	assert.Equal(t, "2026-04", monthlyLabel(fixedTime("2026-04-14")))
+	assert.Equal(t, "2026-01", monthlyLabel(fixedTime("2026-01-01")))
+}
+
+func TestBackupFilename(t *testing.T) {
+	assert.Equal(t, "kea_daily_2026-04-14.db", backupFilename("kea", "daily", "2026-04-14", ".db"))
+	assert.Equal(t, "kea_weekly_2026-W16.db", backupFilename("kea", "weekly", "2026-W16", ".db"))
+	assert.Equal(t, "kea_monthly_2026-04.db", backupFilename("kea", "monthly", "2026-04", ".db"))
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+go test ./internal/backup/... -run "TestDailyLabel|TestWeeklyLabel|TestMonthlyLabel|TestBackupFilename" -v
+```
+
+Expected: compile errors — functions not defined.
+
+- [ ] **Step 3: Add helpers and tier definitions to `backup.go`**
+
+Add after the `run` function stub (before the final `}`):
+
+```go
+type tier struct {
+	name      string
+	label     func(time.Time) string
+	retention int
+}
+
+var tiers = []tier{
+	{name: "daily", label: dailyLabel, retention: 7},
+	{name: "weekly", label: weeklyLabel, retention: 4},
+	{name: "monthly", label: monthlyLabel, retention: 12},
+}
+
+func dailyLabel(t time.Time) string {
+	return t.Format("2006-01-02")
+}
+
+func weeklyLabel(t time.Time) string {
+	year, week := t.ISOWeek()
+	return fmt.Sprintf("%04d-W%02d", year, week)
+}
+
+func monthlyLabel(t time.Time) string {
+	return t.Format("2006-01")
+}
+
+// backupFilename builds the backup file name.
+// e.g. backupFilename("kea", "daily", "2026-04-14", ".db") → "kea_daily_2026-04-14.db"
+func backupFilename(dbBase, tierName, label, ext string) string {
+	return fmt.Sprintf("%s_%s_%s%s", dbBase, tierName, label, ext)
+}
+```
+
+Also add these imports at the top if not already present: `"fmt"`, `"sort"`, `"strings"` are already in the file from Task 1.
+
+- [ ] **Step 4: Run all backup tests**
+
+```bash
+go test ./internal/backup/... -v
+```
+
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/backup/backup.go internal/backup/backup_test.go
+git commit -m "feat(backup): add tier definitions and label helpers"
+```
+
+---
+
+## Task 3: Atomic file copy
+
+**Files:**
+- Modify: `internal/backup/backup.go`
+- Modify: `internal/backup/backup_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/backup/backup_test.go`:
+
+```go
+func TestCopyFile(t *testing.T) {
+	dir := t.TempDir()
+
+	src := filepath.Join(dir, "kea.db")
+	require.NoError(t, os.WriteFile(src, []byte("db-contents"), 0644))
+
+	dst := filepath.Join(dir, "backups", "kea_daily_2026-04-14.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0755))
+
+	require.NoError(t, copyFile(src, dst))
+
+	got, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("db-contents"), got)
+}
+
+func TestCopyFile_LeavesNoTmpOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	// Source does not exist — copy must fail and leave no .tmp behind.
+	src := filepath.Join(dir, "missing.db")
+	dst := filepath.Join(dir, "backups", "out.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0755))
+
+	err := copyFile(src, dst)
+	assert.Error(t, err)
+
+	// No .tmp file left behind.
+	_, statErr := os.Stat(dst + ".tmp")
+	assert.True(t, os.IsNotExist(statErr))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/backup/... -run "TestCopyFile" -v
+```
+
+Expected: compile error — `copyFile` not defined.
+
+- [ ] **Step 3: Implement `copyFile`**
+
+Add to `internal/backup/backup.go`:
+
+```go
+// copyFile copies src to dst atomically via a .tmp intermediate file.
+func copyFile(src, dst string) error {
+	tmp := dst + ".tmp"
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(tmp)
+		return err
+	}
+
+	if err := out.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+
+	if err := os.Rename(tmp, dst); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 4: Run all backup tests**
+
+```bash
+go test ./internal/backup/... -v
+```
+
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/backup/backup.go internal/backup/backup_test.go
+git commit -m "feat(backup): implement atomic file copy"
+```
+
+---
+
+## Task 4: Rotation
+
+**Files:**
+- Modify: `internal/backup/backup.go`
+- Modify: `internal/backup/backup_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/backup/backup_test.go`:
+
+```go
+func TestRotate_PrunesOldestBeyondRetention(t *testing.T) {
+	dir := t.TempDir()
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	// Create 9 daily backup files (retention is 7).
+	files := []string{
+		"kea_daily_2026-04-06.db",
+		"kea_daily_2026-04-07.db",
+		"kea_daily_2026-04-08.db",
+		"kea_daily_2026-04-09.db",
+		"kea_daily_2026-04-10.db",
+		"kea_daily_2026-04-11.db",
+		"kea_daily_2026-04-12.db",
+		"kea_daily_2026-04-13.db",
+		"kea_daily_2026-04-14.db",
+	}
+	for _, f := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(backupDir, f), []byte("x"), 0644))
+	}
+
+	require.NoError(t, rotate(backupDir, "kea", "daily", ".db", 7))
+
+	entries, err := os.ReadDir(backupDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 7)
+	// Oldest two should be gone.
+	_, err = os.Stat(filepath.Join(backupDir, "kea_daily_2026-04-06.db"))
+	assert.True(t, os.IsNotExist(err))
+	_, err = os.Stat(filepath.Join(backupDir, "kea_daily_2026-04-07.db"))
+	assert.True(t, os.IsNotExist(err))
+	// Newest should remain.
+	_, err = os.Stat(filepath.Join(backupDir, "kea_daily_2026-04-14.db"))
+	assert.NoError(t, err)
+}
+
+func TestRotate_NoOpWhenUnderRetention(t *testing.T) {
+	dir := t.TempDir()
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	// Create 3 daily files (retention is 7) — nothing should be deleted.
+	for _, f := range []string{"kea_daily_2026-04-12.db", "kea_daily_2026-04-13.db", "kea_daily_2026-04-14.db"} {
+		require.NoError(t, os.WriteFile(filepath.Join(backupDir, f), []byte("x"), 0644))
+	}
+
+	require.NoError(t, rotate(backupDir, "kea", "daily", ".db", 7))
+
+	entries, err := os.ReadDir(backupDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 3)
+}
+
+func TestRotate_OnlyTouchesMatchingTier(t *testing.T) {
+	dir := t.TempDir()
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	// 9 daily + 1 weekly — rotate daily with retention 7, weekly must be untouched.
+	for i := 6; i <= 14; i++ {
+		name := fmt.Sprintf("kea_daily_2026-04-%02d.db", i)
+		require.NoError(t, os.WriteFile(filepath.Join(backupDir, name), []byte("x"), 0644))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "kea_weekly_2026-W15.db"), []byte("x"), 0644))
+
+	require.NoError(t, rotate(backupDir, "kea", "daily", ".db", 7))
+
+	_, err := os.Stat(filepath.Join(backupDir, "kea_weekly_2026-W15.db"))
+	assert.NoError(t, err, "weekly backup must not be deleted by daily rotation")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/backup/... -run "TestRotate" -v
+```
+
+Expected: compile error — `rotate` not defined.
+
+- [ ] **Step 3: Implement `rotate`**
+
+Add to `internal/backup/backup.go`:
+
+```go
+// rotate removes the oldest backups for a given tier beyond the retention limit.
+// Files are identified by prefix "<dbBase>_<tierName>_" and suffix ext.
+func rotate(backupDir, dbBase, tierName, ext string, retention int) error {
+	prefix := fmt.Sprintf("%s_%s_", dbBase, tierName)
+
+	entries, err := os.ReadDir(backupDir)
+	if err != nil {
+		return err
+	}
+
+	var files []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), prefix) && strings.HasSuffix(e.Name(), ext) {
+			files = append(files, e.Name())
+		}
+	}
+
+	sort.Strings(files) // lexicographic = chronological given the naming scheme
+
+	for len(files) > retention {
+		if err := os.Remove(filepath.Join(backupDir, files[0])); err != nil {
+			return err
+		}
+		files = files[1:]
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 4: Run all backup tests**
+
+```bash
+go test ./internal/backup/... -v
+```
+
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/backup/backup.go internal/backup/backup_test.go
+git commit -m "feat(backup): implement backup rotation"
+```
+
+---
+
+## Task 5: Wire `run()` — full integration tests
+
+**Files:**
+- Modify: `internal/backup/backup.go`
+- Modify: `internal/backup/backup_test.go`
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append to `internal/backup/backup_test.go`:
+
+```go
+// mkDB creates a fake DB file at dbPath with contents "fake-db".
+func mkDB(t *testing.T, dbPath string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(dbPath, []byte("fake-db"), 0644))
+}
+
+func TestRun_FirstRun_AllThreeTiersCreated(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+	mkDB(t, dbPath)
+	clk := fakeClock{t: fixedTime("2026-04-14")}
+
+	require.NoError(t, run(dbPath, clk))
+
+	backupDir := filepath.Join(dir, "backups")
+	assertFileExists(t, backupDir, "kea_daily_2026-04-14.db")
+	assertFileExists(t, backupDir, "kea_weekly_2026-W16.db")
+	assertFileExists(t, backupDir, "kea_monthly_2026-04.db")
+}
+
+func TestRun_AlreadyCurrent_NoNewFiles(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+	mkDB(t, dbPath)
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	// Pre-populate all three tiers for today.
+	clk := fakeClock{t: fixedTime("2026-04-14")}
+	for _, name := range []string{
+		"kea_daily_2026-04-14.db",
+		"kea_weekly_2026-W16.db",
+		"kea_monthly_2026-04.db",
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(backupDir, name), []byte("old"), 0644))
+	}
+
+	require.NoError(t, run(dbPath, clk))
+
+	// Files should still have "old" contents — not overwritten.
+	for _, name := range []string{
+		"kea_daily_2026-04-14.db",
+		"kea_weekly_2026-W16.db",
+		"kea_monthly_2026-04.db",
+	} {
+		got, err := os.ReadFile(filepath.Join(backupDir, name))
+		require.NoError(t, err)
+		assert.Equal(t, []byte("old"), got, "file %s should not be overwritten", name)
+	}
+}
+
+func TestRun_DailyDue_OtherTiersCurrent(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+	mkDB(t, dbPath)
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	clk := fakeClock{t: fixedTime("2026-04-14")}
+	// Weekly and monthly already present for this period; daily is missing.
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "kea_weekly_2026-W16.db"), []byte("old"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "kea_monthly_2026-04.db"), []byte("old"), 0644))
+
+	require.NoError(t, run(dbPath, clk))
+
+	assertFileExists(t, backupDir, "kea_daily_2026-04-14.db")
+	// Others untouched.
+	weekly, _ := os.ReadFile(filepath.Join(backupDir, "kea_weekly_2026-W16.db"))
+	assert.Equal(t, []byte("old"), weekly)
+}
+
+func TestRun_RotationTriggered(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+	mkDB(t, dbPath)
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	// Create 7 existing daily backups (at retention limit).
+	for i := 7; i <= 13; i++ {
+		name := fmt.Sprintf("kea_daily_2026-04-%02d.db", i)
+		require.NoError(t, os.WriteFile(filepath.Join(backupDir, name), []byte("x"), 0644))
+	}
+
+	clk := fakeClock{t: fixedTime("2026-04-14")}
+	require.NoError(t, run(dbPath, clk))
+
+	entries, _ := os.ReadDir(backupDir)
+	var dailyCount int
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "kea_daily_") {
+			dailyCount++
+		}
+	}
+	assert.Equal(t, 7, dailyCount, "should have exactly 7 daily backups after rotation")
+
+	// Oldest (Apr 7) removed, newest (Apr 14) present.
+	_, err := os.Stat(filepath.Join(backupDir, "kea_daily_2026-04-07.db"))
+	assert.True(t, os.IsNotExist(err))
+	assertFileExists(t, backupDir, "kea_daily_2026-04-14.db")
+}
+
+func TestRun_WeeklyDue_OtherTiersCurrent(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+	mkDB(t, dbPath)
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	clk := fakeClock{t: fixedTime("2026-04-14")}
+	// Daily and monthly present; weekly is missing.
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "kea_daily_2026-04-14.db"), []byte("old"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "kea_monthly_2026-04.db"), []byte("old"), 0644))
+
+	require.NoError(t, run(dbPath, clk))
+
+	assertFileExists(t, backupDir, "kea_weekly_2026-W16.db")
+	daily, _ := os.ReadFile(filepath.Join(backupDir, "kea_daily_2026-04-14.db"))
+	assert.Equal(t, []byte("old"), daily, "daily should not be overwritten")
+}
+
+func TestRun_MonthlyDue_OtherTiersCurrent(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+	mkDB(t, dbPath)
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	clk := fakeClock{t: fixedTime("2026-04-14")}
+	// Daily and weekly present; monthly is missing.
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "kea_daily_2026-04-14.db"), []byte("old"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "kea_weekly_2026-W16.db"), []byte("old"), 0644))
+
+	require.NoError(t, run(dbPath, clk))
+
+	assertFileExists(t, backupDir, "kea_monthly_2026-04.db")
+	daily, _ := os.ReadFile(filepath.Join(backupDir, "kea_daily_2026-04-14.db"))
+	assert.Equal(t, []byte("old"), daily, "daily should not be overwritten")
+}
+
+func TestRun_CopyFailure_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+	mkDB(t, dbPath)
+
+	// Make the backups dir a file so MkdirAll fails, triggering an error path.
+	backupsPath := filepath.Join(dir, "backups")
+	require.NoError(t, os.WriteFile(backupsPath, []byte("not-a-dir"), 0644))
+
+	clk := fakeClock{t: fixedTime("2026-04-14")}
+	err := run(dbPath, clk)
+	assert.Error(t, err)
+}
+
+// assertFileExists is a helper that checks a file exists in dir.
+func assertFileExists(t *testing.T, dir, name string) {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(dir, name))
+	assert.NoError(t, err, "expected file %s to exist in %s", name, dir)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/backup/... -run "TestRun_First|TestRun_Already|TestRun_Daily|TestRun_Weekly|TestRun_Monthly|TestRun_Rotation|TestRun_Copy" -v
+```
+
+Expected: FAIL — `run` still returns `nil` without any logic.
+
+- [ ] **Step 3: Implement the full `run()` body**
+
+Replace the `run` function in `internal/backup/backup.go`:
+
+```go
+func run(dbPath string, clk clock) error {
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return nil
+	}
+
+	dir := filepath.Dir(dbPath)
+	backupDir := filepath.Join(dir, "backups")
+	if err := os.MkdirAll(backupDir, 0755); err != nil {
+		return fmt.Errorf("create backup dir: %w", err)
+	}
+
+	ext := filepath.Ext(dbPath)
+	dbBase := strings.TrimSuffix(filepath.Base(dbPath), ext)
+	now := clk.Now()
+
+	for _, t := range tiers {
+		label := t.label(now)
+		dst := filepath.Join(backupDir, backupFilename(dbBase, t.name, label, ext))
+
+		if _, err := os.Stat(dst); err == nil {
+			continue // backup for this period already exists
+		}
+
+		if err := copyFile(dbPath, dst); err != nil {
+			return fmt.Errorf("backup %s: %w", t.name, err)
+		}
+
+		if err := rotate(backupDir, dbBase, t.name, ext, t.retention); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: backup rotation failed for %s: %v\n", t.name, err)
+		}
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 4: Run all backup tests**
+
+```bash
+go test ./internal/backup/... -v
+```
+
+Expected: all PASS
+
+- [ ] **Step 5: Run the full test suite to check for regressions**
+
+```bash
+go test ./...
+```
+
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/backup/backup.go internal/backup/backup_test.go
+git commit -m "feat(backup): implement run() — tier check, copy, rotation"
+```
+
+---
+
+## Task 6: Integrate into `app.NewApp()`
+
+**Files:**
+- Modify: `internal/app/app.go`
+
+- [ ] **Step 1: Add the `backup.Run` call to `NewApp`**
+
+In `internal/app/app.go`, after the `dbPathRaw` is resolved (after the `if dbPathRaw == ""` block) and before `store.NewStore(dbPathRaw, migrationFS)`, add:
+
+```go
+if err := backup.Run(dbPathRaw); err != nil {
+    fmt.Fprintf(os.Stderr, "Warning: backup failed: %v\n", err)
+}
+```
+
+Also add the import `"github.com/hance08/kea/internal/backup"` to the import block.
+
+The updated `NewApp` function should look like this:
+
+```go
+func NewApp(cfg *config.Config, migrationFS fs.FS) (*App, func(), error) {
+	dbPathRaw := cfg.Database.Path
+
+	if dbPathRaw == "" {
+		appDir, err := GetAppDataDir()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to determine data directory: %w", err)
+		}
+		dbPathRaw = filepath.Join(appDir, "kea.db")
+	}
+
+	if err := backup.Run(dbPathRaw); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: backup failed: %v\n", err)
+	}
+
+	dbStore, err := store.NewStore(dbPathRaw, migrationFS)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to initialize database: %w", err)
+	}
+
+	svc := service.NewService(dbStore, dbStore, dbStore, cfg)
+
+	cleanup := func() {
+		if err := dbStore.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing DB: %v\n", err)
+		}
+	}
+
+	return &App{
+		Service: svc,
+	}, cleanup, nil
+}
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: all PASS
+
+- [ ] **Step 3: Build to verify compilation**
+
+```bash
+make build
+```
+
+Expected: `./kea_test` binary produced with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/app/app.go
+git commit -m "feat(backup): wire backup.Run into app.NewApp before store init"
+```

--- a/docs/superpowers/specs/2026-04-14-db-backup-design.md
+++ b/docs/superpowers/specs/2026-04-14-db-backup-design.md
@@ -1,0 +1,133 @@
+# DB Backup Design
+
+**Date:** 2026-04-14
+**Status:** Approved
+
+## Overview
+
+Automatically back up the SQLite database file on each startup, before the database is opened. Backups are organised into three tiers — daily, weekly, monthly — with fixed retention limits and no user configuration required.
+
+## Goals
+
+- Protect against data loss from migrations, corruption, or accidental changes
+- Zero user action required: backups happen silently on every run
+- Never block startup: a backup failure warns but does not abort the app
+
+## Non-Goals
+
+- Manual `kea backup` command
+- Configurable backup directory or retention counts
+- Remote/cloud backup destinations
+- Compression of backup files
+
+## Trigger
+
+`backup.Run(dbPath string)` is called inside `app.NewApp()` after the DB path is resolved but **before** `store.NewStore()` is called. This ensures the backup reflects the state of the DB before any migration or write occurs.
+
+## Backup Location
+
+Backups are stored in a `backups/` subdirectory next to the DB file.
+
+```
+~/.config/kea/
+  kea.db
+  backups/
+    kea_daily_2026-04-14.db
+    kea_weekly_2026-W15.db
+    kea_monthly_2026-04.db
+```
+
+The directory is created if it does not exist.
+
+## Tiers
+
+| Tier    | Filename pattern            | Retention |
+|---------|-----------------------------|-----------|
+| Daily   | `kea_daily_YYYY-MM-DD.db`   | 7         |
+| Weekly  | `kea_weekly_YYYY-WNN.db`    | 4         |
+| Monthly | `kea_monthly_YYYY-MM.db`    | 12        |
+
+Week numbers follow ISO 8601 (Go's `time.ISOWeek()`), zero-padded to two digits (e.g., `W05`).
+
+## When a Backup Is Due
+
+On each startup, `Run()` lists existing files in `backups/` and checks each tier independently:
+
+- **Daily** — no file matching today's `YYYY-MM-DD` exists
+- **Weekly** — no file matching this ISO week `YYYY-WNN` exists
+- **Monthly** — no file matching this year-month `YYYY-MM` exists
+
+Multiple tiers may trigger on the same run (e.g., the first run of a new month triggers all three).
+
+## Copy Strategy
+
+To avoid partial writes, the DB file is first copied to a temporary file (`<name>.tmp`) in the `backups/` directory, then atomically renamed to the final name. If the rename fails, the `.tmp` file is removed.
+
+## Rotation
+
+After a new backup is written, files for that tier are sorted lexicographically (which is chronological given the naming scheme). Files beyond the retention limit (oldest first) are deleted.
+
+## Error Handling
+
+| Condition | Behaviour |
+|---|---|
+| DB file does not exist (first run) | Return nil — no backup needed |
+| `backups/` dir creation fails | Return error; `NewApp` logs warning with pterm but continues |
+| File copy fails | Return error; `NewApp` logs warning but continues |
+| Rotation deletion fails | Log warning, continue — stale extras are not fatal |
+
+Backup errors must never abort startup.
+
+## Package Structure
+
+```
+internal/backup/
+  backup.go       — Run(), tier check, copy, rotation
+  backup_test.go  — unit tests using t.TempDir()
+```
+
+### Public API
+
+```go
+// Run checks each backup tier and writes a new backup if due, then prunes
+// old backups beyond the retention limit. It is a no-op if dbPath does not
+// exist. Errors are non-fatal: the caller should log and continue.
+func Run(dbPath string) error
+```
+
+### Clock Interface (internal)
+
+```go
+type clock interface {
+    Now() time.Time
+}
+```
+
+`realClock{}` wraps `time.Now()` for production. Tests inject `fakeClock{}` with a fixed time to make tier logic deterministic.
+
+## Integration Point
+
+In `internal/app/app.go`, inside `NewApp()`:
+
+```go
+// After dbPathRaw is resolved, before store.NewStore():
+if err := backup.Run(dbPathRaw); err != nil {
+    fmt.Fprintf(os.Stderr, "Warning: backup failed: %v\n", err)
+}
+```
+
+## Testing
+
+All tests use `t.TempDir()` — no real filesystem side effects.
+
+| Test case | What it verifies |
+|---|---|
+| DB does not exist | No backup created, no error |
+| First run, no backups yet | All three tiers copied |
+| Each tier already current | No new file written (no-op) |
+| Each tier due individually | Correct file created, others untouched |
+| All three tiers due together | All three files created |
+| Rotation: daily exceeds 7 | Oldest daily deleted |
+| Rotation: weekly exceeds 4 | Oldest weekly deleted |
+| Rotation: monthly exceeds 12 | Oldest monthly deleted |
+| Copy failure (read-only dir) | Error returned, no crash |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/hance08/kea/internal/backup"
 	"github.com/hance08/kea/internal/config"
 	"github.com/hance08/kea/internal/service"
 	"github.com/hance08/kea/internal/store"
@@ -24,6 +25,10 @@ func NewApp(cfg *config.Config, migrationFS fs.FS) (*App, func(), error) {
 			return nil, nil, fmt.Errorf("failed to determine data directory: %w", err)
 		}
 		dbPathRaw = filepath.Join(appDir, "kea.db")
+	}
+
+	if err := backup.Run(dbPathRaw); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: backup failed: %v\n", err)
 	}
 
 	dbStore, err := store.NewStore(dbPathRaw, migrationFS)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hance08/kea/internal/service"
 	"github.com/hance08/kea/internal/store"
 )
+
 type App struct {
 	Service *service.Service
 }

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -1,6 +1,7 @@
 package backup
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -25,7 +26,7 @@ func Run(dbPath string) error {
 }
 
 func run(dbPath string, clk clock) error {
-	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+	if _, err := os.Stat(dbPath); errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -60,6 +60,7 @@ func backupFilename(dbBase, tierName, label, ext string) string {
 }
 
 // copyFile copies src to dst atomically via a .tmp intermediate file.
+// The parent directory of dst must already exist.
 func copyFile(src, dst string) error {
 	tmp := dst + ".tmp"
 

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -1,6 +1,7 @@
 package backup
 
 import (
+	"fmt"
 	"os"
 	"time"
 )
@@ -24,4 +25,35 @@ func run(dbPath string, clk clock) error {
 		return nil
 	}
 	return nil // remaining logic added in later tasks
+}
+
+type tier struct {
+	name      string
+	label     func(time.Time) string
+	retention int
+}
+
+var tiers = []tier{
+	{name: "daily", label: dailyLabel, retention: 7},
+	{name: "weekly", label: weeklyLabel, retention: 4},
+	{name: "monthly", label: monthlyLabel, retention: 12},
+}
+
+func dailyLabel(t time.Time) string {
+	return t.Format("2006-01-02")
+}
+
+func weeklyLabel(t time.Time) string {
+	year, week := t.ISOWeek()
+	return fmt.Sprintf("%04d-W%02d", year, week)
+}
+
+func monthlyLabel(t time.Time) string {
+	return t.Format("2006-01")
+}
+
+// backupFilename builds the backup file name.
+// e.g. backupFilename("kea", "daily", "2026-04-14", ".db") → "kea_daily_2026-04-14.db"
+func backupFilename(dbBase, tierName, label, ext string) string {
+	return fmt.Sprintf("%s_%s_%s%s", dbBase, tierName, label, ext)
 }

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"time"
 )
@@ -56,4 +57,38 @@ func monthlyLabel(t time.Time) string {
 // e.g. backupFilename("kea", "daily", "2026-04-14", ".db") → "kea_daily_2026-04-14.db"
 func backupFilename(dbBase, tierName, label, ext string) string {
 	return fmt.Sprintf("%s_%s_%s%s", dbBase, tierName, label, ext)
+}
+
+// copyFile copies src to dst atomically via a .tmp intermediate file.
+func copyFile(src, dst string) error {
+	tmp := dst + ".tmp"
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		os.Remove(tmp)
+		return err
+	}
+
+	if err := out.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+
+	if err := os.Rename(tmp, dst); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+
+	return nil
 }

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 )
 
@@ -57,6 +60,35 @@ func monthlyLabel(t time.Time) string {
 // e.g. backupFilename("kea", "daily", "2026-04-14", ".db") → "kea_daily_2026-04-14.db"
 func backupFilename(dbBase, tierName, label, ext string) string {
 	return fmt.Sprintf("%s_%s_%s%s", dbBase, tierName, label, ext)
+}
+
+// rotate removes the oldest backups for a given tier beyond the retention limit.
+// Files are identified by prefix "<dbBase>_<tierName>_" and suffix ext.
+func rotate(backupDir, dbBase, tierName, ext string, retention int) error {
+	prefix := fmt.Sprintf("%s_%s_", dbBase, tierName)
+
+	entries, err := os.ReadDir(backupDir)
+	if err != nil {
+		return err
+	}
+
+	var files []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), prefix) && strings.HasSuffix(e.Name(), ext) {
+			files = append(files, e.Name())
+		}
+	}
+
+	sort.Strings(files) // lexicographic = chronological given the naming scheme
+
+	for len(files) > retention {
+		if err := os.Remove(filepath.Join(backupDir, files[0])); err != nil {
+			return err
+		}
+		files = files[1:]
+	}
+
+	return nil
 }
 
 // copyFile copies src to dst atomically via a .tmp intermediate file.

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -28,7 +28,35 @@ func run(dbPath string, clk clock) error {
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
 		return nil
 	}
-	return nil // remaining logic added in later tasks
+
+	dir := filepath.Dir(dbPath)
+	backupDir := filepath.Join(dir, "backups")
+	if err := os.MkdirAll(backupDir, 0755); err != nil {
+		return fmt.Errorf("create backup dir: %w", err)
+	}
+
+	ext := filepath.Ext(dbPath)
+	dbBase := strings.TrimSuffix(filepath.Base(dbPath), ext)
+	now := clk.Now()
+
+	for _, t := range tiers {
+		label := t.label(now)
+		dst := filepath.Join(backupDir, backupFilename(dbBase, t.name, label, ext))
+
+		if _, err := os.Stat(dst); err == nil {
+			continue // backup for this period already exists
+		}
+
+		if err := copyFile(dbPath, dst); err != nil {
+			return fmt.Errorf("backup %s: %w", t.name, err)
+		}
+
+		if err := rotate(backupDir, dbBase, t.name, ext, t.retention); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: backup rotation failed for %s: %v\n", t.name, err)
+		}
+	}
+
+	return nil
 }
 
 type tier struct {

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -1,0 +1,27 @@
+package backup
+
+import (
+	"os"
+	"time"
+)
+
+type clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+// Run backs up dbPath if any tier is due. It is a no-op when dbPath does not
+// exist. Errors are non-fatal: the caller should log and continue startup.
+func Run(dbPath string) error {
+	return run(dbPath, realClock{})
+}
+
+func run(dbPath string, clk clock) error {
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return nil
+	}
+	return nil // remaining logic added in later tasks
+}

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -1,6 +1,7 @@
 package backup
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -87,4 +88,75 @@ func TestCopyFile_LeavesNoTmpOnFailure(t *testing.T) {
 	// No .tmp file left behind.
 	_, statErr := os.Stat(dst + ".tmp")
 	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestRotate_PrunesOldestBeyondRetention(t *testing.T) {
+	dir := t.TempDir()
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	// Create 9 daily backup files (retention is 7).
+	files := []string{
+		"kea_daily_2026-04-06.db",
+		"kea_daily_2026-04-07.db",
+		"kea_daily_2026-04-08.db",
+		"kea_daily_2026-04-09.db",
+		"kea_daily_2026-04-10.db",
+		"kea_daily_2026-04-11.db",
+		"kea_daily_2026-04-12.db",
+		"kea_daily_2026-04-13.db",
+		"kea_daily_2026-04-14.db",
+	}
+	for _, f := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(backupDir, f), []byte("x"), 0644))
+	}
+
+	require.NoError(t, rotate(backupDir, "kea", "daily", ".db", 7))
+
+	entries, err := os.ReadDir(backupDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 7)
+	// Oldest two should be gone.
+	_, err = os.Stat(filepath.Join(backupDir, "kea_daily_2026-04-06.db"))
+	assert.True(t, os.IsNotExist(err))
+	_, err = os.Stat(filepath.Join(backupDir, "kea_daily_2026-04-07.db"))
+	assert.True(t, os.IsNotExist(err))
+	// Newest should remain.
+	_, err = os.Stat(filepath.Join(backupDir, "kea_daily_2026-04-14.db"))
+	assert.NoError(t, err)
+}
+
+func TestRotate_NoOpWhenUnderRetention(t *testing.T) {
+	dir := t.TempDir()
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	// Create 3 daily files (retention is 7) — nothing should be deleted.
+	for _, f := range []string{"kea_daily_2026-04-12.db", "kea_daily_2026-04-13.db", "kea_daily_2026-04-14.db"} {
+		require.NoError(t, os.WriteFile(filepath.Join(backupDir, f), []byte("x"), 0644))
+	}
+
+	require.NoError(t, rotate(backupDir, "kea", "daily", ".db", 7))
+
+	entries, err := os.ReadDir(backupDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 3)
+}
+
+func TestRotate_OnlyTouchesMatchingTier(t *testing.T) {
+	dir := t.TempDir()
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	// 9 daily + 1 weekly — rotate daily with retention 7, weekly must be untouched.
+	for i := 6; i <= 14; i++ {
+		name := fmt.Sprintf("kea_daily_2026-04-%02d.db", i)
+		require.NoError(t, os.WriteFile(filepath.Join(backupDir, name), []byte("x"), 0644))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "kea_weekly_2026-W15.db"), []byte("x"), 0644))
+
+	require.NoError(t, rotate(backupDir, "kea", "daily", ".db", 7))
+
+	_, err := os.Stat(filepath.Join(backupDir, "kea_weekly_2026-W15.db"))
+	assert.NoError(t, err, "weekly backup must not be deleted by daily rotation")
 }

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -1,6 +1,7 @@
 package backup
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -34,7 +35,7 @@ func TestRun_NoDBFile(t *testing.T) {
 
 	require.NoError(t, err)
 	_, statErr := os.Stat(filepath.Join(dir, "backups"))
-	assert.True(t, os.IsNotExist(statErr), "backups/ dir should not be created when DB is absent")
+	assert.True(t, errors.Is(statErr, os.ErrNotExist), "backups/ dir should not be created when DB is absent")
 }
 
 func TestDailyLabel(t *testing.T) {
@@ -88,7 +89,7 @@ func TestCopyFile_LeavesNoTmpOnFailure(t *testing.T) {
 
 	// No .tmp file left behind.
 	_, statErr := os.Stat(dst + ".tmp")
-	assert.True(t, os.IsNotExist(statErr))
+	assert.True(t, errors.Is(statErr, os.ErrNotExist))
 }
 
 func TestRotate_PrunesOldestBeyondRetention(t *testing.T) {
@@ -119,9 +120,9 @@ func TestRotate_PrunesOldestBeyondRetention(t *testing.T) {
 	assert.Len(t, entries, 7)
 	// Oldest two should be gone.
 	_, err = os.Stat(filepath.Join(backupDir, "kea_daily_2026-04-06.db"))
-	assert.True(t, os.IsNotExist(err))
+	assert.True(t, errors.Is(err, os.ErrNotExist))
 	_, err = os.Stat(filepath.Join(backupDir, "kea_daily_2026-04-07.db"))
-	assert.True(t, os.IsNotExist(err))
+	assert.True(t, errors.Is(err, os.ErrNotExist))
 	// Newest should remain.
 	_, err = os.Stat(filepath.Join(backupDir, "kea_daily_2026-04-14.db"))
 	assert.NoError(t, err)
@@ -298,7 +299,7 @@ func TestRun_RotationTriggered(t *testing.T) {
 
 	// Oldest (Apr 7) removed, newest (Apr 14) present.
 	_, err := os.Stat(filepath.Join(backupDir, "kea_daily_2026-04-07.db"))
-	assert.True(t, os.IsNotExist(err))
+	assert.True(t, errors.Is(err, os.ErrNotExist))
 	assertFileExists(t, backupDir, "kea_daily_2026-04-14.db")
 }
 
@@ -314,6 +315,76 @@ func TestRun_CopyFailure_ReturnsError(t *testing.T) {
 	clk := fakeClock{t: fixedTime("2026-04-14")}
 	err := run(dbPath, clk)
 	assert.Error(t, err)
+}
+
+func TestRotate_PrunesOldestWeekly(t *testing.T) {
+	dir := t.TempDir()
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	// Create 6 weekly backup files (retention is 4).
+	files := []string{
+		"kea_weekly_2026-W10.db",
+		"kea_weekly_2026-W11.db",
+		"kea_weekly_2026-W12.db",
+		"kea_weekly_2026-W13.db",
+		"kea_weekly_2026-W14.db",
+		"kea_weekly_2026-W15.db",
+	}
+	for _, f := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(backupDir, f), []byte("x"), 0644))
+	}
+
+	require.NoError(t, rotate(backupDir, "kea", "weekly", ".db", 4))
+
+	entries, err := os.ReadDir(backupDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 4)
+	_, err = os.Stat(filepath.Join(backupDir, "kea_weekly_2026-W10.db"))
+	assert.True(t, errors.Is(err, os.ErrNotExist))
+	_, err = os.Stat(filepath.Join(backupDir, "kea_weekly_2026-W11.db"))
+	assert.True(t, errors.Is(err, os.ErrNotExist))
+	_, err = os.Stat(filepath.Join(backupDir, "kea_weekly_2026-W15.db"))
+	assert.NoError(t, err)
+}
+
+func TestRotate_PrunesOldestMonthly(t *testing.T) {
+	dir := t.TempDir()
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	// Create 14 monthly backup files (retention is 12).
+	files := []string{
+		"kea_monthly_2025-01.db",
+		"kea_monthly_2025-02.db",
+		"kea_monthly_2025-03.db",
+		"kea_monthly_2025-04.db",
+		"kea_monthly_2025-05.db",
+		"kea_monthly_2025-06.db",
+		"kea_monthly_2025-07.db",
+		"kea_monthly_2025-08.db",
+		"kea_monthly_2025-09.db",
+		"kea_monthly_2025-10.db",
+		"kea_monthly_2025-11.db",
+		"kea_monthly_2025-12.db",
+		"kea_monthly_2026-01.db",
+		"kea_monthly_2026-02.db",
+	}
+	for _, f := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(backupDir, f), []byte("x"), 0644))
+	}
+
+	require.NoError(t, rotate(backupDir, "kea", "monthly", ".db", 12))
+
+	entries, err := os.ReadDir(backupDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 12)
+	_, err = os.Stat(filepath.Join(backupDir, "kea_monthly_2025-01.db"))
+	assert.True(t, errors.Is(err, os.ErrNotExist))
+	_, err = os.Stat(filepath.Join(backupDir, "kea_monthly_2025-02.db"))
+	assert.True(t, errors.Is(err, os.ErrNotExist))
+	_, err = os.Stat(filepath.Join(backupDir, "kea_monthly_2026-02.db"))
+	assert.NoError(t, err)
 }
 
 // assertFileExists is a helper that checks a file exists in dir.

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -1,0 +1,36 @@
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeClock lets tests control "now".
+type fakeClock struct{ t time.Time }
+
+func (f fakeClock) Now() time.Time { return f.t }
+
+func fixedTime(s string) time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+// TestRun_NoDBFile: when the DB does not exist, Run is a no-op.
+func TestRun_NoDBFile(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+
+	err := run(dbPath, fakeClock{t: fixedTime("2026-04-14")})
+
+	require.NoError(t, err)
+	_, statErr := os.Stat(filepath.Join(dir, "backups"))
+	assert.True(t, os.IsNotExist(statErr), "backups/ dir should not be created when DB is absent")
+}

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -34,3 +34,26 @@ func TestRun_NoDBFile(t *testing.T) {
 	_, statErr := os.Stat(filepath.Join(dir, "backups"))
 	assert.True(t, os.IsNotExist(statErr), "backups/ dir should not be created when DB is absent")
 }
+
+func TestDailyLabel(t *testing.T) {
+	assert.Equal(t, "2026-04-14", dailyLabel(fixedTime("2026-04-14")))
+	assert.Equal(t, "2026-01-01", dailyLabel(fixedTime("2026-01-01")))
+}
+
+func TestWeeklyLabel(t *testing.T) {
+	// 2026-04-14 is in ISO week 16 of 2026
+	assert.Equal(t, "2026-W16", weeklyLabel(fixedTime("2026-04-14")))
+	// 2026-01-01 is in ISO week 1 of 2026
+	assert.Equal(t, "2026-W01", weeklyLabel(fixedTime("2026-01-01")))
+}
+
+func TestMonthlyLabel(t *testing.T) {
+	assert.Equal(t, "2026-04", monthlyLabel(fixedTime("2026-04-14")))
+	assert.Equal(t, "2026-01", monthlyLabel(fixedTime("2026-01-01")))
+}
+
+func TestBackupFilename(t *testing.T) {
+	assert.Equal(t, "kea_daily_2026-04-14.db", backupFilename("kea", "daily", "2026-04-14", ".db"))
+	assert.Equal(t, "kea_weekly_2026-W16.db", backupFilename("kea", "weekly", "2026-W16", ".db"))
+	assert.Equal(t, "kea_monthly_2026-04.db", backupFilename("kea", "monthly", "2026-04", ".db"))
+}

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -159,4 +160,165 @@ func TestRotate_OnlyTouchesMatchingTier(t *testing.T) {
 
 	_, err := os.Stat(filepath.Join(backupDir, "kea_weekly_2026-W15.db"))
 	assert.NoError(t, err, "weekly backup must not be deleted by daily rotation")
+}
+
+// mkDB creates a fake DB file at dbPath with contents "fake-db".
+func mkDB(t *testing.T, dbPath string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(dbPath, []byte("fake-db"), 0644))
+}
+
+func TestRun_FirstRun_AllThreeTiersCreated(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+	mkDB(t, dbPath)
+	clk := fakeClock{t: fixedTime("2026-04-14")}
+
+	require.NoError(t, run(dbPath, clk))
+
+	backupDir := filepath.Join(dir, "backups")
+	assertFileExists(t, backupDir, "kea_daily_2026-04-14.db")
+	assertFileExists(t, backupDir, "kea_weekly_2026-W16.db")
+	assertFileExists(t, backupDir, "kea_monthly_2026-04.db")
+}
+
+func TestRun_AlreadyCurrent_NoNewFiles(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+	mkDB(t, dbPath)
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	// Pre-populate all three tiers for today.
+	clk := fakeClock{t: fixedTime("2026-04-14")}
+	for _, name := range []string{
+		"kea_daily_2026-04-14.db",
+		"kea_weekly_2026-W16.db",
+		"kea_monthly_2026-04.db",
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(backupDir, name), []byte("old"), 0644))
+	}
+
+	require.NoError(t, run(dbPath, clk))
+
+	// Files should still have "old" contents — not overwritten.
+	for _, name := range []string{
+		"kea_daily_2026-04-14.db",
+		"kea_weekly_2026-W16.db",
+		"kea_monthly_2026-04.db",
+	} {
+		got, err := os.ReadFile(filepath.Join(backupDir, name))
+		require.NoError(t, err)
+		assert.Equal(t, []byte("old"), got, "file %s should not be overwritten", name)
+	}
+}
+
+func TestRun_DailyDue_OtherTiersCurrent(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+	mkDB(t, dbPath)
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	clk := fakeClock{t: fixedTime("2026-04-14")}
+	// Weekly and monthly already present for this period; daily is missing.
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "kea_weekly_2026-W16.db"), []byte("old"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "kea_monthly_2026-04.db"), []byte("old"), 0644))
+
+	require.NoError(t, run(dbPath, clk))
+
+	assertFileExists(t, backupDir, "kea_daily_2026-04-14.db")
+	// Others untouched.
+	weekly, _ := os.ReadFile(filepath.Join(backupDir, "kea_weekly_2026-W16.db"))
+	assert.Equal(t, []byte("old"), weekly)
+}
+
+func TestRun_WeeklyDue_OtherTiersCurrent(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+	mkDB(t, dbPath)
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	clk := fakeClock{t: fixedTime("2026-04-14")}
+	// Daily and monthly present; weekly is missing.
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "kea_daily_2026-04-14.db"), []byte("old"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "kea_monthly_2026-04.db"), []byte("old"), 0644))
+
+	require.NoError(t, run(dbPath, clk))
+
+	assertFileExists(t, backupDir, "kea_weekly_2026-W16.db")
+	daily, _ := os.ReadFile(filepath.Join(backupDir, "kea_daily_2026-04-14.db"))
+	assert.Equal(t, []byte("old"), daily, "daily should not be overwritten")
+}
+
+func TestRun_MonthlyDue_OtherTiersCurrent(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+	mkDB(t, dbPath)
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	clk := fakeClock{t: fixedTime("2026-04-14")}
+	// Daily and weekly present; monthly is missing.
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "kea_daily_2026-04-14.db"), []byte("old"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "kea_weekly_2026-W16.db"), []byte("old"), 0644))
+
+	require.NoError(t, run(dbPath, clk))
+
+	assertFileExists(t, backupDir, "kea_monthly_2026-04.db")
+	daily, _ := os.ReadFile(filepath.Join(backupDir, "kea_daily_2026-04-14.db"))
+	assert.Equal(t, []byte("old"), daily, "daily should not be overwritten")
+}
+
+func TestRun_RotationTriggered(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+	mkDB(t, dbPath)
+	backupDir := filepath.Join(dir, "backups")
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	// Create 7 existing daily backups (at retention limit).
+	for i := 7; i <= 13; i++ {
+		name := fmt.Sprintf("kea_daily_2026-04-%02d.db", i)
+		require.NoError(t, os.WriteFile(filepath.Join(backupDir, name), []byte("x"), 0644))
+	}
+
+	clk := fakeClock{t: fixedTime("2026-04-14")}
+	require.NoError(t, run(dbPath, clk))
+
+	entries, _ := os.ReadDir(backupDir)
+	var dailyCount int
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "kea_daily_") {
+			dailyCount++
+		}
+	}
+	assert.Equal(t, 7, dailyCount, "should have exactly 7 daily backups after rotation")
+
+	// Oldest (Apr 7) removed, newest (Apr 14) present.
+	_, err := os.Stat(filepath.Join(backupDir, "kea_daily_2026-04-07.db"))
+	assert.True(t, os.IsNotExist(err))
+	assertFileExists(t, backupDir, "kea_daily_2026-04-14.db")
+}
+
+func TestRun_CopyFailure_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+	mkDB(t, dbPath)
+
+	// Make the backups dir a file so MkdirAll fails, triggering an error path.
+	backupsPath := filepath.Join(dir, "backups")
+	require.NoError(t, os.WriteFile(backupsPath, []byte("not-a-dir"), 0644))
+
+	clk := fakeClock{t: fixedTime("2026-04-14")}
+	err := run(dbPath, clk)
+	assert.Error(t, err)
+}
+
+// assertFileExists is a helper that checks a file exists in dir.
+func assertFileExists(t *testing.T, dir, name string) {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(dir, name))
+	assert.NoError(t, err, "expected file %s to exist in %s", name, dir)
 }

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -57,3 +57,34 @@ func TestBackupFilename(t *testing.T) {
 	assert.Equal(t, "kea_weekly_2026-W16.db", backupFilename("kea", "weekly", "2026-W16", ".db"))
 	assert.Equal(t, "kea_monthly_2026-04.db", backupFilename("kea", "monthly", "2026-04", ".db"))
 }
+
+func TestCopyFile(t *testing.T) {
+	dir := t.TempDir()
+
+	src := filepath.Join(dir, "kea.db")
+	require.NoError(t, os.WriteFile(src, []byte("db-contents"), 0644))
+
+	dst := filepath.Join(dir, "backups", "kea_daily_2026-04-14.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0755))
+
+	require.NoError(t, copyFile(src, dst))
+
+	got, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("db-contents"), got)
+}
+
+func TestCopyFile_LeavesNoTmpOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	// Source does not exist — copy must fail and leave no .tmp behind.
+	src := filepath.Join(dir, "missing.db")
+	dst := filepath.Join(dir, "backups", "out.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0755))
+
+	err := copyFile(src, dst)
+	assert.Error(t, err)
+
+	// No .tmp file left behind.
+	_, statErr := os.Stat(dst + ".tmp")
+	assert.True(t, os.IsNotExist(statErr))
+}


### PR DESCRIPTION
## Summary

- Adds new `internal/backup` package with `Run(dbPath string) error` — backs up the SQLite DB file before it is opened on each startup
- Three tiers: daily (7 kept), weekly (4 kept), monthly (12 kept) — backups stored in `backups/` next to the DB file
- Atomic file copy via `.tmp` + rename; rotation prunes oldest files beyond retention limit
- Wired into `app.NewApp()` as a non-fatal pre-store call — backup failure warns to stderr and never blocks startup

## Test Plan

- [ ] 19 unit/integration tests in `internal/backup/backup_test.go` — all passing
- [ ] Covers: no-DB no-op, per-tier label correctness (ISO weeks), filename generation, atomic copy, rotation (daily/weekly/monthly boundary), full run() integration (first run, idempotency, per-tier triggering, error path)
- [ ] Full suite `go test ./...` passes
- [ ] `make build` produces binary cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)