### PR TITLE
feat(reconcile): track last reconciled balance per account

### DIFF
--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -13,7 +13,7 @@ type reconcileAccountProvider interface {
 
 // reconcileTxProvider is the subset of TransactionService used by the runner.
 type reconcileTxProvider interface {
-	GetUnreconciledByAccount(accountID int64) ([]*model.ReconcileEntry, error)
+	GetUnreconciledByAccount(accountID int64) ([]*model.ReconcileEntry, int64, error)
 	ReconcileTransactions(accountID int64, statementBalance int64, txIDs []int64) (int64, error)
 }
 

--- a/cmd/reconcile_actions.go
+++ b/cmd/reconcile_actions.go
@@ -85,14 +85,14 @@ func (r *reconcileRunner) runInteractive(acc *model.Account) error {
 		return fmt.Errorf("invalid balance: %w", err)
 	}
 
-	// 2. Load unreconciled entries.
-	entries, err := r.txSvc.GetUnreconciledByAccount(acc.ID)
+	// 2. Load unreconciled entries and the last reconciled balance.
+	entries, lastReconciledBalance, err := r.txSvc.GetUnreconciledByAccount(acc.ID)
 	if err != nil {
 		return err
 	}
 
 	// 3. Run bubbletea TUI.
-	m := reconcileui.NewModel(acc.Name, statementBalance, entries)
+	m := reconcileui.NewModel(acc.Name, statementBalance, lastReconciledBalance, entries)
 	prog := tea.NewProgram(m, tea.WithAltScreen())
 	finalRaw, err := prog.Run()
 	if err != nil {

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -60,6 +60,15 @@ type TransactionRepository interface {
 	// the listed transactions as reconciled. If all splits in a transaction are
 	// now reconciled the transaction's status is upgraded to StatusReconciled.
 	MarkSplitsReconciledByAccount(accountID int64, txIDs []int64) error
+
+	// GetLastReconciledBalance returns the running reconciled balance for
+	// accountID as persisted after the most recent successful reconcile.
+	// Returns 0 if the account has never been reconciled.
+	GetLastReconciledBalance(accountID int64) (int64, error)
+
+	// SetLastReconciledBalance persists the new running reconciled balance for
+	// accountID. Uses an upsert so the first call creates the row.
+	SetLastReconciledBalance(accountID int64, balance int64) error
 }
 
 type Repository interface {

--- a/internal/service/reconcile_ops.go
+++ b/internal/service/reconcile_ops.go
@@ -6,25 +6,38 @@ import (
 	"github.com/hance08/kea/internal/model"
 )
 
-// GetUnreconciledByAccount returns all Pending/Cleared transactions that
-// have a split touching the given account, including the split amount for
-// that account. Used to populate the reconciliation TUI.
-func (ts *TransactionService) GetUnreconciledByAccount(accountID int64) ([]*model.ReconcileEntry, error) {
+// GetUnreconciledByAccount returns all Pending/Cleared transactions that have
+// a split touching the given account, together with the account's last
+// reconciled balance. Used to populate the reconciliation TUI.
+//
+// The last reconciled balance is 0 if the account has never been reconciled.
+func (ts *TransactionService) GetUnreconciledByAccount(accountID int64) ([]*model.ReconcileEntry, int64, error) {
 	entries, err := ts.txRepo.GetUnreconciledTransactionsByAccount(accountID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load unreconciled transactions: %w", err)
+		return nil, 0, fmt.Errorf("failed to load unreconciled transactions: %w", err)
 	}
-	return entries, nil
+	lastBalance, err := ts.txRepo.GetLastReconciledBalance(accountID)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to load last reconciled balance: %w", err)
+	}
+	return entries, lastBalance, nil
 }
 
 // ReconcileTransactions marks the given transaction IDs as reconciled for
 // accountID. It validates that every requested ID is in the unreconciled set
 // for that account before writing anything.
 //
-// Returns the difference between statementBalance and the sum of the selected
-// split amounts for accountID. A non-zero difference is informational — the
-// method always commits if the IDs are valid. The caller decides whether to
-// warn (non-zero diff) or proceed silently (zero diff).
+// The returned difference is:
+//
+//	statementBalance − (lastReconciledBalance + clearedBalance)
+//
+// where clearedBalance is the sum of splits the caller selected in this
+// session. A zero difference means the selected transactions exactly bridge
+// the gap between the last reconciled balance and the new bank statement.
+//
+// The new running reconciled balance (lastReconciledBalance + clearedBalance)
+// is always persisted after a successful reconcile — regardless of whether the
+// difference is zero. The caller decides whether to warn on a non-zero diff.
 func (ts *TransactionService) ReconcileTransactions(accountID int64, statementBalance int64, txIDs []int64) (int64, error) {
 	if len(txIDs) == 0 {
 		return 0, fmt.Errorf("no transactions selected for reconciliation")
@@ -35,18 +48,24 @@ func (ts *TransactionService) ReconcileTransactions(accountID int64, statementBa
 		return 0, fmt.Errorf("account not found: %w", err)
 	}
 
-	// 2. Fetch unreconciled transactions and build a valid-ID → amount map.
+	// 2. Fetch last reconciled balance.
+	lastBalance, err := ts.txRepo.GetLastReconciledBalance(accountID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to load last reconciled balance: %w", err)
+	}
+
+	// 3. Fetch unreconciled transactions and build a valid-ID → amount map.
 	entries, err := ts.txRepo.GetUnreconciledTransactionsByAccount(accountID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to load unreconciled transactions: %w", err)
 	}
 
-	validAmounts := make(map[int64]int64, len(entries)) // txID → split amount
+	validAmounts := make(map[int64]int64, len(entries))
 	for _, e := range entries {
 		validAmounts[e.ID] = e.Amount
 	}
 
-	// 3. Validate every requested ID and accumulate the cleared balance.
+	// 4. Validate every requested ID and accumulate the cleared balance.
 	var clearedBalance int64
 	for _, id := range txIDs {
 		amount, ok := validAmounts[id]
@@ -56,11 +75,17 @@ func (ts *TransactionService) ReconcileTransactions(accountID int64, statementBa
 		clearedBalance += amount
 	}
 
-	// 4. Mark the account's splits as reconciled (split-level tracking so that
+	// 5. Mark the account's splits as reconciled (split-level tracking so that
 	// multi-account transactions remain visible for other accounts).
 	if err := ts.txRepo.MarkSplitsReconciledByAccount(accountID, txIDs); err != nil {
 		return 0, fmt.Errorf("failed to reconcile transactions: %w", err)
 	}
 
-	return statementBalance - clearedBalance, nil
+	// 6. Persist the new running reconciled balance.
+	newBalance := lastBalance + clearedBalance
+	if err := ts.txRepo.SetLastReconciledBalance(accountID, newBalance); err != nil {
+		return 0, fmt.Errorf("failed to persist reconciled balance: %w", err)
+	}
+
+	return statementBalance - newBalance, nil
 }

--- a/internal/service/reconcile_ops_test.go
+++ b/internal/service/reconcile_ops_test.go
@@ -6,12 +6,14 @@ import (
 	"github.com/hance08/kea/internal/model"
 )
 
-// helper: build a ReconcileEntry slice for a given accountID in the mock
+// seedUnreconciled injects unreconciled entries into the mock for accountID.
 func seedUnreconciled(txRepo *mockTransactionRepo, accountID int64, entries []*model.ReconcileEntry) {
 	txRepo.unreconciledByAccount[accountID] = entries
 }
 
-func TestReconcileTransactions_ZeroDifference(t *testing.T) {
+// ── GetUnreconciledByAccount ──────────────────────────────────────────────────
+
+func TestGetUnreconciledByAccount_ReturnsEntriesAndBalance(t *testing.T) {
 	accRepo := newMockAccountRepo()
 	txRepo := newMockTransactionRepo()
 	svc := newTestTransactionService(accRepo, txRepo)
@@ -19,20 +21,123 @@ func TestReconcileTransactions_ZeroDifference(t *testing.T) {
 	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
 	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
 		{ID: 10, Timestamp: 1000, Description: "Salary", Status: model.StatusCleared, Amount: 100000},
-		{ID: 11, Timestamp: 1001, Description: "Rent", Status: model.StatusCleared, Amount: -50000},
 	})
+	txRepo.lastReconciledBalances[1] = 50000
 
-	// statementBalance = 50000 = 100000 + (-50000)
+	entries, lastBal, err := svc.GetUnreconciledByAccount(1)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(entries))
+	}
+	if lastBal != 50000 {
+		t.Errorf("expected lastReconciledBalance 50000, got %d", lastBal)
+	}
+}
+
+func TestGetUnreconciledByAccount_FirstTime_ReturnsZeroBalance(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	// no entry in lastReconciledBalances → mock returns 0
+
+	_, lastBal, err := svc.GetUnreconciledByAccount(1)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if lastBal != 0 {
+		t.Errorf("expected 0 for first reconcile, got %d", lastBal)
+	}
+}
+
+// ── ReconcileTransactions ─────────────────────────────────────────────────────
+
+func TestReconcileTransactions_FirstReconcile_ZeroDifference(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
+		{ID: 10, Amount: 100000},
+		{ID: 11, Amount: -50000},
+	})
+	// No prior balance (first reconcile) → lastReconciledBalance = 0.
+	// Cleared = 100000 + (-50000) = 50000; statementBalance = 50000 → diff = 0.
+
 	diff, err := svc.ReconcileTransactions(1, 50000, []int64{10, 11})
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if diff != 0 {
-		t.Errorf("expected difference 0, got %d", diff)
+		t.Errorf("expected diff 0, got %d", diff)
 	}
-	if len(txRepo.markSplitsReconciledCalls) != 1 {
-		t.Errorf("expected 1 MarkSplitsReconciledByAccount call, got %d", len(txRepo.markSplitsReconciledCalls))
+	// New last reconciled balance should be 0 + 50000 = 50000.
+	if txRepo.lastReconciledBalances[1] != 50000 {
+		t.Errorf("expected persisted balance 50000, got %d", txRepo.lastReconciledBalances[1])
+	}
+	if len(txRepo.setLastReconciledBalCalls) != 1 {
+		t.Errorf("expected 1 SetLastReconciledBalance call, got %d", len(txRepo.setLastReconciledBalCalls))
+	}
+}
+
+func TestReconcileTransactions_SubsequentReconcile_CarriedBalance(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
+		{ID: 20, Amount: -15000}, // expense of $150
+	})
+	// lastReconciledBalance = 20000 ($200 from prior session).
+	txRepo.lastReconciledBalances[1] = 20000
+	// Bank now shows $50: diff = 5000 − (20000 + (−15000)) = 5000 − 5000 = 0.
+
+	diff, err := svc.ReconcileTransactions(1, 5000, []int64{20})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff != 0 {
+		t.Errorf("expected diff 0, got %d", diff)
+	}
+	// New last reconciled balance = 20000 + (−15000) = 5000.
+	if txRepo.lastReconciledBalances[1] != 5000 {
+		t.Errorf("expected persisted balance 5000, got %d", txRepo.lastReconciledBalances[1])
+	}
+}
+
+func TestReconcileTransactions_ForcedReconcile_PersistsActualCleared(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
+		{ID: 30, Amount: 20000}, // $200 transactions
+	})
+	// No prior balance. User enters $150 (bank shows $150) but cleared $200 — forced.
+	// diff = 15000 − (0 + 20000) = −5000 (OVER $50).
+	// Regardless of force, the service always reconciles and persists lastBal+cleared = 20000.
+
+	diff, err := svc.ReconcileTransactions(1, 15000, []int64{30})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff != -5000 {
+		t.Errorf("expected diff -5000, got %d", diff)
+	}
+	// Persisted balance should be 0 + 20000 = 20000 (actual cleared, not statementBalance).
+	if txRepo.lastReconciledBalances[1] != 20000 {
+		t.Errorf("expected persisted balance 20000, got %d", txRepo.lastReconciledBalances[1])
 	}
 }
 
