### PR TITLE
feat: add reconcile command

### DIFF
--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"github.com/hance08/kea/internal/model"
+	"github.com/hance08/kea/internal/service"
+	"github.com/spf13/cobra"
+)
+
+// reconcileAccountProvider is the subset of AccountService used by the runner.
+type reconcileAccountProvider interface {
+	GetAccountByName(name string) (*model.Account, error)
+}
+
+// reconcileTxProvider is the subset of TransactionService used by the runner.
+type reconcileTxProvider interface {
+	GetUnreconciledByAccount(accountID int64) ([]*model.ReconcileEntry, error)
+	ReconcileTransactions(accountID int64, statementBalance int64, txIDs []int64) (int64, error)
+}
+
+type reconcileFlags struct {
+	Balance string
+	IDs     string
+	Force   bool
+	JSON    bool
+}
+
+type reconcileRunner struct {
+	accSvc reconcileAccountProvider
+	txSvc  reconcileTxProvider
+	flags  *reconcileFlags
+}
+
+// NewReconcileCmd wires up the `kea reconcile` command.
+func NewReconcileCmd(svc *service.Service) *cobra.Command {
+	flags := &reconcileFlags{}
+
+	cmd := &cobra.Command{
+		Use:   "reconcile <account-name>",
+		Short: "Reconcile an account against a statement balance",
+		Long: `Compare your records against an external statement and mark
+matching transactions as reconciled.
+
+Interactive mode (default):
+  kea reconcile "Assets:Checking"
+
+Non-interactive / agent mode (all flags required):
+  kea reconcile "Assets:Checking" --balance 2450.00 --ids 12,15,18 --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			runner := &reconcileRunner{
+				accSvc: svc.Account(),
+				txSvc:  svc.Transaction(),
+				flags:  flags,
+			}
+			return runner.Run(cmd, args)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.Balance, "balance", "", "statement ending balance (e.g. 2450.00)")
+	cmd.Flags().StringVar(&flags.IDs, "ids", "", "comma-separated transaction IDs to reconcile (non-interactive)")
+	cmd.Flags().BoolVar(&flags.Force, "force", false, "skip balance-mismatch warning (non-interactive mode)")
+	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output result as JSON")
+
+	return cmd
+}

--- a/cmd/reconcile_actions.go
+++ b/cmd/reconcile_actions.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/hance08/kea/internal/model"
+	"github.com/hance08/kea/internal/utils"
+	"github.com/hance08/kea/ui/prompts"
+	reconcileui "github.com/hance08/kea/ui/reconcile"
+	"github.com/hance08/kea/ui/views"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+func (r *reconcileRunner) Run(cmd *cobra.Command, args []string) error {
+	accountName := args[0]
+
+	// Resolve account.
+	acc, err := r.accSvc.GetAccountByName(accountName)
+	if err != nil {
+		return fmt.Errorf("account %q not found: %w", accountName, err)
+	}
+
+	nonInteractive := cmd.Flags().Changed("balance") && cmd.Flags().Changed("ids")
+
+	if nonInteractive {
+		return r.runNonInteractive(acc)
+	}
+	return r.runInteractive(acc)
+}
+
+// ── Non-interactive (agent / script) mode ────────────────────────────────────
+
+func (r *reconcileRunner) runNonInteractive(acc *model.Account) error {
+	statementBalance, err := utils.ParseAmount(r.flags.Balance)
+	if err != nil {
+		return fmt.Errorf("invalid --balance value %q: %w", r.flags.Balance, err)
+	}
+
+	txIDs, err := parseIDs(r.flags.IDs)
+	if err != nil {
+		return fmt.Errorf("invalid --ids value %q: %w", r.flags.IDs, err)
+	}
+
+	diff, err := r.txSvc.ReconcileTransactions(acc.ID, statementBalance, txIDs)
+	if err != nil {
+		return err
+	}
+
+	if diff != 0 && !r.flags.Force {
+		return fmt.Errorf(
+			"balance mismatch: off by $%s — use --force to reconcile anyway",
+			utils.FormatAmount(abs64(diff)),
+		)
+	}
+
+	if r.flags.JSON {
+		return writeReconcileJSON(acc.Name, len(txIDs), diff)
+	}
+	pterm.Success.Printf(
+		"Reconciled %d transaction(s) on %q. Difference: $%s\n",
+		len(txIDs), acc.Name, utils.FormatAmount(abs64(diff)),
+	)
+	return nil
+}
+
+// ── Interactive mode ──────────────────────────────────────────────────────────
+
+func (r *reconcileRunner) runInteractive(acc *model.Account) error {
+	// 1. Prompt for statement balance.
+	balanceStr, err := prompts.PromptAmount(
+		"Statement ending balance:",
+		"Enter the closing balance from your bank statement (e.g. 2450.00)",
+		prompts.ValidateAmountFormat(false),
+	)
+	if err != nil {
+		return fmt.Errorf("prompt cancelled: %w", err)
+	}
+
+	statementBalance, err := utils.ParseAmount(balanceStr)
+	if err != nil {
+		return fmt.Errorf("invalid balance: %w", err)
+	}
+
+	// 2. Load unreconciled entries.
+	entries, err := r.txSvc.GetUnreconciledByAccount(acc.ID)
+	if err != nil {
+		return err
+	}
+
+	// 3. Run bubbletea TUI.
+	m := reconcileui.NewModel(acc.Name, statementBalance, entries)
+	prog := tea.NewProgram(m)
+	finalRaw, err := prog.Run()
+	if err != nil {
+		return fmt.Errorf("TUI error: %w", err)
+	}
+	finalModel := finalRaw.(reconcileui.Model)
+
+	if finalModel.Cancelled() {
+		pterm.Info.Println("Reconciliation cancelled.")
+		return nil
+	}
+
+	selectedIDs := finalModel.SelectedIDs()
+	if len(selectedIDs) == 0 {
+		pterm.Info.Println("No transactions selected — nothing reconciled.")
+		return nil
+	}
+
+	// 4. Persist.
+	diff, err := r.txSvc.ReconcileTransactions(acc.ID, statementBalance, selectedIDs)
+	if err != nil {
+		return err
+	}
+
+	if r.flags.JSON {
+		return writeReconcileJSON(acc.Name, len(selectedIDs), diff)
+	}
+
+	if diff == 0 {
+		pterm.Success.Printf("Reconciled %d transaction(s) on %q — balanced!\n", len(selectedIDs), acc.Name)
+	} else {
+		pterm.Warning.Printf(
+			"Reconciled %d transaction(s) on %q with a remaining difference of $%s.\n",
+			len(selectedIDs), acc.Name, utils.FormatAmount(abs64(diff)),
+		)
+	}
+	return nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func parseIDs(s string) ([]int64, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, fmt.Errorf("empty ID list")
+	}
+	parts := strings.Split(s, ",")
+	ids := make([]int64, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		id, err := strconv.ParseInt(p, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ID %q: %w", p, err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func writeReconcileJSON(account string, count int, diff int64) error {
+	return views.WriteJSON(map[string]any{
+		"account":          account,
+		"reconciled_count": count,
+		"difference":       diff,
+	})
+}
+
+func abs64(n int64) int64 {
+	if n < 0 {
+		return -n
+	}
+	return n
+}

--- a/cmd/reconcile_actions.go
+++ b/cmd/reconcile_actions.go
@@ -93,7 +93,7 @@ func (r *reconcileRunner) runInteractive(acc *model.Account) error {
 
 	// 3. Run bubbletea TUI.
 	m := reconcileui.NewModel(acc.Name, statementBalance, entries)
-	prog := tea.NewProgram(m)
+	prog := tea.NewProgram(m, tea.WithAltScreen())
 	finalRaw, err := prog.Run()
 	if err != nil {
 		return fmt.Errorf("TUI error: %w", err)

--- a/cmd/reconcile_actions.go
+++ b/cmd/reconcile_actions.go
@@ -98,7 +98,10 @@ func (r *reconcileRunner) runInteractive(acc *model.Account) error {
 	if err != nil {
 		return fmt.Errorf("TUI error: %w", err)
 	}
-	finalModel := finalRaw.(reconcileui.Model)
+	finalModel, ok := finalRaw.(reconcileui.Model)
+	if !ok {
+		return fmt.Errorf("unexpected TUI model type: %T", finalRaw)
+	}
 
 	if finalModel.Cancelled() {
 		pterm.Info.Println("Reconciliation cancelled.")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -121,6 +121,7 @@ func Execute(migrations fs.FS) {
 		rootCmd.AddCommand(NewAddCmd(application.Service))
 		rootCmd.AddCommand(NewInfoCmd(application.Service))
 		rootCmd.AddCommand(NewReportCmd(application.Service))
+		rootCmd.AddCommand(NewReconcileCmd(application.Service))
 
 		if err := rootCmd.Execute(); err != nil {
 			pterm.Error.Println(capitalize(err.Error()))

--- a/cmd/transaction/edit.go
+++ b/cmd/transaction/edit.go
@@ -50,8 +50,14 @@ func (r *editRunner) Run(args []string) error {
 		return nil
 	}
 
-	if !r.txSvc.IsEditable(detail) {
-		r.view.ShowWarning("This transaction cannot be edited (System Transaction)")
+	isEditable, reason := r.txSvc.IsEditable(detail)
+	if !isEditable {
+		switch reason {
+		case service.NotEditableSystemTx:
+			r.view.ShowWarning("This transaction cannot be edited (System Transaction)")
+		case service.NotEditableReconciled:
+			r.view.ShowWarning("This transaction cannot be edited (Reconciled Transaction)")
+		}
 		return nil
 	}
 

--- a/cmd/transaction/edit_types.go
+++ b/cmd/transaction/edit_types.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/hance08/kea/internal/model"
+	"github.com/hance08/kea/internal/service"
 )
 
 type EditView interface {
@@ -28,7 +29,7 @@ type EditView interface {
 
 type EditProvider interface {
 	GetTransactionByID(txID int64) (*model.TransactionDetail, error)
-	IsEditable(detail *model.TransactionDetail) bool
+	IsEditable(detail *model.TransactionDetail) (bool, service.NotEditableReason)
 	DetermineType(splits []model.SplitDetail) (model.TransactionType, error)
 	GetAllowedAccounts(txType model.TransactionType, currentAccountType model.AccountType, allAccounts []*model.Account) []*model.Account
 	ValidateTransactionEdit(splits []model.SplitDetail) error

--- a/cmd/transaction/list.go
+++ b/cmd/transaction/list.go
@@ -136,10 +136,7 @@ func (r *listRunner) convertToViewItem(tx *model.Transaction, detail *model.Tran
 
 	date := time.Unix(tx.Timestamp, 0).Format("2006-01-02")
 
-	status := "Cleared"
-	if tx.Status == model.StatusPending {
-		status = "Pending"
-	}
+	status := tx.Status.String()
 
 	return views.TransactionListItem{
 		ID:          tx.ID,

--- a/docs/superpowers/plans/2026-04-16-reconciliation.md
+++ b/docs/superpowers/plans/2026-04-16-reconciliation.md
@@ -1,0 +1,1224 @@
+# Reconciliation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `kea reconcile <account-name>` — an interactive bubbletea TUI that lets the user check off transactions against a bank statement and mark them as reconciled, with a non-interactive flag mode for agent/script use.
+
+**Architecture:** A new `ReconcileEntry` model type carries the data the TUI needs (transaction + split amount for the reconciled account). Two new repository methods handle the SQL: a focused query for unreconciled transactions and a bulk status update. The service method validates IDs, computes the balance difference, and delegates the write to the repo. The bubbletea TUI lives in `ui/reconcile/`, and the cobra command follows the existing `cmd/add.go` + `cmd/add_actions.go` split pattern.
+
+**Tech Stack:** Go, `github.com/charmbracelet/bubbletea` v1.3, `github.com/charmbracelet/lipgloss` v1.1, `github.com/charmbracelet/bubbles` (key), `github.com/charmbracelet/huh` (balance prompt), `github.com/pterm/pterm` (success output), SQLite via `github.com/mattn/go-sqlite3`.
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `internal/model/transaction.go` | Add `ReconcileEntry` type |
+| Modify | `internal/repository/interfaces.go` | Add 2 new methods to `TransactionRepository` |
+| Modify | `internal/service/testhelper_test.go` | Add mock implementations for new repo methods |
+| Create | `internal/service/reconcile_ops.go` | `ReconcileTransactions` + `GetUnreconciledByAccount` |
+| Create | `internal/service/reconcile_ops_test.go` | Service-layer tests |
+| Create | `internal/store/sqlite_reconcile.go` | Store implementations of new repo methods |
+| Create | `ui/reconcile/keys.go` | bubbletea key bindings |
+| Create | `ui/reconcile/model.go` | bubbletea Model, Init, Update, View |
+| Create | `cmd/reconcile.go` | Cobra command definition, flag binding |
+| Create | `cmd/reconcile_actions.go` | Runner, Run(), interactive/non-interactive branching |
+| Modify | `cmd/root.go` | Register `NewReconcileCmd` |
+
+---
+
+## Task 1: Add `ReconcileEntry` model type
+
+**Files:**
+- Modify: `internal/model/transaction.go`
+
+- [ ] **Step 1: Add the type**
+
+Append to the end of `internal/model/transaction.go`:
+
+```go
+// ReconcileEntry is a read-only projection used by the reconciliation workflow.
+// It carries a transaction plus the net split amount for the queried account,
+// so the TUI can display amounts and the service can compute the cleared balance
+// without issuing per-transaction queries.
+type ReconcileEntry struct {
+	ID          int64
+	Timestamp   int64
+	Description string
+	Status      TransactionStatus
+	Amount      int64 // net split amount for the reconciled account
+}
+```
+
+- [ ] **Step 2: Verify the project builds**
+
+```bash
+go build ./...
+```
+
+Expected: no output (clean build).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/model/transaction.go
+git commit -m "feat(model): add ReconcileEntry type for reconciliation workflow"
+```
+
+---
+
+## Task 2: Extend `TransactionRepository` interface
+
+**Files:**
+- Modify: `internal/repository/interfaces.go`
+
+- [ ] **Step 1: Add the two new method signatures to `TransactionRepository`**
+
+In `internal/repository/interfaces.go`, add the following two lines inside the `TransactionRepository` interface, after the `GetSplitsWithAccountsByTransaction` line:
+
+```go
+	// GetUnreconciledTransactionsByAccount returns all Pending and Cleared
+	// transactions that have a split touching accountID, together with the
+	// net split amount for that account. Ordered by timestamp ASC.
+	GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.ReconcileEntry, error)
+
+	// BulkUpdateTransactionStatus sets status on all listed transaction IDs
+	// in a single atomic UPDATE. Returns an error if the affected row count
+	// does not match len(txIDs).
+	BulkUpdateTransactionStatus(txIDs []int64, status model.TransactionStatus) error
+```
+
+- [ ] **Step 2: Verify the build fails with expected errors**
+
+```bash
+go build ./...
+```
+
+Expected: compile errors from `internal/store/` saying `*Store` does not implement `TransactionRepository` (missing the two new methods). This is correct — the store implementations come in Task 6.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/repository/interfaces.go
+git commit -m "feat(repository): add GetUnreconciledTransactionsByAccount and BulkUpdateTransactionStatus to interface"
+```
+
+---
+
+## Task 3: Extend `mockTransactionRepo` with the two new methods
+
+**Files:**
+- Modify: `internal/service/testhelper_test.go`
+
+- [ ] **Step 1: Add fields to `mockTransactionRepo`**
+
+Inside the `mockTransactionRepo` struct (after `updateSplitCalls []int64`), add:
+
+```go
+	// reconciliation support
+	unreconciledByAccount    map[int64][]*model.ReconcileEntry
+	unreconciledByAccountErr map[int64]error
+	bulkUpdateErr            error
+	bulkUpdateCalls          [][]int64
+```
+
+- [ ] **Step 2: Initialize the new maps in `newMockTransactionRepo`**
+
+Inside the struct literal in `newMockTransactionRepo()`, add these two lines alongside the other `make(...)` initializations:
+
+```go
+	unreconciledByAccount:    make(map[int64][]*model.ReconcileEntry),
+	unreconciledByAccountErr: make(map[int64]error),
+```
+
+- [ ] **Step 3: Add the two method implementations**
+
+Append to the end of the `mockTransactionRepo` section in `testhelper_test.go`, before the `mockCombinedRepo` section:
+
+```go
+func (m *mockTransactionRepo) GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.ReconcileEntry, error) {
+	if err, ok := m.unreconciledByAccountErr[accountID]; ok {
+		return nil, err
+	}
+	return m.unreconciledByAccount[accountID], nil
+}
+
+func (m *mockTransactionRepo) BulkUpdateTransactionStatus(txIDs []int64, status model.TransactionStatus) error {
+	if m.bulkUpdateErr != nil {
+		return m.bulkUpdateErr
+	}
+	ids := make([]int64, len(txIDs))
+	copy(ids, txIDs)
+	m.bulkUpdateCalls = append(m.bulkUpdateCalls, ids)
+	for _, id := range txIDs {
+		if tx, ok := m.transactions[id]; ok {
+			tx.Status = status
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Verify the service tests still pass**
+
+```bash
+go test ./internal/service/...
+```
+
+Expected: all existing tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/testhelper_test.go
+git commit -m "test(service): extend mockTransactionRepo with reconciliation methods"
+```
+
+---
+
+## Task 4: Write failing service tests
+
+**Files:**
+- Create: `internal/service/reconcile_ops_test.go`
+
+- [ ] **Step 1: Create the test file**
+
+```go
+package service
+
+import (
+	"testing"
+
+	"github.com/hance08/kea/internal/model"
+)
+
+// helper: build a ReconcileEntry slice for a given accountID in the mock
+func seedUnreconciled(txRepo *mockTransactionRepo, accountID int64, entries []*model.ReconcileEntry) {
+	txRepo.unreconciledByAccount[accountID] = entries
+}
+
+func TestReconcileTransactions_ZeroDifference(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
+		{ID: 10, Timestamp: 1000, Description: "Salary", Status: model.StatusCleared, Amount: 100000},
+		{ID: 11, Timestamp: 1001, Description: "Rent", Status: model.StatusCleared, Amount: -50000},
+	})
+
+	// statementBalance = 50000 = 100000 + (-50000)
+	diff, err := svc.ReconcileTransactions(1, 50000, []int64{10, 11})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff != 0 {
+		t.Errorf("expected difference 0, got %d", diff)
+	}
+	if len(txRepo.bulkUpdateCalls) != 1 {
+		t.Errorf("expected 1 bulk update call, got %d", len(txRepo.bulkUpdateCalls))
+	}
+}
+
+func TestReconcileTransactions_NonZeroDifference(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
+		{ID: 10, Timestamp: 1000, Description: "Salary", Status: model.StatusCleared, Amount: 100000},
+	})
+
+	// statementBalance = 120000, but we're only reconciling 100000 → diff = 20000
+	diff, err := svc.ReconcileTransactions(1, 120000, []int64{10})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff != 20000 {
+		t.Errorf("expected difference 20000, got %d", diff)
+	}
+	if len(txRepo.bulkUpdateCalls) != 1 {
+		t.Fatalf("expected bulk update to be called")
+	}
+}
+
+func TestReconcileTransactions_UnknownTxID(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
+		{ID: 10, Timestamp: 1000, Description: "Salary", Status: model.StatusCleared, Amount: 100000},
+	})
+
+	_, err := svc.ReconcileTransactions(1, 100000, []int64{10, 99}) // 99 is unknown
+
+	if err == nil {
+		t.Fatal("expected error for unknown transaction ID, got nil")
+	}
+	if len(txRepo.bulkUpdateCalls) != 0 {
+		t.Error("bulk update must not be called when validation fails")
+	}
+}
+
+func TestReconcileTransactions_AlreadyReconciledID(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	// unreconciledByAccount does NOT contain ID 20 (it's already reconciled)
+	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
+		{ID: 10, Timestamp: 1000, Description: "Salary", Status: model.StatusCleared, Amount: 100000},
+	})
+
+	_, err := svc.ReconcileTransactions(1, 100000, []int64{10, 20}) // 20 not in unreconciled set
+
+	if err == nil {
+		t.Fatal("expected error for already-reconciled ID, got nil")
+	}
+	if len(txRepo.bulkUpdateCalls) != 0 {
+		t.Error("bulk update must not be called when validation fails")
+	}
+}
+
+func TestReconcileTransactions_EmptyIDs(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+
+	_, err := svc.ReconcileTransactions(1, 100000, []int64{})
+
+	if err == nil {
+		t.Fatal("expected error for empty IDs, got nil")
+	}
+}
+
+func TestReconcileTransactions_AccountNotFound(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	// account ID 99 does not exist in accRepo
+
+	_, err := svc.ReconcileTransactions(99, 100000, []int64{10})
+
+	if err == nil {
+		t.Fatal("expected error for unknown account, got nil")
+	}
+	if len(txRepo.bulkUpdateCalls) != 0 {
+		t.Error("bulk update must not be called when account lookup fails")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — confirm they all fail**
+
+```bash
+go test ./internal/service/... -run TestReconcileTransactions -v
+```
+
+Expected: `FAIL` — `svc.ReconcileTransactions undefined` (method does not exist yet).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/service/reconcile_ops_test.go
+git commit -m "test(service): add failing tests for ReconcileTransactions"
+```
+
+---
+
+## Task 5: Implement service methods
+
+**Files:**
+- Create: `internal/service/reconcile_ops.go`
+
+- [ ] **Step 1: Create the implementation file**
+
+```go
+package service
+
+import (
+	"fmt"
+
+	"github.com/hance08/kea/internal/model"
+)
+
+// GetUnreconciledByAccount returns all Pending/Cleared transactions that
+// have a split touching the given account, including the split amount for
+// that account. Used to populate the reconciliation TUI.
+func (ts *TransactionService) GetUnreconciledByAccount(accountID int64) ([]*model.ReconcileEntry, error) {
+	entries, err := ts.txRepo.GetUnreconciledTransactionsByAccount(accountID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load unreconciled transactions: %w", err)
+	}
+	return entries, nil
+}
+
+// ReconcileTransactions marks the given transaction IDs as reconciled for
+// accountID. It validates that every requested ID is in the unreconciled set
+// for that account before writing anything.
+//
+// Returns the difference between statementBalance and the sum of the selected
+// split amounts for accountID. A non-zero difference is informational — the
+// method always commits if the IDs are valid. The caller decides whether to
+// warn (non-zero diff) or proceed silently (zero diff).
+func (ts *TransactionService) ReconcileTransactions(accountID int64, statementBalance int64, txIDs []int64) (int64, error) {
+	if len(txIDs) == 0 {
+		return 0, fmt.Errorf("no transactions selected for reconciliation")
+	}
+
+	// 1. Verify account exists.
+	if _, err := ts.accRepo.GetAccountByID(accountID); err != nil {
+		return 0, fmt.Errorf("account not found: %w", err)
+	}
+
+	// 2. Fetch unreconciled transactions and build a valid-ID → amount map.
+	entries, err := ts.txRepo.GetUnreconciledTransactionsByAccount(accountID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to load unreconciled transactions: %w", err)
+	}
+
+	validAmounts := make(map[int64]int64, len(entries)) // txID → split amount
+	for _, e := range entries {
+		validAmounts[e.ID] = e.Amount
+	}
+
+	// 3. Validate every requested ID and accumulate the cleared balance.
+	var clearedBalance int64
+	for _, id := range txIDs {
+		amount, ok := validAmounts[id]
+		if !ok {
+			return 0, fmt.Errorf("transaction ID %d is not in the unreconciled set for this account", id)
+		}
+		clearedBalance += amount
+	}
+
+	// 4. Atomically mark all selected transactions as reconciled.
+	if err := ts.txRepo.BulkUpdateTransactionStatus(txIDs, model.StatusReconciled); err != nil {
+		return 0, fmt.Errorf("failed to reconcile transactions: %w", err)
+	}
+
+	return statementBalance - clearedBalance, nil
+}
+```
+
+- [ ] **Step 2: Run the tests — confirm they all pass**
+
+```bash
+go test ./internal/service/... -run TestReconcileTransactions -v
+```
+
+Expected: all 6 tests show `PASS`.
+
+- [ ] **Step 3: Run the full service test suite**
+
+```bash
+go test ./internal/service/...
+```
+
+Expected: all tests pass, no regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/service/reconcile_ops.go
+git commit -m "feat(service): implement ReconcileTransactions and GetUnreconciledByAccount"
+```
+
+---
+
+## Task 6: Implement store methods
+
+**Files:**
+- Create: `internal/store/sqlite_reconcile.go`
+
+- [ ] **Step 1: Create the implementation file**
+
+```go
+package store
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hance08/kea/internal/model"
+)
+
+// GetUnreconciledTransactionsByAccount returns all Pending (0) and Cleared (1)
+// transactions that have a split on accountID, together with the net split
+// amount for that account (grouped to handle rare multi-split-per-account cases).
+// Results are ordered by timestamp ASC so the TUI shows chronological order.
+func (s *Store) GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.ReconcileEntry, error) {
+	rows, err := s.db.Query(`
+        SELECT t.id, t.timestamp, t.description, t.status, SUM(s.amount) AS amount
+        FROM transactions t
+        INNER JOIN splits s ON t.id = s.transaction_id
+        WHERE s.account_id = ?
+          AND t.status IN (0, 1)
+        GROUP BY t.id, t.timestamp, t.description, t.status
+        ORDER BY t.timestamp ASC, t.id ASC
+    `, accountID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query unreconciled transactions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []*model.ReconcileEntry
+	for rows.Next() {
+		e := &model.ReconcileEntry{}
+		if err := rows.Scan(&e.ID, &e.Timestamp, &e.Description, &e.Status, &e.Amount); err != nil {
+			return nil, fmt.Errorf("failed to scan reconcile entry: %w", err)
+		}
+		result = append(result, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows iteration error: %w", err)
+	}
+	return result, nil
+}
+
+// BulkUpdateTransactionStatus sets the status of all listed transaction IDs
+// in a single UPDATE statement. Returns an error if the affected row count
+// does not match len(txIDs) — indicating one or more IDs did not exist.
+func (s *Store) BulkUpdateTransactionStatus(txIDs []int64, status model.TransactionStatus) error {
+	if len(txIDs) == 0 {
+		return nil
+	}
+
+	placeholders := strings.Repeat("?,", len(txIDs))
+	placeholders = placeholders[:len(placeholders)-1] // trim trailing comma
+
+	query := fmt.Sprintf(
+		"UPDATE transactions SET status = ? WHERE id IN (%s)",
+		placeholders,
+	)
+
+	args := make([]any, 0, len(txIDs)+1)
+	args = append(args, status)
+	for _, id := range txIDs {
+		args = append(args, id)
+	}
+
+	result, err := s.db.Exec(query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to bulk update transaction status: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rowsAffected != int64(len(txIDs)) {
+		return fmt.Errorf("expected to update %d transactions, updated %d", len(txIDs), rowsAffected)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2: Verify the project builds cleanly (store now satisfies the interface)**
+
+```bash
+go build ./...
+```
+
+Expected: no output (clean build).
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+go test ./...
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/store/sqlite_reconcile.go
+git commit -m "feat(store): implement GetUnreconciledTransactionsByAccount and BulkUpdateTransactionStatus"
+```
+
+---
+
+## Task 7: TUI key bindings
+
+**Files:**
+- Create: `ui/reconcile/keys.go`
+
+- [ ] **Step 1: Create the keys file**
+
+```go
+package reconcileui
+
+import "github.com/charmbracelet/bubbles/key"
+
+type keyMap struct {
+	Up      key.Binding
+	Down    key.Binding
+	Toggle  key.Binding
+	Confirm key.Binding
+	Quit    key.Binding
+	Yes     key.Binding
+	No      key.Binding
+}
+
+func defaultKeyMap() keyMap {
+	return keyMap{
+		Up:      key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑/k", "up")),
+		Down:    key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
+		Toggle:  key.NewBinding(key.WithKeys(" "), key.WithHelp("space", "toggle")),
+		Confirm: key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "finish")),
+		Quit:    key.NewBinding(key.WithKeys("q", "esc"), key.WithHelp("q/esc", "quit")),
+		Yes:     key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "confirm")),
+		No:      key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "cancel")),
+	}
+}
+```
+
+- [ ] **Step 2: Verify it builds**
+
+```bash
+go build ./ui/reconcile/...
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ui/reconcile/keys.go
+git commit -m "feat(ui/reconcile): add bubbletea key bindings"
+```
+
+---
+
+## Task 8: TUI model
+
+**Files:**
+- Create: `ui/reconcile/model.go`
+
+- [ ] **Step 1: Create the model file**
+
+```go
+package reconcileui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/hance08/kea/internal/model"
+	"github.com/hance08/kea/internal/utils"
+)
+
+type listItem struct {
+	entry   *model.ReconcileEntry
+	checked bool
+}
+
+// Model is the bubbletea model for the reconciliation TUI.
+// After tea.Program.Run() returns, inspect Cancelled() and SelectedIDs()
+// to determine the outcome.
+type Model struct {
+	accountName      string
+	statementBalance int64
+	items            []listItem
+	cursor           int
+	confirmPending   bool // waiting for y/n after Enter with non-zero diff
+	cancelled        bool
+	done             bool
+	keys             keyMap
+}
+
+// NewModel constructs the initial reconciliation model.
+func NewModel(accountName string, statementBalance int64, entries []*model.ReconcileEntry) Model {
+	items := make([]listItem, len(entries))
+	for i, e := range entries {
+		items[i] = listItem{entry: e}
+	}
+	return Model{
+		accountName:      accountName,
+		statementBalance: statementBalance,
+		items:            items,
+		keys:             defaultKeyMap(),
+	}
+}
+
+// Cancelled reports whether the user quit without confirming.
+func (m Model) Cancelled() bool { return m.cancelled }
+
+// SelectedIDs returns the transaction IDs the user checked off.
+func (m Model) SelectedIDs() []int64 {
+	var ids []int64
+	for _, it := range m.items {
+		if it.checked {
+			ids = append(ids, it.entry.ID)
+		}
+	}
+	return ids
+}
+
+func (m Model) Init() tea.Cmd { return nil }
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if m.confirmPending {
+			switch {
+			case key.Matches(msg, m.keys.Yes):
+				m.done = true
+				return m, tea.Quit
+			case key.Matches(msg, m.keys.No):
+				m.confirmPending = false
+			}
+			return m, nil
+		}
+		switch {
+		case key.Matches(msg, m.keys.Quit):
+			m.cancelled = true
+			return m, tea.Quit
+		case key.Matches(msg, m.keys.Up):
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case key.Matches(msg, m.keys.Down):
+			if m.cursor < len(m.items)-1 {
+				m.cursor++
+			}
+		case key.Matches(msg, m.keys.Toggle):
+			if len(m.items) > 0 {
+				m.items[m.cursor].checked = !m.items[m.cursor].checked
+			}
+		case key.Matches(msg, m.keys.Confirm):
+			if len(m.items) == 0 {
+				return m, nil
+			}
+			if m.difference() != 0 {
+				m.confirmPending = true
+			} else {
+				m.done = true
+				return m, tea.Quit
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m Model) View() string {
+	if len(m.items) == 0 {
+		return "No unreconciled transactions for this account.\n\nPress q to quit.\n"
+	}
+
+	var sb strings.Builder
+
+	// ── Header ──────────────────────────────────────────
+	diff := m.difference()
+	var badge string
+	if diff == 0 {
+		badge = lipgloss.NewStyle().
+			Padding(0, 1).
+			Background(lipgloss.Color("22")).
+			Foreground(lipgloss.Color("15")).
+			Render("BALANCED")
+	} else {
+		badge = lipgloss.NewStyle().
+			Padding(0, 1).
+			Background(lipgloss.Color("58")).
+			Foreground(lipgloss.Color("15")).
+			Render(fmt.Sprintf("OFF BY $%s", utils.FormatAmount(abs(diff))))
+	}
+
+	accountStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("78"))
+	sb.WriteString(fmt.Sprintf("%-40s %s\n\n", accountStyle.Render(m.accountName), badge))
+
+	stmtStr := utils.FormatAmount(m.statementBalance)
+	sb.WriteString(fmt.Sprintf("STATEMENT: $%s · %d UNRECONCILED\n", stmtStr, len(m.items)))
+	sb.WriteString(strings.Repeat("─", 52) + "\n")
+
+	// ── Transaction list ────────────────────────────────
+	for i, it := range m.items {
+		checkbox := "[ ]"
+		rowStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+		if it.checked {
+			checkbox = "[✓]"
+			rowStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("78"))
+		}
+
+		date := time.Unix(it.entry.Timestamp, 0).Format("Jan 02")
+		amt := fmt.Sprintf("$%s", utils.FormatAmount(it.entry.Amount))
+		line := fmt.Sprintf("%s %s  %-28s %10s", checkbox, date, truncate(it.entry.Description, 28), amt)
+
+		if i == m.cursor {
+			line = lipgloss.NewStyle().
+				Background(lipgloss.Color("236")).
+				Foreground(lipgloss.Color("255")).
+				Render(line)
+		} else {
+			line = rowStyle.Render(line)
+		}
+		sb.WriteString(line + "\n")
+	}
+
+	sb.WriteString(strings.Repeat("─", 52) + "\n")
+
+	// ── Footer balance ───────────────────────────────────
+	clearedStr := utils.FormatAmount(m.clearedBalance())
+	diffStr := utils.FormatAmount(abs(diff))
+	remainingStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	if diff == 0 {
+		remainingStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("78"))
+	}
+	sb.WriteString(fmt.Sprintf(
+		"Cleared $%s · %s\n",
+		clearedStr,
+		remainingStyle.Render(fmt.Sprintf("Remaining $%s", diffStr)),
+	))
+
+	// ── Prompt or hint ───────────────────────────────────
+	if m.confirmPending {
+		warnStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+		sb.WriteString(fmt.Sprintf("\n%s\n",
+			warnStyle.Render(fmt.Sprintf("You're off by $%s. Confirm anyway? (y/n)", diffStr)),
+		))
+	} else {
+		sb.WriteString("\nspace toggle · enter finish · ↑↓ navigate · q quit\n")
+	}
+
+	return sb.String()
+}
+
+// ── helpers ─────────────────────────────────────────────
+
+func (m Model) clearedBalance() int64 {
+	var total int64
+	for _, it := range m.items {
+		if it.checked {
+			total += it.entry.Amount
+		}
+	}
+	return total
+}
+
+func (m Model) difference() int64 {
+	return m.statementBalance - m.clearedBalance()
+}
+
+func abs(n int64) int64 {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-1] + "…"
+}
+```
+
+- [ ] **Step 2: Verify it builds**
+
+```bash
+go build ./ui/reconcile/...
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ui/reconcile/model.go
+git commit -m "feat(ui/reconcile): implement bubbletea reconciliation TUI model"
+```
+
+---
+
+## Task 9: Cobra command definition
+
+**Files:**
+- Create: `cmd/reconcile.go`
+
+- [ ] **Step 1: Create the command file**
+
+```go
+package cmd
+
+import (
+	"github.com/hance08/kea/internal/model"
+	"github.com/hance08/kea/internal/service"
+	"github.com/spf13/cobra"
+)
+
+// reconcileAccountProvider is the subset of AccountService used by the runner.
+type reconcileAccountProvider interface {
+	GetAccountByName(name string) (*model.Account, error)
+}
+
+// reconcileTxProvider is the subset of TransactionService used by the runner.
+type reconcileTxProvider interface {
+	GetUnreconciledByAccount(accountID int64) ([]*model.ReconcileEntry, error)
+	ReconcileTransactions(accountID int64, statementBalance int64, txIDs []int64) (int64, error)
+}
+
+type reconcileFlags struct {
+	Balance string
+	IDs     string
+	Force   bool
+	JSON    bool
+}
+
+type reconcileRunner struct {
+	accSvc reconcileAccountProvider
+	txSvc  reconcileTxProvider
+	flags  *reconcileFlags
+}
+
+// NewReconcileCmd wires up the `kea reconcile` command.
+func NewReconcileCmd(svc *service.Service) *cobra.Command {
+	flags := &reconcileFlags{}
+
+	cmd := &cobra.Command{
+		Use:   "reconcile <account-name>",
+		Short: "Reconcile an account against a statement balance",
+		Long: `Compare your records against an external statement and mark
+matching transactions as reconciled.
+
+Interactive mode (default):
+  kea reconcile "Assets:Checking"
+
+Non-interactive / agent mode (all flags required):
+  kea reconcile "Assets:Checking" --balance 2450.00 --ids 12,15,18 --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			runner := &reconcileRunner{
+				accSvc: svc.Account(),
+				txSvc:  svc.Transaction(),
+				flags:  flags,
+			}
+			return runner.Run(cmd, args)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.Balance, "balance", "", "statement ending balance (e.g. 2450.00)")
+	cmd.Flags().StringVar(&flags.IDs, "ids", "", "comma-separated transaction IDs to reconcile (non-interactive)")
+	cmd.Flags().BoolVar(&flags.Force, "force", false, "skip balance-mismatch warning (non-interactive mode)")
+	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output result as JSON")
+
+	return cmd
+}
+```
+
+- [ ] **Step 2: Verify it builds**
+
+```bash
+go build ./cmd/...
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/reconcile.go
+git commit -m "feat(cmd): add reconcile command definition and provider interfaces"
+```
+
+---
+
+## Task 10: Command runner (interactive + non-interactive)
+
+**Files:**
+- Create: `cmd/reconcile_actions.go`
+
+- [ ] **Step 1: Create the actions file**
+
+```go
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/hance08/kea/internal/model"
+	"github.com/hance08/kea/internal/utils"
+	"github.com/hance08/kea/ui/prompts"
+	reconcileui "github.com/hance08/kea/ui/reconcile"
+	"github.com/hance08/kea/ui/views"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+func (r *reconcileRunner) Run(cmd *cobra.Command, args []string) error {
+	accountName := args[0]
+
+	// Resolve account.
+	acc, err := r.accSvc.GetAccountByName(accountName)
+	if err != nil {
+		return fmt.Errorf("account %q not found: %w", accountName, err)
+	}
+
+	nonInteractive := cmd.Flags().Changed("balance") && cmd.Flags().Changed("ids")
+
+	if nonInteractive {
+		return r.runNonInteractive(acc)
+	}
+	return r.runInteractive(acc)
+}
+
+// ── Non-interactive (agent / script) mode ────────────────────────────────────
+
+func (r *reconcileRunner) runNonInteractive(acc *model.Account) error {
+	statementBalance, err := utils.ParseAmount(r.flags.Balance)
+	if err != nil {
+		return fmt.Errorf("invalid --balance value %q: %w", r.flags.Balance, err)
+	}
+
+	txIDs, err := parseIDs(r.flags.IDs)
+	if err != nil {
+		return fmt.Errorf("invalid --ids value %q: %w", r.flags.IDs, err)
+	}
+
+	diff, err := r.txSvc.ReconcileTransactions(acc.ID, statementBalance, txIDs)
+	if err != nil {
+		return err
+	}
+
+	if diff != 0 && !r.flags.Force {
+		return fmt.Errorf(
+			"balance mismatch: off by $%s — use --force to reconcile anyway",
+			utils.FormatAmount(abs64(diff)),
+		)
+	}
+
+	if r.flags.JSON {
+		return writeReconcileJSON(acc.Name, len(txIDs), diff)
+	}
+	pterm.Success.Printf(
+		"Reconciled %d transaction(s) on %q. Difference: $%s\n",
+		len(txIDs), acc.Name, utils.FormatAmount(abs64(diff)),
+	)
+	return nil
+}
+
+// ── Interactive mode ──────────────────────────────────────────────────────────
+
+func (r *reconcileRunner) runInteractive(acc *model.Account) error {
+	// 1. Prompt for statement balance.
+	balanceStr, err := prompts.PromptAmount(
+		"Statement ending balance:",
+		"Enter the closing balance from your bank statement (e.g. 2450.00)",
+		prompts.ValidateAmountFormat(false),
+	)
+	if err != nil {
+		return fmt.Errorf("prompt cancelled: %w", err)
+	}
+
+	statementBalance, err := utils.ParseAmount(balanceStr)
+	if err != nil {
+		return fmt.Errorf("invalid balance: %w", err)
+	}
+
+	// 2. Load unreconciled entries.
+	entries, err := r.txSvc.GetUnreconciledByAccount(acc.ID)
+	if err != nil {
+		return err
+	}
+
+	// 3. Run bubbletea TUI.
+	m := reconcileui.NewModel(acc.Name, statementBalance, entries)
+	prog := tea.NewProgram(m)
+	finalRaw, err := prog.Run()
+	if err != nil {
+		return fmt.Errorf("TUI error: %w", err)
+	}
+	finalModel := finalRaw.(reconcileui.Model)
+
+	if finalModel.Cancelled() {
+		pterm.Info.Println("Reconciliation cancelled.")
+		return nil
+	}
+
+	selectedIDs := finalModel.SelectedIDs()
+	if len(selectedIDs) == 0 {
+		pterm.Info.Println("No transactions selected — nothing reconciled.")
+		return nil
+	}
+
+	// 4. Persist.
+	diff, err := r.txSvc.ReconcileTransactions(acc.ID, statementBalance, selectedIDs)
+	if err != nil {
+		return err
+	}
+
+	if r.flags.JSON {
+		return writeReconcileJSON(acc.Name, len(selectedIDs), diff)
+	}
+
+	if diff == 0 {
+		pterm.Success.Printf("Reconciled %d transaction(s) on %q — balanced!\n", len(selectedIDs), acc.Name)
+	} else {
+		pterm.Warning.Printf(
+			"Reconciled %d transaction(s) on %q with a remaining difference of $%s.\n",
+			len(selectedIDs), acc.Name, utils.FormatAmount(abs64(diff)),
+		)
+	}
+	return nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func parseIDs(s string) ([]int64, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, fmt.Errorf("empty ID list")
+	}
+	parts := strings.Split(s, ",")
+	ids := make([]int64, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		id, err := strconv.ParseInt(p, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ID %q: %w", p, err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func writeReconcileJSON(account string, count int, diff int64) error {
+	return views.WriteJSON(map[string]any{
+		"account":          account,
+		"reconciled_count": count,
+		"difference":       diff,
+	})
+}
+
+func abs64(n int64) int64 {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+```
+
+- [ ] **Step 2: Verify it builds**
+
+```bash
+go build ./cmd/...
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/reconcile_actions.go
+git commit -m "feat(cmd): implement reconcile runner with interactive and non-interactive modes"
+```
+
+---
+
+## Task 11: Wire the command in `root.go`
+
+**Files:**
+- Modify: `cmd/root.go`
+
+- [ ] **Step 1: Register `NewReconcileCmd`**
+
+In `cmd/root.go`, inside the `exitCode` closure where the other top-level commands are registered (around line 119–123), add one line:
+
+```go
+rootCmd.AddCommand(NewReconcileCmd(application.Service))
+```
+
+Place it after `rootCmd.AddCommand(NewReportCmd(application.Service))` so the ordering is consistent.
+
+- [ ] **Step 2: Build and smoke-test**
+
+```bash
+make build
+./kea_test reconcile --help
+```
+
+Expected output:
+```
+Compare your records against an external statement and mark
+matching transactions as reconciled.
+...
+Usage:
+  kea reconcile <account-name> [flags]
+
+Flags:
+      --balance string   statement ending balance (e.g. 2450.00)
+      --force            skip balance-mismatch warning (non-interactive mode)
+  -h, --help             help for reconcile
+      --ids string       comma-separated transaction IDs to reconcile (non-interactive)
+  -j, --json             output result as JSON
+```
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/root.go
+git commit -m "feat(cmd): register kea reconcile command in root"
+```
+
+---
+
+## Task 12: Final smoke test
+
+- [ ] **Step 1: Build**
+
+```bash
+make build
+```
+
+Expected: produces `./kea_test`, no errors.
+
+- [ ] **Step 2: Verify the command is listed in help**
+
+```bash
+./kea_test --help
+```
+
+Expected: `reconcile` appears in the command list.
+
+- [ ] **Step 3: Verify non-interactive mode produces JSON**
+
+```bash
+./kea_test reconcile "Assets:Checking" --balance 0 --ids 1 --force --json 2>&1 || true
+```
+
+Expected: either a JSON result or an error message (e.g. account not found) — the key is no panic and structured output.
+
+- [ ] **Step 4: Commit if clean**
+
+If there are any lint or build issues found during smoke testing, fix them and commit with:
+
+```bash
+git commit -m "fix(reconcile): address smoke test issues"
+```

--- a/docs/superpowers/specs/2026-04-16-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-04-16-reconciliation-design.md
@@ -1,0 +1,229 @@
+# Reconciliation Feature Design
+
+_Date: 2026-04-16_
+
+## Overview
+
+Reconciliation is the process of comparing your KEA records against an external statement (bank, credit card, etc.) and marking matched transactions as immutable. This document covers the full design of `kea reconcile`, including the interactive TUI, non-interactive agent mode, service layer, and repository layer.
+
+---
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Supported account types | All (A, L, R, E, C) |
+| Session resumability | One-shot — no session state persisted |
+| Balance mismatch behaviour | Soft warning — user can confirm even with non-zero difference |
+| Command placement | Top-level: `kea reconcile <account-name>` |
+| Entry inputs | Account name (arg) + statement ending balance (interactive prompt or `--balance` flag) |
+| TUI library | `bubbletea` (already an indirect dep via `huh`) |
+| TUI layout | Compact header with status badge, checkbox `[✓]`/`[ ]` style |
+| Agent mode | Fully non-interactive when `--balance`, `--ids`, and `--json` are all provided |
+
+---
+
+## Command & Entry Point
+
+### Interactive mode (default)
+
+```
+$ kea reconcile "Assets:Checking"
+  Statement ending balance: 2450.00    ← huh input prompt
+  [bubbletea TUI opens]
+```
+
+### Non-interactive / agent mode
+
+```bash
+kea reconcile "Assets:Checking" \
+  --balance 2450.00 \
+  --ids 12,15,18,22 \
+  --force \
+  --json
+```
+
+When `--balance` and `--ids` are both present the TUI is skipped entirely. `--force` suppresses the balance-mismatch warning. `--json` emits machine-readable output.
+
+### Flags
+
+| Flag | Type | Description |
+|---|---|---|
+| `--balance` | `string` | Statement ending balance (parsed via `utils.ParseAmount`) |
+| `--ids` | `string` | Comma-separated transaction IDs to reconcile (non-interactive mode) |
+| `--force` | `bool` | Skip balance-mismatch confirmation (non-interactive mode) |
+| `--json` | `bool` | Emit JSON result instead of styled output |
+
+### JSON output
+
+```json
+{
+  "account": "Assets:Checking",
+  "reconciled_count": 4,
+  "difference": 0
+}
+```
+
+### File layout
+
+Follows the existing `cmd/add.go` + `cmd/add_actions.go` pattern:
+
+```
+cmd/reconcile.go          — cobra command, flag binding, runner construction
+cmd/reconcile_actions.go  — runner struct, Run(), interactive/non-interactive branching
+```
+
+A `ReconcileProvider` interface gates the service dependency on the runner, keeping it testable without a real database.
+
+---
+
+## TUI Screen (bubbletea)
+
+### Layout
+
+```
+Assets:Checking                        [OFF BY $450.00]
+
+STATEMENT: $2,450.00 · 6 UNRECONCILED
+──────────────────────────────────────
+[✓] Apr 01  Rent payment          -$1,200.00
+[ ] Apr 03  Grocery Store             -$87.50
+[✓] Apr 05  Salary deposit        +$3,200.00
+[ ] Apr 08  Electric bill             -$95.00
+[ ] Apr 10  Coffee shop                -$4.80   ← cursor
+[ ] Apr 12  Internet bill             -$60.00
+──────────────────────────────────────
+Cleared $2,000.00 · Remaining $450.00
+
+space toggle · enter finish · ↑↓ · q quit
+```
+
+- Status badge turns green and reads `BALANCED` when difference = 0
+- `Remaining` label turns green when difference = 0, red when non-zero
+- Cursor row is highlighted
+
+### Keybindings
+
+| Key | Action |
+|---|---|
+| `↑` / `k` | Move cursor up |
+| `↓` / `j` | Move cursor down |
+| `space` | Toggle selected transaction |
+| `enter` | Finish — confirm and reconcile |
+| `q` / `esc` | Quit without reconciling |
+
+### Finish flow
+
+1. User presses `enter`
+2. If difference ≠ 0: show inline warning `"You're off by $X. Confirm anyway? (y/n)"` and wait for keypress
+3. If `y` (or difference = 0): call service, show success message, exit TUI
+4. If `n`: return to the checklist
+
+### File layout
+
+```
+ui/reconcile/model.go     — bubbletea Model, Init, Update, View
+ui/reconcile/keys.go      — key bindings
+```
+
+---
+
+## Service Layer
+
+### Method signature
+
+```go
+// ReconcileTransactions marks the given transactions as reconciled for an account.
+// Returns the difference between statementBalance and the sum of the selected
+// splits for the account. A non-zero difference is informational — the caller
+// decides whether to warn or abort.
+func (ts *TransactionService) ReconcileTransactions(
+    accountID int64,
+    statementBalance int64,
+    txIDs []int64,
+) (difference int64, err error)
+```
+
+### Logic
+
+1. Verify the account exists via `GetAccountByID`.
+2. Fetch unreconciled transactions via `GetUnreconciledTransactionsByAccount(accountID)`.
+3. Build a set of valid IDs from step 2. Reject any `txID` not in the set (unknown or already reconciled) — return an error before any writes.
+4. Compute `clearedBalance` = sum of the selected split amounts for `accountID` across the chosen transactions.
+5. Call `BulkUpdateTransactionStatus(txIDs, StatusReconciled)` atomically.
+6. Return `difference = statementBalance - clearedBalance`.
+
+The method never gates on `difference` — it always reconciles if the IDs are valid. Soft-warning logic lives in the command layer.
+
+---
+
+## Repository Layer
+
+Two new methods added to `TransactionRepository` in `internal/repository/interfaces.go`:
+
+```go
+// GetUnreconciledTransactionsByAccount returns all Pending and Cleared
+// transactions that have a split touching the given account.
+// StatusReconciled transactions are excluded.
+GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.Transaction, error)
+
+// BulkUpdateTransactionStatus sets the status of all given transaction IDs
+// in a single atomic UPDATE statement.
+BulkUpdateTransactionStatus(txIDs []int64, status model.TransactionStatus) error
+```
+
+### SQL notes
+
+`GetUnreconciledTransactionsByAccount` joins `transactions` with `splits` on `account_id` and filters `status IN (0, 1)`.
+
+`BulkUpdateTransactionStatus` issues `UPDATE transactions SET status = ? WHERE id IN (...)` inside a database transaction to guarantee atomicity.
+
+Both methods are implemented in `internal/store/`.
+
+---
+
+## Testing
+
+Service-layer tests follow the existing white-box pattern (`package service`) with mocks from `testhelper_test.go`.
+
+### New mock methods
+
+`mockTransactionRepo` gains:
+- `GetUnreconciledTransactionsByAccount(accountID int64)` — injectable error map + return slice
+- `BulkUpdateTransactionStatus(txIDs []int64, status model.TransactionStatus)` — call recorder + injectable error
+
+### Test cases for `ReconcileTransactions`
+
+| Case | Expected |
+|---|---|
+| Valid IDs, difference = 0 | returns 0, no error, bulk update called |
+| Valid IDs, difference ≠ 0 | returns difference, no error, bulk update called |
+| Unknown txID in request | error returned, bulk update not called |
+| Already-reconciled txID | error returned, bulk update not called |
+| Empty txIDs slice | error returned |
+| Account not found | error returned |
+
+No store-level integration tests are added in this feature (that gap exists across the codebase and is out of scope here).
+
+---
+
+## Data Flow Summary
+
+```
+kea reconcile "Assets:Checking"
+  │
+  ├─ huh prompt → statementBalance
+  │
+  ├─ svc.Transaction().GetUnreconciledTransactionsByAccount(accountID)
+  │     → []Transaction   (populates TUI list)
+  │
+  ├─ [user toggles transactions in bubbletea TUI]
+  │
+  ├─ user presses Enter
+  │     → if difference ≠ 0: soft warning y/n
+  │
+  └─ svc.Transaction().ReconcileTransactions(accountID, statementBalance, selectedIDs)
+        ├─ validate IDs
+        ├─ BulkUpdateTransactionStatus(selectedIDs, StatusReconciled)
+        └─ return difference
+```

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/golang-migrate/migrate/v4 v4.19.0
+	github.com/mattn/go-runewidth v0.0.19
 	github.com/mattn/go-sqlite3 v1.14.32
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pterm/pterm v0.12.82
@@ -46,7 +47,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,10 @@ go 1.25.4
 require github.com/spf13/cobra v1.10.1 // direct
 
 require (
+	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
+	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v0.8.0
+	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/golang-migrate/migrate/v4 v4.19.0
 	github.com/mattn/go-sqlite3 v1.14.32
@@ -23,10 +26,7 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect
-	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 // indirect
-	github.com/charmbracelet/bubbletea v1.3.10 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect

--- a/internal/model/transaction.go
+++ b/internal/model/transaction.go
@@ -73,3 +73,15 @@ type SplitDetail struct {
 	Currency    string
 	Memo        string
 }
+
+// ReconcileEntry is a read-only projection used by the reconciliation workflow.
+// It carries a transaction plus the net split amount for the queried account,
+// so the TUI can display amounts and the service can compute the cleared balance
+// without issuing per-transaction queries.
+type ReconcileEntry struct {
+	ID          int64
+	Timestamp   int64
+	Description string
+	Status      TransactionStatus
+	Amount      int64 // net split amount for the reconciled account
+}

--- a/internal/model/transaction.go
+++ b/internal/model/transaction.go
@@ -79,9 +79,10 @@ type SplitDetail struct {
 // so the TUI can display amounts and the service can compute the cleared balance
 // without issuing per-transaction queries.
 type ReconcileEntry struct {
-	ID          int64
-	Timestamp   int64
-	Description string
-	Status      TransactionStatus
-	Amount      int64 // net split amount for the reconciled account
+	ID            int64
+	Timestamp     int64
+	Description   string
+	Status        TransactionStatus
+	Amount        int64  // net split amount for the reconciled account
+	OffsetAccount string // other-side account name; "(split)" for multi-split transactions
 }

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -45,6 +45,16 @@ type TransactionRepository interface {
 	// GetSplitsWithAccountsByTransaction returns all splits (with account info) for
 	// a single transaction in one JOIN query.
 	GetSplitsWithAccountsByTransaction(txID int64) ([]model.SplitDetail, error)
+
+	// GetUnreconciledTransactionsByAccount returns all Pending and Cleared
+	// transactions that have a split touching accountID, together with the
+	// net split amount for that account. Ordered by timestamp ASC.
+	GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.ReconcileEntry, error)
+
+	// BulkUpdateTransactionStatus sets status on all listed transaction IDs
+	// in a single atomic UPDATE. Returns an error if the affected row count
+	// does not match len(txIDs).
+	BulkUpdateTransactionStatus(txIDs []int64, status model.TransactionStatus) error
 }
 
 type Repository interface {

--- a/internal/service/reconcile_ops.go
+++ b/internal/service/reconcile_ops.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/hance08/kea/internal/model"
+)
+
+// GetUnreconciledByAccount returns all Pending/Cleared transactions that
+// have a split touching the given account, including the split amount for
+// that account. Used to populate the reconciliation TUI.
+func (ts *TransactionService) GetUnreconciledByAccount(accountID int64) ([]*model.ReconcileEntry, error) {
+	entries, err := ts.txRepo.GetUnreconciledTransactionsByAccount(accountID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load unreconciled transactions: %w", err)
+	}
+	return entries, nil
+}
+
+// ReconcileTransactions marks the given transaction IDs as reconciled for
+// accountID. It validates that every requested ID is in the unreconciled set
+// for that account before writing anything.
+//
+// Returns the difference between statementBalance and the sum of the selected
+// split amounts for accountID. A non-zero difference is informational — the
+// method always commits if the IDs are valid. The caller decides whether to
+// warn (non-zero diff) or proceed silently (zero diff).
+func (ts *TransactionService) ReconcileTransactions(accountID int64, statementBalance int64, txIDs []int64) (int64, error) {
+	if len(txIDs) == 0 {
+		return 0, fmt.Errorf("no transactions selected for reconciliation")
+	}
+
+	// 1. Verify account exists.
+	if _, err := ts.accRepo.GetAccountByID(accountID); err != nil {
+		return 0, fmt.Errorf("account not found: %w", err)
+	}
+
+	// 2. Fetch unreconciled transactions and build a valid-ID → amount map.
+	entries, err := ts.txRepo.GetUnreconciledTransactionsByAccount(accountID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to load unreconciled transactions: %w", err)
+	}
+
+	validAmounts := make(map[int64]int64, len(entries)) // txID → split amount
+	for _, e := range entries {
+		validAmounts[e.ID] = e.Amount
+	}
+
+	// 3. Validate every requested ID and accumulate the cleared balance.
+	var clearedBalance int64
+	for _, id := range txIDs {
+		amount, ok := validAmounts[id]
+		if !ok {
+			return 0, fmt.Errorf("transaction ID %d is not in the unreconciled set for this account", id)
+		}
+		clearedBalance += amount
+	}
+
+	// 4. Atomically mark all selected transactions as reconciled.
+	if err := ts.txRepo.BulkUpdateTransactionStatus(txIDs, model.StatusReconciled); err != nil {
+		return 0, fmt.Errorf("failed to reconcile transactions: %w", err)
+	}
+
+	return statementBalance - clearedBalance, nil
+}

--- a/internal/service/reconcile_ops_test.go
+++ b/internal/service/reconcile_ops_test.go
@@ -113,6 +113,9 @@ func TestReconcileTransactions_EmptyIDs(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty IDs, got nil")
 	}
+	if len(txRepo.bulkUpdateCalls) != 0 {
+		t.Error("bulk update must not be called when IDs are empty")
+	}
 }
 
 func TestReconcileTransactions_AccountNotFound(t *testing.T) {

--- a/internal/service/reconcile_ops_test.go
+++ b/internal/service/reconcile_ops_test.go
@@ -1,0 +1,133 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/hance08/kea/internal/model"
+)
+
+// helper: build a ReconcileEntry slice for a given accountID in the mock
+func seedUnreconciled(txRepo *mockTransactionRepo, accountID int64, entries []*model.ReconcileEntry) {
+	txRepo.unreconciledByAccount[accountID] = entries
+}
+
+func TestReconcileTransactions_ZeroDifference(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
+		{ID: 10, Timestamp: 1000, Description: "Salary", Status: model.StatusCleared, Amount: 100000},
+		{ID: 11, Timestamp: 1001, Description: "Rent", Status: model.StatusCleared, Amount: -50000},
+	})
+
+	// statementBalance = 50000 = 100000 + (-50000)
+	diff, err := svc.ReconcileTransactions(1, 50000, []int64{10, 11})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff != 0 {
+		t.Errorf("expected difference 0, got %d", diff)
+	}
+	if len(txRepo.bulkUpdateCalls) != 1 {
+		t.Errorf("expected 1 bulk update call, got %d", len(txRepo.bulkUpdateCalls))
+	}
+}
+
+func TestReconcileTransactions_NonZeroDifference(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
+		{ID: 10, Timestamp: 1000, Description: "Salary", Status: model.StatusCleared, Amount: 100000},
+	})
+
+	// statementBalance = 120000, but we're only reconciling 100000 → diff = 20000
+	diff, err := svc.ReconcileTransactions(1, 120000, []int64{10})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff != 20000 {
+		t.Errorf("expected difference 20000, got %d", diff)
+	}
+	if len(txRepo.bulkUpdateCalls) != 1 {
+		t.Fatalf("expected bulk update to be called")
+	}
+}
+
+func TestReconcileTransactions_UnknownTxID(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
+		{ID: 10, Timestamp: 1000, Description: "Salary", Status: model.StatusCleared, Amount: 100000},
+	})
+
+	_, err := svc.ReconcileTransactions(1, 100000, []int64{10, 99}) // 99 is unknown
+
+	if err == nil {
+		t.Fatal("expected error for unknown transaction ID, got nil")
+	}
+	if len(txRepo.bulkUpdateCalls) != 0 {
+		t.Error("bulk update must not be called when validation fails")
+	}
+}
+
+func TestReconcileTransactions_AlreadyReconciledID(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	// unreconciledByAccount does NOT contain ID 20 (it's already reconciled)
+	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
+		{ID: 10, Timestamp: 1000, Description: "Salary", Status: model.StatusCleared, Amount: 100000},
+	})
+
+	_, err := svc.ReconcileTransactions(1, 100000, []int64{10, 20}) // 20 not in unreconciled set
+
+	if err == nil {
+		t.Fatal("expected error for already-reconciled ID, got nil")
+	}
+	if len(txRepo.bulkUpdateCalls) != 0 {
+		t.Error("bulk update must not be called when validation fails")
+	}
+}
+
+func TestReconcileTransactions_EmptyIDs(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+
+	_, err := svc.ReconcileTransactions(1, 100000, []int64{})
+
+	if err == nil {
+		t.Fatal("expected error for empty IDs, got nil")
+	}
+}
+
+func TestReconcileTransactions_AccountNotFound(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	// account ID 99 does not exist in accRepo
+
+	_, err := svc.ReconcileTransactions(99, 100000, []int64{10})
+
+	if err == nil {
+		t.Fatal("expected error for unknown account, got nil")
+	}
+	if len(txRepo.bulkUpdateCalls) != 0 {
+		t.Error("bulk update must not be called when account lookup fails")
+	}
+}

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -27,12 +27,12 @@ type mockAccountRepo struct {
 	nextID         int64
 
 	// injectable errors
-	createErr          error
-	deleteErr          error
-	getByNameErr       map[string]error
-	getByIDErr         map[int64]error
-	getBalanceErr      map[int64]error
-	getAllBalancesErr   error
+	createErr         error
+	deleteErr         error
+	getByNameErr      map[string]error
+	getByIDErr        map[int64]error
+	getBalanceErr     map[int64]error
+	getAllBalancesErr error
 }
 
 func newMockAccountRepo() *mockAccountRepo {
@@ -196,16 +196,24 @@ type mockTransactionRepo struct {
 	deleteSplitCalls []int64
 	createSplitCalls []*model.Split
 	updateSplitCalls []int64
+
+	// reconciliation support
+	unreconciledByAccount    map[int64][]*model.ReconcileEntry
+	unreconciledByAccountErr map[int64]error
+	bulkUpdateErr            error
+	bulkUpdateCalls          [][]int64
 }
 
 func newMockTransactionRepo() *mockTransactionRepo {
 	return &mockTransactionRepo{
-		transactions:    make(map[int64]*model.Transaction),
-		splits:          make(map[int64][]*model.Split),
-		getByIDErr:      make(map[int64]error),
-		splitsWithAccts: make(map[int64][]model.SplitDetail),
-		nextTxID:        1,
-		nextSplitID:     100,
+		transactions:             make(map[int64]*model.Transaction),
+		splits:                   make(map[int64][]*model.Split),
+		getByIDErr:               make(map[int64]error),
+		splitsWithAccts:          make(map[int64][]model.SplitDetail),
+		unreconciledByAccount:    make(map[int64][]*model.ReconcileEntry),
+		unreconciledByAccountErr: make(map[int64]error),
+		nextTxID:                 1,
+		nextSplitID:              100,
 	}
 }
 
@@ -346,6 +354,28 @@ func (m *mockTransactionRepo) GetSplitsWithAccountsByTransaction(txID int64) ([]
 		})
 	}
 	return result, nil
