### PR TITLE
fix(reconcile): track reconciliation at split level, not transaction level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ _output/
 
 kea_test
 TODO
+.superpowers/

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -55,6 +55,11 @@ type TransactionRepository interface {
 	// in a single atomic UPDATE. Returns an error if the affected row count
 	// does not match len(txIDs).
 	BulkUpdateTransactionStatus(txIDs []int64, status model.TransactionStatus) error
+
+	// MarkSplitsReconciledByAccount marks the splits for accountID in each of
+	// the listed transactions as reconciled. If all splits in a transaction are
+	// now reconciled the transaction's status is upgraded to StatusReconciled.
+	MarkSplitsReconciledByAccount(accountID int64, txIDs []int64) error
 }
 
 type Repository interface {

--- a/internal/service/reconcile_ops.go
+++ b/internal/service/reconcile_ops.go
@@ -56,8 +56,9 @@ func (ts *TransactionService) ReconcileTransactions(accountID int64, statementBa
 		clearedBalance += amount
 	}
 
-	// 4. Atomically mark all selected transactions as reconciled.
-	if err := ts.txRepo.BulkUpdateTransactionStatus(txIDs, model.StatusReconciled); err != nil {
+	// 4. Mark the account's splits as reconciled (split-level tracking so that
+	// multi-account transactions remain visible for other accounts).
+	if err := ts.txRepo.MarkSplitsReconciledByAccount(accountID, txIDs); err != nil {
 		return 0, fmt.Errorf("failed to reconcile transactions: %w", err)
 	}
 

--- a/internal/service/reconcile_ops_test.go
+++ b/internal/service/reconcile_ops_test.go
@@ -31,8 +31,8 @@ func TestReconcileTransactions_ZeroDifference(t *testing.T) {
 	if diff != 0 {
 		t.Errorf("expected difference 0, got %d", diff)
 	}
-	if len(txRepo.bulkUpdateCalls) != 1 {
-		t.Errorf("expected 1 bulk update call, got %d", len(txRepo.bulkUpdateCalls))
+	if len(txRepo.markSplitsReconciledCalls) != 1 {
+		t.Errorf("expected 1 MarkSplitsReconciledByAccount call, got %d", len(txRepo.markSplitsReconciledCalls))
 	}
 }
 
@@ -55,8 +55,8 @@ func TestReconcileTransactions_NonZeroDifference(t *testing.T) {
 	if diff != 20000 {
 		t.Errorf("expected difference 20000, got %d", diff)
 	}
-	if len(txRepo.bulkUpdateCalls) != 1 {
-		t.Fatalf("expected bulk update to be called")
+	if len(txRepo.markSplitsReconciledCalls) != 1 {
+		t.Fatalf("expected MarkSplitsReconciledByAccount to be called")
 	}
 }
 
@@ -75,8 +75,8 @@ func TestReconcileTransactions_UnknownTxID(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unknown transaction ID, got nil")
 	}
-	if len(txRepo.bulkUpdateCalls) != 0 {
-		t.Error("bulk update must not be called when validation fails")
+	if len(txRepo.markSplitsReconciledCalls) != 0 {
+		t.Error("MarkSplitsReconciledByAccount must not be called when validation fails")
 	}
 }
 
@@ -96,8 +96,8 @@ func TestReconcileTransactions_AlreadyReconciledID(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for already-reconciled ID, got nil")
 	}
-	if len(txRepo.bulkUpdateCalls) != 0 {
-		t.Error("bulk update must not be called when validation fails")
+	if len(txRepo.markSplitsReconciledCalls) != 0 {
+		t.Error("MarkSplitsReconciledByAccount must not be called when validation fails")
 	}
 }
 
@@ -113,8 +113,8 @@ func TestReconcileTransactions_EmptyIDs(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty IDs, got nil")
 	}
-	if len(txRepo.bulkUpdateCalls) != 0 {
-		t.Error("bulk update must not be called when IDs are empty")
+	if len(txRepo.markSplitsReconciledCalls) != 0 {
+		t.Error("MarkSplitsReconciledByAccount must not be called when IDs are empty")
 	}
 }
 
@@ -130,7 +130,7 @@ func TestReconcileTransactions_AccountNotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unknown account, got nil")
 	}
-	if len(txRepo.bulkUpdateCalls) != 0 {
-		t.Error("bulk update must not be called when account lookup fails")
+	if len(txRepo.markSplitsReconciledCalls) != 0 {
+		t.Error("MarkSplitsReconciledByAccount must not be called when account lookup fails")
 	}
 }

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -202,6 +202,11 @@ type mockTransactionRepo struct {
 	unreconciledByAccountErr map[int64]error
 	bulkUpdateErr            error
 	bulkUpdateCalls          [][]int64
+	markSplitsReconciledErr  error
+	markSplitsReconciledCalls []struct {
+		accountID int64
+		txIDs     []int64
+	}
 }
 
 func newMockTransactionRepo() *mockTransactionRepo {
@@ -375,6 +380,19 @@ func (m *mockTransactionRepo) BulkUpdateTransactionStatus(txIDs []int64, status 
 			tx.Status = status
 		}
 	}
+	return nil
+}
+
+func (m *mockTransactionRepo) MarkSplitsReconciledByAccount(accountID int64, txIDs []int64) error {
+	if m.markSplitsReconciledErr != nil {
+		return m.markSplitsReconciledErr
+	}
+	ids := make([]int64, len(txIDs))
+	copy(ids, txIDs)
+	m.markSplitsReconciledCalls = append(m.markSplitsReconciledCalls, struct {
+		accountID int64
+		txIDs     []int64
+	}{accountID, ids})
 	return nil
 }
 

--- a/internal/store/sqlite_reconcile.go
+++ b/internal/store/sqlite_reconcile.go
@@ -7,10 +7,12 @@ import (
 	"github.com/hance08/kea/internal/model"
 )
 
-// GetUnreconciledTransactionsByAccount returns all Pending (0) and Cleared (1)
-// transactions that have a split on accountID, together with the net split
-// amount for that account (grouped to handle rare multi-split-per-account cases).
-// Results are ordered by timestamp ASC so the TUI shows chronological order.
+// GetUnreconciledTransactionsByAccount returns all transactions that have an
+// unreconciled split on accountID (splits.reconciled = 0), together with the
+// net split amount for that account (grouped to handle rare multi-split-per-account
+// cases). Filtering on the split flag — rather than the transaction status —
+// ensures multi-account transactions remain visible for other accounts after one
+// account has already been reconciled. Results are ordered by timestamp ASC.
 func (s *Store) GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.ReconcileEntry, error) {
 	rows, err := s.db.Query(`
         SELECT
@@ -36,7 +38,7 @@ func (s *Store) GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.
         FROM transactions t
         INNER JOIN splits s ON t.id = s.transaction_id
         WHERE s.account_id = ?
-          AND t.status IN (0, 1)
+          AND s.reconciled = 0
         GROUP BY t.id, t.timestamp, t.description, t.status
         ORDER BY t.timestamp ASC, t.id ASC
     `, accountID, accountID, accountID)
@@ -57,6 +59,71 @@ func (s *Store) GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.
 		return nil, fmt.Errorf("rows iteration error: %w", err)
 	}
 	return result, nil
+}
+
+// MarkSplitsReconciledByAccount marks the splits for accountID in each of the
+// listed transactions as reconciled (splits.reconciled = 1). After updating the
+// splits it checks whether every split in each affected transaction is now
+// reconciled; if so the transaction's status is upgraded to StatusReconciled.
+// This is intentionally two separate statements (not wrapped in a store-level
+// transaction) because the status upgrade is a derived convenience — the split
+// flag is the source of truth.
+func (s *Store) MarkSplitsReconciledByAccount(accountID int64, txIDs []int64) error {
+	if len(txIDs) == 0 {
+		return nil
+	}
+
+	placeholders := strings.Repeat("?,", len(txIDs))
+	placeholders = placeholders[:len(placeholders)-1]
+
+	// 1. Mark the account's splits as reconciled.
+	splitArgs := make([]any, 0, len(txIDs)+1)
+	splitArgs = append(splitArgs, accountID)
+	for _, id := range txIDs {
+		splitArgs = append(splitArgs, id)
+	}
+	splitQuery := fmt.Sprintf(
+		"UPDATE splits SET reconciled = 1 WHERE account_id = ? AND transaction_id IN (%s)",
+		placeholders,
+	)
+	if _, err := s.db.Exec(splitQuery, splitArgs...); err != nil {
+		return fmt.Errorf("failed to mark splits as reconciled: %w", err)
+	}
+
+	// 2. Find transactions where ALL splits are now reconciled.
+	txArgs := make([]any, len(txIDs))
+	for i, id := range txIDs {
+		txArgs[i] = id
+	}
+	fullyQuery := fmt.Sprintf(`
+		SELECT transaction_id FROM splits
+		WHERE transaction_id IN (%s)
+		GROUP BY transaction_id
+		HAVING MIN(reconciled) = 1
+	`, placeholders)
+	rows, err := s.db.Query(fullyQuery, txArgs...)
+	if err != nil {
+		return fmt.Errorf("failed to check fully reconciled transactions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var fullyReconciled []int64
+	for rows.Next() {
+		var txID int64
+		if err := rows.Scan(&txID); err != nil {
+			return fmt.Errorf("failed to scan transaction ID: %w", err)
+		}
+		fullyReconciled = append(fullyReconciled, txID)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("rows iteration error: %w", err)
+	}
+
+	// 3. Upgrade the status of fully-reconciled transactions.
+	if len(fullyReconciled) == 0 {
+		return nil
+	}
+	return s.BulkUpdateTransactionStatus(fullyReconciled, model.StatusReconciled)
 }
 
 // BulkUpdateTransactionStatus sets the status of all listed transaction IDs

--- a/migrations/0003_add_split_reconciled.up.sql
+++ b/migrations/0003_add_split_reconciled.up.sql
@@ -1,0 +1,5 @@
+-- Track reconciliation at the split level so that multi-account transactions
+-- (transfers, split expenses) can be reconciled independently per account.
+ALTER TABLE splits ADD COLUMN reconciled INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_splits_reconciled ON splits (reconciled);


### PR DESCRIPTION
## Summary

- Multi-account transactions (transfers, split expenses like `Expense +200 / AccountA -100 / AccountB -100`) would vanish from other accounts' reconcile lists after being reconciled from one account, because the whole transaction row was marked `status = Reconciled`
- Added `splits.reconciled` column (migration `0003`) as the source of truth for per-account reconciliation state
- `GetUnreconciledTransactionsByAccount` now filters on `s.reconciled = 0` instead of `t.status IN (0, 1)`, so each account sees its own unreconciled splits independently
- New `MarkSplitsReconciledByAccount` marks only the queried account's splits; transaction status is upgraded to `Reconciled` only when every split in the transaction is marked

## Test plan

- [ ] Run `go test ./...` — all tests pass
- [ ] Create a 3-way split transaction (e.g. Expense +200, AccountA -100, AccountB -100)
- [ ] Reconcile AccountA — transaction should disappear from AccountA's list but **remain** in AccountB's list
- [ ] Reconcile AccountB — transaction should now disappear from AccountB's list and the transaction status should be upgraded to Reconciled
- [ ] Verify transfer transactions behave the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)