@@ -43,17 +148,17 @@ func TestReconcileTransactions_NonZeroDifference(t *testing.T) {
 
 	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
 	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
-		{ID: 10, Timestamp: 1000, Description: "Salary", Status: model.StatusCleared, Amount: 100000},
+		{ID: 10, Amount: 100000},
 	})
+	// lastBal = 0; cleared = 100000; statementBalance = 120000 → diff = 20000 (SHORT).
 
-	// statementBalance = 120000, but we're only reconciling 100000 → diff = 20000
 	diff, err := svc.ReconcileTransactions(1, 120000, []int64{10})
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if diff != 20000 {
-		t.Errorf("expected difference 20000, got %d", diff)
+		t.Errorf("expected diff 20000, got %d", diff)
 	}
 	if len(txRepo.markSplitsReconciledCalls) != 1 {
 		t.Fatalf("expected MarkSplitsReconciledByAccount to be called")
@@ -67,16 +172,19 @@ func TestReconcileTransactions_UnknownTxID(t *testing.T) {
 
 	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
 	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
-		{ID: 10, Timestamp: 1000, Description: "Salary", Status: model.StatusCleared, Amount: 100000},
+		{ID: 10, Amount: 100000},
 	})
 
-	_, err := svc.ReconcileTransactions(1, 100000, []int64{10, 99}) // 99 is unknown
+	_, err := svc.ReconcileTransactions(1, 100000, []int64{10, 99})
 
 	if err == nil {
 		t.Fatal("expected error for unknown transaction ID, got nil")
 	}
 	if len(txRepo.markSplitsReconciledCalls) != 0 {
 		t.Error("MarkSplitsReconciledByAccount must not be called when validation fails")
+	}
+	if len(txRepo.setLastReconciledBalCalls) != 0 {
+		t.Error("SetLastReconciledBalance must not be called when validation fails")
 	}
 }
 