+}
+
+func (m *mockTransactionRepo) GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.ReconcileEntry, error) {
+	if err, ok := m.unreconciledByAccountErr[accountID]; ok {
+		return nil, err
+	}
+	return m.unreconciledByAccount[accountID], nil
+}
+
+func (m *mockTransactionRepo) BulkUpdateTransactionStatus(txIDs []int64, status model.TransactionStatus) error {
+	if m.bulkUpdateErr != nil {
+		return m.bulkUpdateErr
+	}
+	ids := make([]int64, len(txIDs))
+	copy(ids, txIDs)
+	m.bulkUpdateCalls = append(m.bulkUpdateCalls, ids)
+	for _, id := range txIDs {
+		if tx, ok := m.transactions[id]; ok {
+			tx.Status = status
+		}
+	}
+	return nil
 }
 
 // ──────────────────────────────────────────────

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -275,14 +275,23 @@ func (ts *TransactionService) UpdateTransactionComplete(txID int64, description 
 	})
 }
 
-func (ts *TransactionService) IsEditable(detail *model.TransactionDetail) bool {
+// NotEditableReason identifies why a transaction cannot be edited.
+type NotEditableReason int
+
+const (
+	EditableOK              NotEditableReason = 0 // transaction may be edited
+	NotEditableSystemTx     NotEditableReason = 1 // opening-balance system transaction
+	NotEditableReconciled   NotEditableReason = 2 // already reconciled
+)
+
+func (ts *TransactionService) IsEditable(detail *model.TransactionDetail) (bool, NotEditableReason) {
 	if detail.ID == model.OpeningBalanceTransactionID {
-		return false
+		return false, NotEditableSystemTx
 	}
 
 	if detail.Status == model.StatusReconciled {
-		return false
+		return false, NotEditableReconciled
 	}
 
-	return true
+	return true, EditableOK
 }

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -571,21 +571,29 @@ func TestIsEditable(t *testing.T) {
 
 	t.Run("regular transaction is editable", func(t *testing.T) {
 		detail := &model.TransactionDetail{ID: 5}
-		assert.True(t, svc.IsEditable(detail))
+		editable, code := svc.IsEditable(detail)
+		assert.True(t, editable)
+		assert.Equal(t, int64(0), code)
 	})
 
 	t.Run("opening balance transaction (ID=1) is not editable", func(t *testing.T) {
 		detail := &model.TransactionDetail{ID: model.OpeningBalanceTransactionID}
-		assert.False(t, svc.IsEditable(detail))
+		editable, code := svc.IsEditable(detail)
+		assert.False(t, editable)
+		assert.Equal(t, int64(1), code)
 	})
 
 	t.Run("ID=2 is editable", func(t *testing.T) {
 		detail := &model.TransactionDetail{ID: 2}
-		assert.True(t, svc.IsEditable(detail))
+		editable, code := svc.IsEditable(detail)
+		assert.True(t, editable)
+		assert.Equal(t, int64(0), code)
 	})
 
 	t.Run("reconciled transaction is not editable", func(t *testing.T) {
 		detail := &model.TransactionDetail{ID: 5, Status: model.StatusReconciled}
-		assert.False(t, svc.IsEditable(detail))
+		editable, code := svc.IsEditable(detail)
+		assert.False(t, editable)
+		assert.Equal(t, int64(2), code)
 	})
 }

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -571,29 +571,29 @@ func TestIsEditable(t *testing.T) {
 
 	t.Run("regular transaction is editable", func(t *testing.T) {
 		detail := &model.TransactionDetail{ID: 5}
-		editable, code := svc.IsEditable(detail)
+		editable, reason := svc.IsEditable(detail)
 		assert.True(t, editable)
-		assert.Equal(t, int64(0), code)
+		assert.Equal(t, EditableOK, reason)
 	})
 
 	t.Run("opening balance transaction (ID=1) is not editable", func(t *testing.T) {
 		detail := &model.TransactionDetail{ID: model.OpeningBalanceTransactionID}
-		editable, code := svc.IsEditable(detail)
+		editable, reason := svc.IsEditable(detail)
 		assert.False(t, editable)
-		assert.Equal(t, int64(1), code)
+		assert.Equal(t, NotEditableSystemTx, reason)
 	})
 
 	t.Run("ID=2 is editable", func(t *testing.T) {
 		detail := &model.TransactionDetail{ID: 2}
-		editable, code := svc.IsEditable(detail)
+		editable, reason := svc.IsEditable(detail)
 		assert.True(t, editable)
-		assert.Equal(t, int64(0), code)
+		assert.Equal(t, EditableOK, reason)
 	})
 
 	t.Run("reconciled transaction is not editable", func(t *testing.T) {
 		detail := &model.TransactionDetail{ID: 5, Status: model.StatusReconciled}
-		editable, code := svc.IsEditable(detail)
+		editable, reason := svc.IsEditable(detail)
 		assert.False(t, editable)
-		assert.Equal(t, int64(2), code)
+		assert.Equal(t, NotEditableReconciled, reason)
 	})
 }

--- a/internal/store/sqlite_reconcile.go
+++ b/internal/store/sqlite_reconcile.go
@@ -13,14 +13,33 @@ import (
 // Results are ordered by timestamp ASC so the TUI shows chronological order.
 func (s *Store) GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.ReconcileEntry, error) {
 	rows, err := s.db.Query(`
-        SELECT t.id, t.timestamp, t.description, t.status, SUM(s.amount) AS amount
+        SELECT
+            t.id, t.timestamp, t.description, t.status,
+            SUM(s.amount) AS amount,
+            CASE
+                WHEN (
+                    SELECT COUNT(DISTINCT s2.account_id)
+                    FROM splits s2
+                    WHERE s2.transaction_id = t.id AND s2.account_id != ?
+                ) > 1
+                THEN '(split)'
+                ELSE COALESCE(
+                    (
+                        SELECT a.name
+                        FROM splits s2
+                        JOIN accounts a ON a.id = s2.account_id
+                        WHERE s2.transaction_id = t.id AND s2.account_id != ?
+                        LIMIT 1
+                    ), ''
+                )
+            END AS offset_account
         FROM transactions t
         INNER JOIN splits s ON t.id = s.transaction_id
         WHERE s.account_id = ?
           AND t.status IN (0, 1)
         GROUP BY t.id, t.timestamp, t.description, t.status
         ORDER BY t.timestamp ASC, t.id ASC
-    `, accountID)
+    `, accountID, accountID, accountID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query unreconciled transactions: %w", err)
 	}
@@ -29,7 +48,7 @@ func (s *Store) GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.
 	var result []*model.ReconcileEntry
 	for rows.Next() {
 		e := &model.ReconcileEntry{}
-		if err := rows.Scan(&e.ID, &e.Timestamp, &e.Description, &e.Status, &e.Amount); err != nil {
+		if err := rows.Scan(&e.ID, &e.Timestamp, &e.Description, &e.Status, &e.Amount, &e.OffsetAccount); err != nil {
 			return nil, fmt.Errorf("failed to scan reconcile entry: %w", err)
 		}
 		result = append(result, e)

--- a/internal/store/sqlite_reconcile.go
+++ b/internal/store/sqlite_reconcile.go
@@ -1,0 +1,78 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hance08/kea/internal/model"
+)
+
+// GetUnreconciledTransactionsByAccount returns all Pending (0) and Cleared (1)
+// transactions that have a split on accountID, together with the net split
+// amount for that account (grouped to handle rare multi-split-per-account cases).
+// Results are ordered by timestamp ASC so the TUI shows chronological order.
+func (s *Store) GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.ReconcileEntry, error) {
+	rows, err := s.db.Query(`
+        SELECT t.id, t.timestamp, t.description, t.status, SUM(s.amount) AS amount
+        FROM transactions t
+        INNER JOIN splits s ON t.id = s.transaction_id
+        WHERE s.account_id = ?
+          AND t.status IN (0, 1)
+        GROUP BY t.id, t.timestamp, t.description, t.status
+        ORDER BY t.timestamp ASC, t.id ASC
+    `, accountID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query unreconciled transactions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []*model.ReconcileEntry
+	for rows.Next() {
+		e := &model.ReconcileEntry{}
+		if err := rows.Scan(&e.ID, &e.Timestamp, &e.Description, &e.Status, &e.Amount); err != nil {
+			return nil, fmt.Errorf("failed to scan reconcile entry: %w", err)
+		}
+		result = append(result, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows iteration error: %w", err)
+	}
+	return result, nil
+}
+
+// BulkUpdateTransactionStatus sets the status of all listed transaction IDs
+// in a single UPDATE statement. Returns an error if the affected row count
+// does not match len(txIDs) — indicating one or more IDs did not exist.
+func (s *Store) BulkUpdateTransactionStatus(txIDs []int64, status model.TransactionStatus) error {
+	if len(txIDs) == 0 {
+		return nil
+	}
+
+	placeholders := strings.Repeat("?,", len(txIDs))
+	placeholders = placeholders[:len(placeholders)-1] // trim trailing comma
+
+	query := fmt.Sprintf(
+		"UPDATE transactions SET status = ? WHERE id IN (%s)",
+		placeholders,
+	)
+
+	args := make([]any, 0, len(txIDs)+1)
+	args = append(args, status)
+	for _, id := range txIDs {
+		args = append(args, id)
+	}
+
+	result, err := s.db.Exec(query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to bulk update transaction status: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rowsAffected != int64(len(txIDs)) {
+		return fmt.Errorf("expected to update %d transactions, updated %d", len(txIDs), rowsAffected)
+	}
+	return nil
+}

--- a/ui/reconcile/keys.go
+++ b/ui/reconcile/keys.go
@@ -1,0 +1,25 @@
+package reconcileui
+
+import "github.com/charmbracelet/bubbles/key"
+
+type keyMap struct {
+	Up      key.Binding
+	Down    key.Binding
+	Toggle  key.Binding
+	Confirm key.Binding
+	Quit    key.Binding
+	Yes     key.Binding
+	No      key.Binding
+}
+
+func defaultKeyMap() keyMap {
+	return keyMap{
+		Up:      key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑/k", "up")),
+		Down:    key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
+		Toggle:  key.NewBinding(key.WithKeys(" "), key.WithHelp("space", "toggle")),
+		Confirm: key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "finish")),
+		Quit:    key.NewBinding(key.WithKeys("q", "esc"), key.WithHelp("q/esc", "quit")),
+		Yes:     key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "confirm")),
+		No:      key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "cancel")),
+	}
+}

--- a/ui/reconcile/keys.go
+++ b/ui/reconcile/keys.go
@@ -3,23 +3,25 @@ package reconcileui
 import "github.com/charmbracelet/bubbles/key"
 
 type keyMap struct {
-	Up      key.Binding
-	Down    key.Binding
-	Toggle  key.Binding
-	Confirm key.Binding
-	Quit    key.Binding
-	Yes     key.Binding
-	No      key.Binding
+	Up        key.Binding
+	Down      key.Binding
+	Toggle    key.Binding
+	SelectAll key.Binding
+	Confirm   key.Binding
+	Quit      key.Binding
+	Yes       key.Binding
+	No        key.Binding
 }
 
 func defaultKeyMap() keyMap {
 	return keyMap{
-		Up:      key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑/k", "up")),
-		Down:    key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
-		Toggle:  key.NewBinding(key.WithKeys(" "), key.WithHelp("space", "toggle")),
-		Confirm: key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "finish")),
-		Quit:    key.NewBinding(key.WithKeys("q", "esc"), key.WithHelp("q/esc", "quit")),
-		Yes:     key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "confirm")),
-		No:      key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "cancel")),
+		Up:        key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑/k", "up")),
+		Down:      key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
+		Toggle:    key.NewBinding(key.WithKeys(" "), key.WithHelp("space", "toggle")),
+		SelectAll: key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "select all")),
+		Confirm:   key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "finish")),
+		Quit:      key.NewBinding(key.WithKeys("q", "esc"), key.WithHelp("q/esc", "quit")),
+		Yes:       key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "confirm")),
+		No:        key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "cancel")),
 	}
 }

--- a/ui/reconcile/model.go
+++ b/ui/reconcile/model.go
@@ -138,6 +138,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if len(m.items) > 0 {
 				m.items[m.cursor].checked = !m.items[m.cursor].checked
 			}
+		case key.Matches(msg, m.keys.SelectAll):
+			// If every item is already checked, uncheck all; otherwise check all.
+			allChecked := true
+			for _, it := range m.items {
+				if !it.checked {
+					allChecked = false
+					break
+				}
+			}
+			for i := range m.items {
+				m.items[i].checked = !allChecked
+			}
 		case key.Matches(msg, m.keys.Confirm):
 			if len(m.items) == 0 {
 				return m, nil
@@ -193,12 +205,14 @@ func (m Model) View() string {
 	above := start
 	below := len(m.items) - end
 
+	const sepWidth = 70
+
 	// ── Top separator (with scroll-up indicator) ─────────
 	if above > 0 {
 		indicator := fmt.Sprintf("↑ %d more  ", above)
-		sb.WriteString(indicator + strings.Repeat("─", 52-len(indicator)) + "\n")
+		sb.WriteString(indicator + strings.Repeat("─", sepWidth-len(indicator)) + "\n")
 	} else {
-		sb.WriteString(strings.Repeat("─", 52) + "\n")
+		sb.WriteString(strings.Repeat("─", sepWidth) + "\n")
 	}
 
 	// ── Transaction list ────────────────────────────────
@@ -217,9 +231,16 @@ func (m Model) View() string {
 			rowStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("78"))
 		}
 
-		date := time.Unix(it.entry.Timestamp, 0).Format("Jan 02")
+		date := time.Unix(it.entry.Timestamp, 0).Format("06-01-02")
 		amt := fmt.Sprintf("$%s", utils.FormatAmount(it.entry.Amount))
-		line := fmt.Sprintf("%s%s %s  %-26s %10s", cursorMark, checkbox, date, truncate(it.entry.Description, 26), amt)
+		line := fmt.Sprintf("%s%s %s  %-18s  %-18s  %12s",
+			cursorMark,
+			checkbox,
+			date,
+			truncate(it.entry.Description, 18),
+			truncate(it.entry.OffsetAccount, 18),
+			amt,
+		)
 
 		if i == m.cursor {
 			line = lipgloss.NewStyle().
@@ -235,9 +256,9 @@ func (m Model) View() string {
 	// ── Bottom separator (with scroll-down indicator) ────
 	if below > 0 {
 		indicator := fmt.Sprintf("  ↓ %d more", below)
-		sb.WriteString(strings.Repeat("─", 52-len(indicator)) + indicator + "\n")
+		sb.WriteString(strings.Repeat("─", sepWidth-len(indicator)) + indicator + "\n")
 	} else {
-		sb.WriteString(strings.Repeat("─", 52) + "\n")
+		sb.WriteString(strings.Repeat("─", sepWidth) + "\n")
 	}
 
 	// ── Footer balance ───────────────────────────────────
@@ -260,7 +281,7 @@ func (m Model) View() string {
 			warnStyle.Render(fmt.Sprintf("You're off by $%s. Confirm anyway? (y/n)", diffStr)),
 		))
 	} else {
-		sb.WriteString("\nspace toggle · enter finish · ↑↓ navigate · q quit\n")
+		sb.WriteString("\nspace toggle · a select all · enter finish · ↑↓ navigate · q quit\n")
 	}
 
 	return sb.String()

--- a/ui/reconcile/model.go
+++ b/ui/reconcile/model.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	rw "github.com/mattn/go-runewidth"
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/utils"
 )
@@ -16,6 +17,20 @@ import (
 // account+badge (1) · blank (1) · statement (1) · top-sep (1) ·
 // bottom-sep (1) · cleared (1) · blank (1) · hint (1) = 8
 const overheadLines = 8
+
+// Column widths in terminal display columns (accounts for double-wide CJK chars).
+const (
+	colDate   = 8  // "YY-MM-DD"
+	colAcct   = 16 // reconciled account
+	colOffset = 16 // other-side account
+	colDesc   = 12 // description
+	colAmt    = 12 // amount, right-aligned
+)
+
+// sepWidth is the total display width of separator lines.
+// cursor(2) + checkbox(3) + sp(1) + date(8) + sp(2) + acct(16) + sp(2) +
+// offset(16) + sp(2) + desc(12) + sp(2) + amt(12) = 78
+const sepWidth = 78
 
 type listItem struct {
 	entry   *model.ReconcileEntry
@@ -30,8 +45,8 @@ type Model struct {
 	statementBalance int64
 	items            []listItem
 	cursor           int
-	viewportOffset   int // index of the first visible item
-	height           int // terminal height (0 = unknown, show all)
+	viewportOffset   int  // index of the first visible item
+	height           int  // terminal height (0 = unknown, show all)
 	confirmPending   bool // waiting for y/n after Enter with non-zero diff
 	cancelled        bool
 	done             bool
@@ -205,8 +220,6 @@ func (m Model) View() string {
 	above := start
 	below := len(m.items) - end
 
-	const sepWidth = 70
-
 	// ── Top separator (with scroll-up indicator) ─────────
 	if above > 0 {
 		indicator := fmt.Sprintf("↑ %d more  ", above)
@@ -215,7 +228,8 @@ func (m Model) View() string {
 		sb.WriteString(strings.Repeat("─", sepWidth) + "\n")
 	}
 
-	// ── Transaction list ────────────────────────────────
+	// ── Transaction list ─────────────────────────────────
+	// Column order: date · account · offset account · description · amount
 	for i := start; i < end; i++ {
 		it := m.items[i]
 
@@ -232,15 +246,13 @@ func (m Model) View() string {
 		}
 
 		date := time.Unix(it.entry.Timestamp, 0).Format("06-01-02")
-		amt := fmt.Sprintf("$%s", utils.FormatAmount(it.entry.Amount))
-		line := fmt.Sprintf("%s%s %s  %-18s  %-18s  %12s",
-			cursorMark,
-			checkbox,
-			date,
-			truncate(it.entry.Description, 18),
-			truncate(it.entry.OffsetAccount, 18),
-			amt,
-		)
+		amt := fmt.Sprintf("%*s", colAmt, "$"+utils.FormatAmount(it.entry.Amount))
+
+		line := cursorMark + checkbox + " " + date + "  " +
+			padRight(m.accountName, colAcct) + "  " +
+			padRight(it.entry.OffsetAccount, colOffset) + "  " +
+			padRight(it.entry.Description, colDesc) + "  " +
+			amt
 
 		if i == m.cursor {
 			line = lipgloss.NewStyle().
@@ -310,9 +322,16 @@ func abs(n int64) int64 {
 	return n
 }
 
-func truncate(s string, max int) string {
-	if len(s) <= max {
-		return s
+// padRight pads s to exactly `width` terminal display columns, correctly
+// accounting for double-wide CJK characters. Strings wider than `width`
+// are truncated and suffixed with "…".
+func padRight(s string, width int) string {
+	w := rw.StringWidth(s)
+	if w >= width {
+		// Truncate: fill width-1 columns then append "…" (1 column).
+		truncated := rw.Truncate(s, width-1, "")
+		tw := rw.StringWidth(truncated)
+		return truncated + strings.Repeat(" ", width-1-tw) + "…"
 	}
-	return s[:max-1] + "…"
+	return s + strings.Repeat(" ", width-w)
 }

--- a/ui/reconcile/model.go
+++ b/ui/reconcile/model.go
@@ -194,12 +194,18 @@ func (m Model) View() string {
 			Background(lipgloss.Color("22")).
 			Foreground(lipgloss.Color("15")).
 			Render("BALANCED")
-	} else {
+	} else if diff > 0 {
 		badge = lipgloss.NewStyle().
 			Padding(0, 1).
 			Background(lipgloss.Color("58")).
 			Foreground(lipgloss.Color("15")).
-			Render(fmt.Sprintf("OFF BY $%s", utils.FormatAmount(abs(diff))))
+			Render(fmt.Sprintf("SHORT $%s", utils.FormatAmount(diff)))
+	} else {
+		badge = lipgloss.NewStyle().
+			Padding(0, 1).
+			Background(lipgloss.Color("130")).
+			Foreground(lipgloss.Color("15")).
+			Render(fmt.Sprintf("OVER $%s", utils.FormatAmount(abs(diff))))
 	}
 
 	accountStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("78"))
@@ -273,21 +279,34 @@ func (m Model) View() string {
 	// ── Footer balance ───────────────────────────────────
 	clearedStr := utils.FormatAmount(m.clearedBalance())
 	diffStr := utils.FormatAmount(abs(diff))
-	remainingStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
-	if diff == 0 {
-		remainingStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("78"))
+	var diffLabel string
+	var diffStyle lipgloss.Style
+	switch {
+	case diff == 0:
+		diffLabel = "Balanced"
+		diffStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("78"))
+	case diff > 0:
+		diffLabel = fmt.Sprintf("Short $%s", diffStr)
+		diffStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	default: // diff < 0: cleared more than statement
+		diffLabel = fmt.Sprintf("Over $%s", diffStr)
+		diffStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 	}
 	sb.WriteString(fmt.Sprintf(
 		"Cleared $%s · %s\n",
 		clearedStr,
-		remainingStyle.Render(fmt.Sprintf("Remaining $%s", diffStr)),
+		diffStyle.Render(diffLabel),
 	))
 
 	// ── Prompt or hint ───────────────────────────────────
 	if m.confirmPending {
 		warnStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+		direction := "short"
+		if diff < 0 {
+			direction = "over"
+		}
 		sb.WriteString(fmt.Sprintf("\n%s\n",
-			warnStyle.Render(fmt.Sprintf("You're off by $%s. Confirm anyway? (y/n)", diffStr)),
+			warnStyle.Render(fmt.Sprintf("$%s %s. Confirm anyway? (y/n)", diffStr, direction)),
 		))
 	} else {
 		sb.WriteString("\nspace toggle · a select all · enter finish · ↑↓ navigate · q quit\n")

--- a/ui/reconcile/model.go
+++ b/ui/reconcile/model.go
@@ -12,6 +12,11 @@ import (
 	"github.com/hance08/kea/internal/utils"
 )
 
+// overheadLines is the number of non-item lines in the view:
+// account+badge (1) · blank (1) · statement (1) · top-sep (1) ·
+// bottom-sep (1) · cleared (1) · blank (1) · hint (1) = 8
+const overheadLines = 8
+
 type listItem struct {
 	entry   *model.ReconcileEntry
 	checked bool
@@ -25,6 +30,8 @@ type Model struct {
 	statementBalance int64
 	items            []listItem
 	cursor           int
+	viewportOffset   int // index of the first visible item
+	height           int // terminal height (0 = unknown, show all)
 	confirmPending   bool // waiting for y/n after Enter with non-zero diff
 	cancelled        bool
 	done             bool
@@ -59,10 +66,49 @@ func (m Model) SelectedIDs() []int64 {
 	return ids
 }
 
+// visibleCount returns how many item rows fit in the current terminal height.
+// Returns len(items) when height is unknown (0) so nothing is clipped.
+func (m Model) visibleCount() int {
+	if m.height == 0 {
+		return len(m.items)
+	}
+	n := m.height - overheadLines
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// clampViewport adjusts viewportOffset so the cursor row is always visible.
+func clampViewport(cursor, viewportOffset, visibleCount, totalItems int) int {
+	if cursor < viewportOffset {
+		viewportOffset = cursor
+	}
+	if cursor >= viewportOffset+visibleCount {
+		viewportOffset = cursor - visibleCount + 1
+	}
+	maxOffset := totalItems - visibleCount
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if viewportOffset > maxOffset {
+		viewportOffset = maxOffset
+	}
+	if viewportOffset < 0 {
+		viewportOffset = 0
+	}
+	return viewportOffset
+}
+
 func (m Model) Init() tea.Cmd { return nil }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.height = msg.Height
+		m.viewportOffset = clampViewport(m.cursor, m.viewportOffset, m.visibleCount(), len(m.items))
+		return m, nil
+
 	case tea.KeyMsg:
 		if m.confirmPending {
 			switch {
@@ -81,10 +127,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, m.keys.Up):
 			if m.cursor > 0 {
 				m.cursor--
+				m.viewportOffset = clampViewport(m.cursor, m.viewportOffset, m.visibleCount(), len(m.items))
 			}
 		case key.Matches(msg, m.keys.Down):
 			if m.cursor < len(m.items)-1 {
 				m.cursor++
+				m.viewportOffset = clampViewport(m.cursor, m.viewportOffset, m.visibleCount(), len(m.items))
 			}
 		case key.Matches(msg, m.keys.Toggle):
 			if len(m.items) > 0 {
@@ -134,10 +182,29 @@ func (m Model) View() string {
 
 	stmtStr := utils.FormatAmount(m.statementBalance)
 	sb.WriteString(fmt.Sprintf("STATEMENT: $%s · %d UNRECONCILED\n", stmtStr, len(m.items)))
-	sb.WriteString(strings.Repeat("─", 52) + "\n")
+
+	// ── Viewport calculation ─────────────────────────────
+	vis := m.visibleCount()
+	start := m.viewportOffset
+	end := start + vis
+	if end > len(m.items) {
+		end = len(m.items)
+	}
+	above := start
+	below := len(m.items) - end
+
+	// ── Top separator (with scroll-up indicator) ─────────
+	if above > 0 {
+		indicator := fmt.Sprintf("↑ %d more  ", above)
+		sb.WriteString(indicator + strings.Repeat("─", 52-len(indicator)) + "\n")
+	} else {
+		sb.WriteString(strings.Repeat("─", 52) + "\n")
+	}
 
 	// ── Transaction list ────────────────────────────────
-	for i, it := range m.items {
+	for i := start; i < end; i++ {
+		it := m.items[i]
+
 		cursorMark := "  "
 		if i == m.cursor {
 			cursorMark = "▶ "
@@ -165,7 +232,13 @@ func (m Model) View() string {
 		sb.WriteString(line + "\n")
 	}
 
-	sb.WriteString(strings.Repeat("─", 52) + "\n")
+	// ── Bottom separator (with scroll-down indicator) ────
+	if below > 0 {
+		indicator := fmt.Sprintf("  ↓ %d more", below)
+		sb.WriteString(strings.Repeat("─", 52-len(indicator)) + indicator + "\n")
+	} else {
+		sb.WriteString(strings.Repeat("─", 52) + "\n")
+	}
 
 	// ── Footer balance ───────────────────────────────────
 	clearedStr := utils.FormatAmount(m.clearedBalance())

--- a/ui/reconcile/model.go
+++ b/ui/reconcile/model.go
@@ -1,0 +1,219 @@
+package reconcileui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/hance08/kea/internal/model"
+	"github.com/hance08/kea/internal/utils"
+)
+
+type listItem struct {
+	entry   *model.ReconcileEntry
+	checked bool
+}
+
+// Model is the bubbletea model for the reconciliation TUI.
+// After tea.Program.Run() returns, inspect Cancelled() and SelectedIDs()
+// to determine the outcome.
+type Model struct {
+	accountName      string
+	statementBalance int64
+	items            []listItem
+	cursor           int
+	confirmPending   bool // waiting for y/n after Enter with non-zero diff
+	cancelled        bool
+	done             bool
+	keys             keyMap
+}
+
+// NewModel constructs the initial reconciliation model.
+func NewModel(accountName string, statementBalance int64, entries []*model.ReconcileEntry) Model {
+	items := make([]listItem, len(entries))
+	for i, e := range entries {
+		items[i] = listItem{entry: e}
+	}
+	return Model{
+		accountName:      accountName,
+		statementBalance: statementBalance,
+		items:            items,
+		keys:             defaultKeyMap(),
+	}
+}
+
+// Cancelled reports whether the user quit without confirming.
+func (m Model) Cancelled() bool { return m.cancelled }
+
+// SelectedIDs returns the transaction IDs the user checked off.
+func (m Model) SelectedIDs() []int64 {
+	var ids []int64
+	for _, it := range m.items {
+		if it.checked {
+			ids = append(ids, it.entry.ID)
+		}
+	}
+	return ids
+}
+
+func (m Model) Init() tea.Cmd { return nil }
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if m.confirmPending {
+			switch {
+			case key.Matches(msg, m.keys.Yes):
+				m.done = true
+				return m, tea.Quit
+			case key.Matches(msg, m.keys.No):
+				m.confirmPending = false
+			}
+			return m, nil
+		}
+		switch {
+		case key.Matches(msg, m.keys.Quit):
+			m.cancelled = true
+			return m, tea.Quit
+		case key.Matches(msg, m.keys.Up):
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case key.Matches(msg, m.keys.Down):
+			if m.cursor < len(m.items)-1 {
+				m.cursor++
+			}
+		case key.Matches(msg, m.keys.Toggle):
+			if len(m.items) > 0 {
+				m.items[m.cursor].checked = !m.items[m.cursor].checked
+			}
+		case key.Matches(msg, m.keys.Confirm):
+			if len(m.items) == 0 {
+				return m, nil
+			}
+			if m.difference() != 0 {
+				m.confirmPending = true
+			} else {
+				m.done = true
+				return m, tea.Quit
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m Model) View() string {
+	if len(m.items) == 0 {
+		return "No unreconciled transactions for this account.\n\nPress q to quit.\n"
+	}
+
+	var sb strings.Builder
+
+	// ── Header ──────────────────────────────────────────
+	diff := m.difference()
+	var badge string
+	if diff == 0 {
+		badge = lipgloss.NewStyle().
+			Padding(0, 1).
+			Background(lipgloss.Color("22")).
+			Foreground(lipgloss.Color("15")).
+			Render("BALANCED")
+	} else {
+		badge = lipgloss.NewStyle().
+			Padding(0, 1).
+			Background(lipgloss.Color("58")).
+			Foreground(lipgloss.Color("15")).
+			Render(fmt.Sprintf("OFF BY $%s", utils.FormatAmount(abs(diff))))
+	}
+
+	accountStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("78"))
+	sb.WriteString(fmt.Sprintf("%-40s %s\n\n", accountStyle.Render(m.accountName), badge))
+
+	stmtStr := utils.FormatAmount(m.statementBalance)
+	sb.WriteString(fmt.Sprintf("STATEMENT: $%s · %d UNRECONCILED\n", stmtStr, len(m.items)))
+	sb.WriteString(strings.Repeat("─", 52) + "\n")
+
+	// ── Transaction list ────────────────────────────────
+	for i, it := range m.items {
+		checkbox := "[ ]"
+		rowStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+		if it.checked {
+			checkbox = "[✓]"
+			rowStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("78"))
+		}
+
+		date := time.Unix(it.entry.Timestamp, 0).Format("Jan 02")
+		amt := fmt.Sprintf("$%s", utils.FormatAmount(it.entry.Amount))
+		line := fmt.Sprintf("%s %s  %-28s %10s", checkbox, date, truncate(it.entry.Description, 28), amt)
+
+		if i == m.cursor {
+			line = lipgloss.NewStyle().
+				Background(lipgloss.Color("236")).
+				Foreground(lipgloss.Color("255")).
+				Render(line)
+		} else {
+			line = rowStyle.Render(line)
+		}
+		sb.WriteString(line + "\n")
+	}
+
+	sb.WriteString(strings.Repeat("─", 52) + "\n")
+
+	// ── Footer balance ───────────────────────────────────
+	clearedStr := utils.FormatAmount(m.clearedBalance())
+	diffStr := utils.FormatAmount(abs(diff))
+	remainingStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	if diff == 0 {
+		remainingStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("78"))
+	}
+	sb.WriteString(fmt.Sprintf(
+		"Cleared $%s · %s\n",
+		clearedStr,
+		remainingStyle.Render(fmt.Sprintf("Remaining $%s", diffStr)),
+	))
+
+	// ── Prompt or hint ───────────────────────────────────
+	if m.confirmPending {
+		warnStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+		sb.WriteString(fmt.Sprintf("\n%s\n",
+			warnStyle.Render(fmt.Sprintf("You're off by $%s. Confirm anyway? (y/n)", diffStr)),
+		))
+	} else {
+		sb.WriteString("\nspace toggle · enter finish · ↑↓ navigate · q quit\n")
+	}
+
+	return sb.String()
+}
+
+// ── helpers ─────────────────────────────────────────────
+
+func (m Model) clearedBalance() int64 {
+	var total int64
+	for _, it := range m.items {
+		if it.checked {
+			total += it.entry.Amount
+		}
+	}
+	return total
+}
+
+func (m Model) difference() int64 {
+	return m.statementBalance - m.clearedBalance()
+}
+
+func abs(n int64) int64 {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-1] + "…"
+}

--- a/ui/reconcile/model.go
+++ b/ui/reconcile/model.go
@@ -138,6 +138,11 @@ func (m Model) View() string {
 
 	// ── Transaction list ────────────────────────────────
 	for i, it := range m.items {
+		cursorMark := "  "
+		if i == m.cursor {
+			cursorMark = "▶ "
+		}
+
 		checkbox := "[ ]"
 		rowStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
 		if it.checked {
@@ -147,7 +152,7 @@ func (m Model) View() string {
 
 		date := time.Unix(it.entry.Timestamp, 0).Format("Jan 02")
 		amt := fmt.Sprintf("$%s", utils.FormatAmount(it.entry.Amount))
-		line := fmt.Sprintf("%s %s  %-28s %10s", checkbox, date, truncate(it.entry.Description, 28), amt)
+		line := fmt.Sprintf("%s%s %s  %-26s %10s", cursorMark, checkbox, date, truncate(it.entry.Description, 26), amt)
 
 		if i == m.cursor {
 			line = lipgloss.NewStyle().

--- a/ui/reconcile/model.go
+++ b/ui/reconcile/model.go
@@ -8,9 +8,9 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	rw "github.com/mattn/go-runewidth"
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/utils"
+	rw "github.com/mattn/go-runewidth"
 )
 
 // overheadLines is the number of non-item lines in the view:
@@ -20,17 +20,15 @@ const overheadLines = 8
 
 // Column widths in terminal display columns (accounts for double-wide CJK chars).
 const (
-	colDate   = 8  // "YY-MM-DD"
-	colAcct   = 16 // reconciled account
-	colOffset = 16 // other-side account
+	colOffset = 40 // other-side account
 	colDesc   = 12 // description
 	colAmt    = 12 // amount, right-aligned
 )
 
 // sepWidth is the total display width of separator lines.
-// cursor(2) + checkbox(3) + sp(1) + date(8) + sp(2) + acct(16) + sp(2) +
-// offset(16) + sp(2) + desc(12) + sp(2) + amt(12) = 78
-const sepWidth = 78
+// cursor(2) + checkbox(3) + sp(1) + date(8) + sp(2) +
+// offset(40) + sp(2) + desc(12) + sp(2) + amt(12) = 84
+const sepWidth = 84
 
 type listItem struct {
 	entry   *model.ReconcileEntry
@@ -249,7 +247,6 @@ func (m Model) View() string {
 		amt := fmt.Sprintf("%*s", colAmt, "$"+utils.FormatAmount(it.entry.Amount))
 
 		line := cursorMark + checkbox + " " + date + "  " +
-			padRight(m.accountName, colAcct) + "  " +
 			padRight(it.entry.OffsetAccount, colOffset) + "  " +
 			padRight(it.entry.Description, colDesc) + "  " +
 			amt

--- a/ui/views/transaction_detail.go
+++ b/ui/views/transaction_detail.go
@@ -25,10 +25,7 @@ func (v *TransactionDetailView) Render(input *model.TransactionDetail, isCreate 
 
 	date := time.Unix(input.Timestamp, 0).Format("2006-01-02")
 
-	status := "Cleared"
-	if input.Status == 0 {
-		status = "Pending"
-	}
+	status := input.Status.String()
 
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{})


### PR DESCRIPTION
## Summary

Adds `kea reconcile <account>` for matching internal records against a bank statement. Transactions are marked `StatusReconciled` and become immutable afterward.

## New command

```
kea reconcile <account-name>
kea reconcile Assets:Checking --balance 2450.00 --ids 1,3,7 --force --json
```

**Interactive mode** — bubbletea TUI:
- Scrolling viewport that tracks the cursor (handles large transaction lists)
- Columns: `date · offset account · description · amount` with CJK-aware fixed-width alignment via `go-runewidth`
- `space` toggle · `a` select all / deselect all · `enter` confirm · `q` quit
- Live balance diff with explicit directional labels: `SHORT $X` (red) / `OVER $X` (amber) / `BALANCED` (green)
- `↑ N more` / `↓ N more` scroll indicators in separators

**Non-interactive mode** (`--balance` + `--ids` required) — for scripts and AI agents:
- `--force` skips the balance-mismatch guard
- `--json` emits machine-readable output

## Changes

| Layer | Files | What changed |
|-------|-------|-------------|
| Model | `internal/model/transaction.go` | `ReconcileEntry` struct with `OffsetAccount` field |
| Repository | `internal/repository/interfaces.go` | Two new methods on `TransactionRepository` |
| Service | `internal/service/reconcile_ops.go` | `GetUnreconciledByAccount`, `ReconcileTransactions` |
| Service | `internal/service/transaction_ops.go` | `IsEditable` returns typed `NotEditableReason` instead of magic `int64` |
| Store | `internal/store/sqlite_reconcile.go` | SQL with correlated subquery for offset account; bulk-update in one statement |
| TUI | `ui/reconcile/keys.go`, `model.go` | Full bubbletea model |
| Command | `cmd/reconcile.go`, `cmd/reconcile_actions.go` | Cobra command wiring |
| Bug fix | `cmd/transaction/list.go`, `ui/views/transaction_detail.go` | Use `Status.String()` so reconciled transactions no longer show as "Cleared" |
| Refactor | `cmd/transaction/edit_types.go`, `edit.go` | `EditProvider.IsEditable` uses `service.NotEditableReason` type |

## Test plan

- [ ] `go test ./...` passes
- [ ] `kea reconcile <account>` opens TUI; up/down scrolls through all transactions
- [ ] `space` toggles a row; `a` selects/deselects all; badge updates live
- [ ] Badge shows `SHORT` when cleared < statement, `OVER` when cleared > statement
- [ ] `enter` with non-zero diff shows direction-aware confirm prompt
- [ ] After reconciling, `kea transaction list` shows status `Reconciled` (not `Cleared`)
- [ ] Reconciled transactions cannot be edited or deleted
- [ ] Non-interactive: `kea reconcile <account> --balance 2450 --ids 1,2` works without TUI
- [ ] `--force` bypasses balance mismatch; `--json` emits JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)