### PR TITLE
fix(reconcile): upgrade transaction status as soon as any split is reconciled

### DIFF
--- a/internal/store/sqlite_reconcile.go
+++ b/internal/store/sqlite_reconcile.go
@@ -62,12 +62,16 @@ func (s *Store) GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.
 }
 
 // MarkSplitsReconciledByAccount marks the splits for accountID in each of the
-// listed transactions as reconciled (splits.reconciled = 1). After updating the
-// splits it checks whether every split in each affected transaction is now
-// reconciled; if so the transaction's status is upgraded to StatusReconciled.
-// This is intentionally two separate statements (not wrapped in a store-level
-// transaction) because the status upgrade is a derived convenience — the split
-// flag is the source of truth.
+// listed transactions as reconciled (splits.reconciled = 1), then upgrades
+// every affected transaction's status to StatusReconciled.
+//
+// The transaction status is upgraded as soon as any split is reconciled — not
+// only when all splits are reconciled. Expense, Revenue, and Equity accounts
+// are never reconciled against statements, so requiring all splits to be marked
+// would mean ordinary expense transactions could never reach StatusReconciled.
+// The reconcile TUI filters on s.reconciled = 0 (not t.status), so marking the
+// transaction Reconciled here does not hide it from other accounts that still
+// need to reconcile their own splits.
 func (s *Store) MarkSplitsReconciledByAccount(accountID int64, txIDs []int64) error {
 	if len(txIDs) == 0 {
 		return nil
@@ -90,40 +94,8 @@ func (s *Store) MarkSplitsReconciledByAccount(accountID int64, txIDs []int64) er
 		return fmt.Errorf("failed to mark splits as reconciled: %w", err)
 	}
 
-	// 2. Find transactions where ALL splits are now reconciled.
-	txArgs := make([]any, len(txIDs))
-	for i, id := range txIDs {
-		txArgs[i] = id
-	}
-	fullyQuery := fmt.Sprintf(`
-		SELECT transaction_id FROM splits
-		WHERE transaction_id IN (%s)
-		GROUP BY transaction_id
-		HAVING MIN(reconciled) = 1
-	`, placeholders)
-	rows, err := s.db.Query(fullyQuery, txArgs...)
-	if err != nil {
-		return fmt.Errorf("failed to check fully reconciled transactions: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var fullyReconciled []int64
-	for rows.Next() {
-		var txID int64
-		if err := rows.Scan(&txID); err != nil {
-			return fmt.Errorf("failed to scan transaction ID: %w", err)
-		}
-		fullyReconciled = append(fullyReconciled, txID)
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("rows iteration error: %w", err)
-	}
-
-	// 3. Upgrade the status of fully-reconciled transactions.
-	if len(fullyReconciled) == 0 {
-		return nil
-	}
-	return s.BulkUpdateTransactionStatus(fullyReconciled, model.StatusReconciled)
+	// 2. Upgrade all affected transactions to StatusReconciled.
+	return s.BulkUpdateTransactionStatus(txIDs, model.StatusReconciled)
 }
 
 // BulkUpdateTransactionStatus sets the status of all listed transaction IDs


### PR DESCRIPTION
## Summary

- After reconciling a simple 2-split transaction (e.g. `Expense +100 / AccountA -100`), the transaction still appeared editable in the transaction list and did not show status "Reconciled"
- Root cause: the previous logic required **all** splits in a transaction to have `reconciled = 1` before upgrading `transactions.status`. Expense/Revenue/Equity splits are never independently reconciled against statements, so this condition could never be met for ordinary transactions
- Fix: upgrade the transaction status to `StatusReconciled` immediately when **any** split is reconciled — i.e. for all transactions in the reconciled batch
- The reconcile TUI is unaffected: it filters on `s.reconciled = 0` (not `t.status`), so other accounts' unreconciled splits remain visible even after the transaction status is upgraded

## Why this is safe for multi-account transactions

The PR #15 fix (split-level tracking) already decoupled the reconcile TUI from `t.status`. For a transfer `AccountA -100 / AccountB +100`:
- Reconcile AccountA → AccountA split `reconciled=1`, transaction status → `Reconciled`
- AccountB's split is still `reconciled=0` → it **still appears** in AccountB's reconcile list ✓

## Test plan

- [ ] `go test ./...` passes
- [ ] Reconcile a simple expense transaction (2 splits) — verify it shows "Reconciled" in the transaction list afterward and cannot be edited
- [ ] Verify transfer transactions still work: reconciling AccountA leaves AccountB's entry visible in AccountB's reconcile list

🤖 Generated with [Claude Code](https://claude.com/claude-code)