@@ -86,18 +194,17 @@ func TestReconcileTransactions_AlreadyReconciledID(t *testing.T) {
 	svc := newTestTransactionService(accRepo, txRepo)
 
 	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
-	// unreconciledByAccount does NOT contain ID 20 (it's already reconciled)
 	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
-		{ID: 10, Timestamp: 1000, Description: "Salary", Status: model.StatusCleared, Amount: 100000},
+		{ID: 10, Amount: 100000},
 	})
 
-	_, err := svc.ReconcileTransactions(1, 100000, []int64{10, 20}) // 20 not in unreconciled set
+	_, err := svc.ReconcileTransactions(1, 100000, []int64{10, 20})
 
 	if err == nil {
 		t.Fatal("expected error for already-reconciled ID, got nil")
 	}
-	if len(txRepo.markSplitsReconciledCalls) != 0 {
-		t.Error("MarkSplitsReconciledByAccount must not be called when validation fails")
+	if len(txRepo.setLastReconciledBalCalls) != 0 {
+		t.Error("SetLastReconciledBalance must not be called when validation fails")
 	}
 }
 
@@ -113,9 +220,6 @@ func TestReconcileTransactions_EmptyIDs(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty IDs, got nil")
 	}
-	if len(txRepo.markSplitsReconciledCalls) != 0 {
-		t.Error("MarkSplitsReconciledByAccount must not be called when IDs are empty")
-	}
 }
 
 func TestReconcileTransactions_AccountNotFound(t *testing.T) {
@@ -123,14 +227,12 @@ func TestReconcileTransactions_AccountNotFound(t *testing.T) {
 	txRepo := newMockTransactionRepo()
 	svc := newTestTransactionService(accRepo, txRepo)
 
-	// account ID 99 does not exist in accRepo
-
 	_, err := svc.ReconcileTransactions(99, 100000, []int64{10})
 
 	if err == nil {
 		t.Fatal("expected error for unknown account, got nil")
 	}
-	if len(txRepo.markSplitsReconciledCalls) != 0 {
-		t.Error("MarkSplitsReconciledByAccount must not be called when account lookup fails")
+	if len(txRepo.setLastReconciledBalCalls) != 0 {
+		t.Error("SetLastReconciledBalance must not be called when account lookup fails")
 	}
 }

--- a/internal/service/reconcile_ops_test.go
+++ b/internal/service/reconcile_ops_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hance08/kea/internal/model"
@@ -234,5 +235,62 @@ func TestReconcileTransactions_AccountNotFound(t *testing.T) {
 	}
 	if len(txRepo.setLastReconciledBalCalls) != 0 {
 		t.Error("SetLastReconciledBalance must not be called when account lookup fails")
+	}
+}
+
+func TestReconcileTransactions_GetLastReconciledBalance_Error(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	txRepo.getLastReconciledBalErr[1] = fmt.Errorf("db error")
+
+	_, err := svc.ReconcileTransactions(1, 50000, []int64{10})
+
+	if err == nil {
+		t.Fatal("expected error when GetLastReconciledBalance fails")
+	}
+	if len(txRepo.markSplitsReconciledCalls) != 0 {
+		t.Error("MarkSplitsReconciledByAccount must not be called on GetLastReconciledBalance error")
+	}
+	if len(txRepo.setLastReconciledBalCalls) != 0 {
+		t.Error("SetLastReconciledBalance must not be called on GetLastReconciledBalance error")
+	}
+}
+
+func TestReconcileTransactions_SetLastReconciledBalance_Error(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
+		{ID: 10, Amount: 50000},
+	})
+	txRepo.setLastReconciledBalErr[1] = fmt.Errorf("persist error")
+
+	_, err := svc.ReconcileTransactions(1, 50000, []int64{10})
+
+	if err == nil {
+		t.Fatal("expected error when SetLastReconciledBalance fails")
+	}
+	if len(txRepo.markSplitsReconciledCalls) != 1 {
+		t.Error("MarkSplitsReconciledByAccount should have been called before the error")
+	}
+}
+
+func TestGetUnreconciledByAccount_GetLastReconciledBalance_Error(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	txRepo.getLastReconciledBalErr[1] = fmt.Errorf("db error")
+
+	_, _, err := svc.GetUnreconciledByAccount(1)
+
+	if err == nil {
+		t.Fatal("expected error when GetLastReconciledBalance fails in GetUnreconciledByAccount")
 	}
 }

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -209,9 +209,12 @@ type mockTransactionRepo struct {
 	}
 
 	// last reconciled balance support
