### PR TITLE
refactor(add): remove -T/--type flag from kea add

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -45,7 +45,6 @@ Examples:
 	cmd.Flags().StringVarP(&flags.To, "to", "t", "", "Destination account (where money goes to)")
 	cmd.Flags().StringVarP(&flags.Status, "status", "s", "cleared", "Transaction status: pending or cleared")
 	cmd.Flags().StringVar(&flags.Timestamp, "date", "", "Transaction date (YYYY-MM-DD), default is today")
-	cmd.Flags().StringVarP(&flags.Type, "type", "T", "", "Transaction type: expense, income, or transfer (validates account types when provided)")
 	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output created transaction as JSON")
 
 	return cmd
@@ -57,11 +56,10 @@ func (r *addRunner) Run(flags *addFlags, cmd *cobra.Command) error {
 
 	// Check if using flag mode or interactive mode
 	hasFlags := cmd.Flags().Changed("desc") || cmd.Flags().Changed("amount") ||
-		cmd.Flags().Changed("from") || cmd.Flags().Changed("to") ||
-		cmd.Flags().Changed("type")
+		cmd.Flags().Changed("from") || cmd.Flags().Changed("to")
 
 	if flags.JSON && !hasFlags {
-		return fmt.Errorf("--json requires flags: --type, --amount, --from, --to")
+		return fmt.Errorf("--json requires flags: --amount, --from, --to")
 	}
 
 	if hasFlags {

--- a/cmd/add_actions.go
+++ b/cmd/add_actions.go
@@ -16,22 +16,6 @@ func (r *addRunner) runFromFlags(flags *addFlags) (addTransactionInput, error) {
 		return addTransactionInput{}, fmt.Errorf("when using flags, --amount, --from, and --to are all required")
 	}
 
-	var srcAllowedTypes, dstAllowedTypes []string
-
-	// Validate account types if --type is provided
-	if flags.Type != "" {
-		mode := r.determineMode(flags.Type)
-		if mode != model.TxTypeExpense && mode != model.TxTypeIncome && mode != model.TxTypeTransfer {
-			return addTransactionInput{}, fmt.Errorf("invalid type %q: must be expense, income, or transfer", flags.Type)
-		}
-		rule, err := r.txSvc.GetTransactionRule(mode)
-		if err != nil {
-			return addTransactionInput{}, err
-		}
-		srcAllowedTypes = rule.SourceTypes
-		dstAllowedTypes = rule.DestTypes
-	}
-
 	description := flags.Description
 	if description == "" {
 		description = "-"
@@ -55,11 +39,11 @@ func (r *addRunner) runFromFlags(flags *addFlags) (addTransactionInput, error) {
 		return addTransactionInput{}, err
 	}
 
-	if err := r.validateAccountSelectable(flags.From, srcAllowedTypes, "--from"); err != nil {
+	if err := r.validateAccountSelectable(flags.From, nil, "--from"); err != nil {
 		return addTransactionInput{}, err
 	}
 
-	if err := r.validateAccountSelectable(flags.To, dstAllowedTypes, "--to"); err != nil {
+	if err := r.validateAccountSelectable(flags.To, nil, "--to"); err != nil {
 		return addTransactionInput{}, err
 	}
 

--- a/cmd/add_types.go
+++ b/cmd/add_types.go
@@ -27,7 +27,6 @@ type addFlags struct {
 	To          string
 	Status      string
 	Timestamp   string
-	Type        string
 	JSON        bool
 }
 


### PR DESCRIPTION
## Summary

- Removes the `-T`/`--type` flag from `kea add` as it was a purely optional validation guard with no effect on transaction creation
- Account selectability (leaf account, not hidden) is still enforced via `--from`/`--to`
- Simplifies the flag surface and removes dead code paths

## Test plan

- [x] `kea add --amount 100 --from "Assets:Cash" --to "Expenses:Food"` works without `-T`
- [x] `kea add` interactive mode unaffected
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)