-	lastReconciledBalances map[int64]int64
-	getLastReconciledErr   error
-	setLastReconciledErr   error
+	lastReconciledBalances    map[int64]int64
+	getLastReconciledBalErr   map[int64]error
+	setLastReconciledBalCalls []struct {
+		accountID int64
+		balance   int64
+	}
 }
 
 func newMockTransactionRepo() *mockTransactionRepo {
@@ -223,6 +226,7 @@ func newMockTransactionRepo() *mockTransactionRepo {
 		unreconciledByAccount:    make(map[int64][]*model.ReconcileEntry),
 		unreconciledByAccountErr: make(map[int64]error),
 		lastReconciledBalances:   make(map[int64]int64),
+		getLastReconciledBalErr:  make(map[int64]error),
 		nextTxID:                 1,
 		nextSplitID:              100,
 	}
@@ -403,17 +407,18 @@ func (m *mockTransactionRepo) MarkSplitsReconciledByAccount(accountID int64, txI
 }
 
 func (m *mockTransactionRepo) GetLastReconciledBalance(accountID int64) (int64, error) {
-	if m.getLastReconciledErr != nil {
-		return 0, m.getLastReconciledErr
+	if err, ok := m.getLastReconciledBalErr[accountID]; ok {
+		return 0, err
 	}
 	return m.lastReconciledBalances[accountID], nil
 }
 
 func (m *mockTransactionRepo) SetLastReconciledBalance(accountID int64, balance int64) error {
-	if m.setLastReconciledErr != nil {
-		return m.setLastReconciledErr
-	}
 	m.lastReconciledBalances[accountID] = balance
+	m.setLastReconciledBalCalls = append(m.setLastReconciledBalCalls, struct {
+		accountID int64
+		balance   int64
+	}{accountID, balance})
 	return nil
 }
 

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -207,6 +207,11 @@ type mockTransactionRepo struct {
 		accountID int64
 		txIDs     []int64
 	}
+
+	// last reconciled balance support
+	lastReconciledBalances map[int64]int64
+	getLastReconciledErr   error
+	setLastReconciledErr   error
 }
 
 func newMockTransactionRepo() *mockTransactionRepo {
@@ -217,6 +222,7 @@ func newMockTransactionRepo() *mockTransactionRepo {
 		splitsWithAccts:          make(map[int64][]model.SplitDetail),
 		unreconciledByAccount:    make(map[int64][]*model.ReconcileEntry),
 		unreconciledByAccountErr: make(map[int64]error),
+		lastReconciledBalances:   make(map[int64]int64),
 		nextTxID:                 1,
 		nextSplitID:              100,
 	}
@@ -393,6 +399,21 @@ func (m *mockTransactionRepo) MarkSplitsReconciledByAccount(accountID int64, txI
 		accountID int64
 		txIDs     []int64
 	}{accountID, ids})
+	return nil
+}
+
+func (m *mockTransactionRepo) GetLastReconciledBalance(accountID int64) (int64, error) {
+	if m.getLastReconciledErr != nil {
+		return 0, m.getLastReconciledErr
+	}
+	return m.lastReconciledBalances[accountID], nil
+}
+
+func (m *mockTransactionRepo) SetLastReconciledBalance(accountID int64, balance int64) error {
+	if m.setLastReconciledErr != nil {
+		return m.setLastReconciledErr
+	}
+	m.lastReconciledBalances[accountID] = balance
 	return nil
 }
 

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -215,6 +215,7 @@ type mockTransactionRepo struct {
 		accountID int64
 		balance   int64
 	}
+	setLastReconciledBalErr map[int64]error
 }
 
 func newMockTransactionRepo() *mockTransactionRepo {
@@ -227,6 +228,7 @@ func newMockTransactionRepo() *mockTransactionRepo {
 		unreconciledByAccountErr: make(map[int64]error),
 		lastReconciledBalances:   make(map[int64]int64),
 		getLastReconciledBalErr:  make(map[int64]error),
+		setLastReconciledBalErr:  make(map[int64]error),
 		nextTxID:                 1,
 		nextSplitID:              100,
 	}
@@ -414,6 +416,9 @@ func (m *mockTransactionRepo) GetLastReconciledBalance(accountID int64) (int64, 
 }
 
 func (m *mockTransactionRepo) SetLastReconciledBalance(accountID int64, balance int64) error {
+	if err, ok := m.setLastReconciledBalErr[accountID]; ok {
+		return err
+	}
 	m.lastReconciledBalances[accountID] = balance
 	m.setLastReconciledBalCalls = append(m.setLastReconciledBalCalls, struct {
 		accountID int64

--- a/internal/store/sqlite_reconcile.go
+++ b/internal/store/sqlite_reconcile.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
 
@@ -131,6 +132,39 @@ func (s *Store) BulkUpdateTransactionStatus(txIDs []int64, status model.Transact
 	}
 	if rowsAffected != int64(len(txIDs)) {
 		return fmt.Errorf("expected to update %d transactions, updated %d", len(txIDs), rowsAffected)
+	}
+	return nil
+}
+
+// GetLastReconciledBalance returns the running reconciled balance for
+// accountID. Returns 0 if the account has never been reconciled (no row in
+// account_reconcile_state for this account yet).
+func (s *Store) GetLastReconciledBalance(accountID int64) (int64, error) {
+	var balance int64
+	err := s.db.QueryRow(
+		"SELECT last_reconciled_balance FROM account_reconcile_state WHERE account_id = ?",
+		accountID,
+	).Scan(&balance)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("failed to get last reconciled balance: %w", err)
+	}
+	return balance, nil
+}
+
+// SetLastReconciledBalance persists the new running reconciled balance for
+// accountID. An upsert is used so that the first reconcile for an account
+// inserts a row; subsequent reconciles update it.
+func (s *Store) SetLastReconciledBalance(accountID int64, balance int64) error {
+	_, err := s.db.Exec(`
+        INSERT INTO account_reconcile_state (account_id, last_reconciled_balance)
+        VALUES (?, ?)
+        ON CONFLICT(account_id) DO UPDATE SET last_reconciled_balance = excluded.last_reconciled_balance
+    `, accountID, balance)
+	if err != nil {
+		return fmt.Errorf("failed to set last reconciled balance: %w", err)
 	}
 	return nil
 }

--- a/migrations/0004_add_account_reconcile_state.up.sql
+++ b/migrations/0004_add_account_reconcile_state.up.sql
@@ -1,0 +1,8 @@
+-- Per-account reconciliation state. Stores the running reconciled balance so
+-- that the reconcile UI can use the bank statement's actual closing balance
+-- instead of asking for a net-change delta on every session.
+CREATE TABLE IF NOT EXISTS account_reconcile_state (
+    account_id              INTEGER PRIMARY KEY,
+    last_reconciled_balance INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE
+);

--- a/ui/reconcile/model.go
+++ b/ui/reconcile/model.go
@@ -14,9 +14,9 @@ import (
 )
 
 // overheadLines is the number of non-item lines in the view:
-// account+badge (1) · blank (1) · statement (1) · top-sep (1) ·
-// bottom-sep (1) · cleared (1) · blank (1) · hint (1) = 8
-const overheadLines = 8
+// account+badge (1) · blank (1) · statement (1) · last-reconciled (1) ·
+// top-sep (1) · bottom-sep (1) · cleared (1) · blank (1) · hint (1) = 9
+const overheadLines = 9
 
 // Column widths in terminal display columns (accounts for double-wide CJK chars).
 const (
@@ -39,29 +39,31 @@ type listItem struct {
 // After tea.Program.Run() returns, inspect Cancelled() and SelectedIDs()
 // to determine the outcome.
 type Model struct {
-	accountName      string
-	statementBalance int64
-	items            []listItem
-	cursor           int
-	viewportOffset   int  // index of the first visible item
-	height           int  // terminal height (0 = unknown, show all)
-	confirmPending   bool // waiting for y/n after Enter with non-zero diff
-	cancelled        bool
-	done             bool
-	keys             keyMap
+	accountName           string
+	statementBalance      int64
+	lastReconciledBalance int64
+	items                 []listItem
+	cursor                int
+	viewportOffset        int  // index of the first visible item
+	height                int  // terminal height (0 = unknown, show all)
+	confirmPending        bool // waiting for y/n after Enter with non-zero diff
+	cancelled             bool
+	done                  bool
+	keys                  keyMap
 }
 
 // NewModel constructs the initial reconciliation model.
-func NewModel(accountName string, statementBalance int64, entries []*model.ReconcileEntry) Model {
+func NewModel(accountName string, statementBalance int64, lastReconciledBalance int64, entries []*model.ReconcileEntry) Model {
 	items := make([]listItem, len(entries))
 	for i, e := range entries {
 		items[i] = listItem{entry: e}
 	}
 	return Model{
-		accountName:      accountName,
-		statementBalance: statementBalance,
-		items:            items,
-		keys:             defaultKeyMap(),
+		accountName:           accountName,
+		statementBalance:      statementBalance,
+		lastReconciledBalance: lastReconciledBalance,
+		items:                 items,
+		keys:                  defaultKeyMap(),
 	}
 }
 
@@ -212,7 +214,9 @@ func (m Model) View() string {
 	sb.WriteString(fmt.Sprintf("%-40s %s\n\n", accountStyle.Render(m.accountName), badge))
 
 	stmtStr := utils.FormatAmount(m.statementBalance)
+	lastStr := utils.FormatAmount(m.lastReconciledBalance)
 	sb.WriteString(fmt.Sprintf("STATEMENT: $%s · %d UNRECONCILED\n", stmtStr, len(m.items)))
+	sb.WriteString(fmt.Sprintf("LAST RECONCILED: $%s\n", lastStr))
 
 	// ── Viewport calculation ─────────────────────────────
 	vis := m.visibleCount()
@@ -328,7 +332,7 @@ func (m Model) clearedBalance() int64 {
 }
 
 func (m Model) difference() int64 {
-	return m.statementBalance - m.clearedBalance()
+	return m.statementBalance - (m.lastReconciledBalance + m.clearedBalance())
 }
 
 func abs(n int64) int64 {


### PR DESCRIPTION
## Summary

- Adds `account_reconcile_state` table (migration 0004) to persist a running reconciled balance per account
- Changes the reconcile difference formula from `statementBalance - clearedBalance` to `statementBalance - (lastReconciledBalance + clearedBalance)` so users enter the bank's actual closing balance, not a net-change delta
- TUI now shows a **LAST RECONCILED: $X** line and persists the new running balance after every successful reconcile session

## Test Plan

- [ ] `go test ./...` — all pass (13 service tests including first-reconcile, carried-balance, forced-reconcile, and all error paths)
- [ ] `make build` — exits 0
- [ ] Interactive reconcile: first session behaves identically to before; second session statement balance entry matches the bank's actual closing balance
- [ ] Non-interactive (`--balance` / `--ids`) path: difference is computed correctly using the carried balance

🤖 Generated with [Claude Code](https://claude.com/claude-code)