### PR TITLE
feat: store transaction type in database

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/service"
 	"github.com/hance08/kea/ui/views"
 	"github.com/spf13/cobra"
@@ -46,7 +47,12 @@ Examples:
 	cmd.Flags().StringVarP(&flags.Status, "status", "s", "cleared", "Transaction status: pending or cleared")
 	cmd.Flags().StringVar(&flags.Timestamp, "date", "", "Transaction date (YYYY-MM-DD), default is today")
 	cmd.Flags().StringVar(&flags.Type, "type", "", "Transaction type: expense, income, transfer")
+	cmd.Flags().StringArrayVar(&flags.Splits, "split", nil, "Split as AccountName=amount, e.g. Assets:Bank=-1000 (repeatable)")
 	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output created transaction as JSON")
+
+	cmd.MarkFlagsMutuallyExclusive("split", "from")
+	cmd.MarkFlagsMutuallyExclusive("split", "to")
+	cmd.MarkFlagsMutuallyExclusive("split", "amount")
 
 	return cmd
 }
@@ -57,7 +63,8 @@ func (r *addRunner) Run(flags *addFlags, cmd *cobra.Command) error {
 
 	// Check if using flag mode or interactive mode
 	hasFlags := cmd.Flags().Changed("desc") || cmd.Flags().Changed("amount") ||
-		cmd.Flags().Changed("from") || cmd.Flags().Changed("to") || cmd.Flags().Changed("type")
+		cmd.Flags().Changed("from") || cmd.Flags().Changed("to") ||
+		cmd.Flags().Changed("type") || cmd.Flags().Changed("split")
 
 	if flags.JSON && !hasFlags {
 		return fmt.Errorf("--json requires flags: --amount, --from, --to")
@@ -74,15 +81,22 @@ func (r *addRunner) Run(flags *addFlags, cmd *cobra.Command) error {
 		return err
 	}
 
-	result, err := r.txSvc.CreateSimpleTransaction(
-		input.FromAccountID,
-		input.ToAccountID,
-		input.AmountCents,
-		input.Description,
-		input.Timestamp,
-		input.Status,
-		input.Type,
-	)
+	var result model.TransactionDetail
+	if len(input.Splits) > 0 {
+		result, err = r.txSvc.CreateTransactionFromSplits(
+			input.Splits, input.Description, input.Timestamp, input.Status, input.Type,
+		)
+	} else {
+		result, err = r.txSvc.CreateSimpleTransaction(
+			input.FromAccountID,
+			input.ToAccountID,
+			input.AmountCents,
+			input.Description,
+			input.Timestamp,
+			input.Status,
+			input.Type,
+		)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to create transaction: %w", err)
 	}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -80,6 +80,7 @@ func (r *addRunner) Run(flags *addFlags, cmd *cobra.Command) error {
 		input.Description,
 		input.Timestamp,
 		input.Status,
+		"",
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create transaction: %w", err)

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -45,6 +45,7 @@ Examples:
 	cmd.Flags().StringVarP(&flags.To, "to", "t", "", "Destination account (where money goes to)")
 	cmd.Flags().StringVarP(&flags.Status, "status", "s", "cleared", "Transaction status: pending or cleared")
 	cmd.Flags().StringVar(&flags.Timestamp, "date", "", "Transaction date (YYYY-MM-DD), default is today")
+	cmd.Flags().StringVar(&flags.Type, "type", "", "Transaction type: expense, income, transfer")
 	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output created transaction as JSON")
 
 	return cmd
@@ -56,7 +57,7 @@ func (r *addRunner) Run(flags *addFlags, cmd *cobra.Command) error {
 
 	// Check if using flag mode or interactive mode
 	hasFlags := cmd.Flags().Changed("desc") || cmd.Flags().Changed("amount") ||
-		cmd.Flags().Changed("from") || cmd.Flags().Changed("to")
+		cmd.Flags().Changed("from") || cmd.Flags().Changed("to") || cmd.Flags().Changed("type")
 
 	if flags.JSON && !hasFlags {
 		return fmt.Errorf("--json requires flags: --amount, --from, --to")
@@ -80,7 +81,7 @@ func (r *addRunner) Run(flags *addFlags, cmd *cobra.Command) error {
 		input.Description,
 		input.Timestamp,
 		input.Status,
-		"",
+		input.Type,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create transaction: %w", err)

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -67,7 +67,7 @@ func (r *addRunner) Run(flags *addFlags, cmd *cobra.Command) error {
 		cmd.Flags().Changed("type") || cmd.Flags().Changed("split")
 
 	if flags.JSON && !hasFlags {
-		return fmt.Errorf("--json requires flags: --amount, --from, --to")
+		return fmt.Errorf("--json requires flag mode: use --amount/--from/--to or --split")
 	}
 
 	if hasFlags {

--- a/cmd/add_actions.go
+++ b/cmd/add_actions.go
@@ -32,10 +32,7 @@ func (r *addRunner) runFromFlags(flags *addFlags) (addTransactionInput, error) {
 	}
 
 	// Parse status
-	status := model.StatusCleared
-	if strings.ToLower(flags.Status) == "pending" {
-		status = model.StatusPending
-	}
+	status := parseStatus(flags.Status)
 
 	// Parse timestamp
 	timestamp, err := r.parseDate(flags.Timestamp)
@@ -245,10 +242,7 @@ func (r *addRunner) runFromSplitFlags(flags *addFlags) (addTransactionInput, err
 		description = "-"
 	}
 
-	status := model.StatusCleared
-	if strings.ToLower(flags.Status) == "pending" {
-		status = model.StatusPending
-	}
+	status := parseStatus(flags.Status)
 
 	timestamp, err := r.parseDate(flags.Timestamp)
 	if err != nil {
@@ -290,4 +284,11 @@ func parseSplitFlag(s string) (model.SplitDetail, error) {
 		return model.SplitDetail{}, fmt.Errorf("invalid split %q: %w", s, err)
 	}
 	return model.SplitDetail{AccountName: accountName, Amount: cents}, nil
+}
+
+func parseStatus(s string) model.TransactionStatus {
+	if strings.ToLower(s) == "pending" {
+		return model.StatusPending
+	}
+	return model.StatusCleared
 }

--- a/cmd/add_actions.go
+++ b/cmd/add_actions.go
@@ -39,6 +39,14 @@ func (r *addRunner) runFromFlags(flags *addFlags) (addTransactionInput, error) {
 		return addTransactionInput{}, err
 	}
 
+	var txType model.TransactionType
+	if flags.Type != "" {
+		txType, err = parseTransactionType(flags.Type)
+		if err != nil {
+			return addTransactionInput{}, err
+		}
+	}
+
 	if err := r.validateAccountSelectable(flags.From, nil, "--from"); err != nil {
 		return addTransactionInput{}, err
 	}
@@ -54,6 +62,7 @@ func (r *addRunner) runFromFlags(flags *addFlags) (addTransactionInput, error) {
 		Description:   description,
 		Timestamp:     timestamp,
 		Status:        status,
+		Type:          txType,
 	}, nil
 }
 
@@ -153,6 +162,7 @@ func (r *addRunner) runInteractive() (addTransactionInput, error) {
 		Description:   description,
 		Timestamp:     timestamp,
 		Status:        status,
+		Type:          mode,
 	}, nil
 }
 
@@ -192,6 +202,19 @@ func (r *addRunner) parseDate(dateStr string) (int64, error) {
 		return 0, fmt.Errorf("invalid date format, use %s: %w", model.DateFormat, err)
 	}
 	return t.Unix(), nil
+}
+
+func parseTransactionType(s string) (model.TransactionType, error) {
+	switch strings.ToLower(s) {
+	case "expense":
+		return model.TxTypeExpense, nil
+	case "income":
+		return model.TxTypeIncome, nil
+	case "transfer":
+		return model.TxTypeTransfer, nil
+	default:
+		return "", fmt.Errorf("invalid type %q: must be expense, income, or transfer", s)
+	}
 }
 
 var modeUIConfigs = map[model.TransactionType]struct{ Src, Dst string }{

--- a/cmd/add_actions.go
+++ b/cmd/add_actions.go
@@ -205,7 +205,7 @@ func (r *addRunner) parseDate(dateStr string) (int64, error) {
 }
 
 func parseTransactionType(s string) (model.TransactionType, error) {
-	switch strings.ToLower(s) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "expense":
 		return model.TxTypeExpense, nil
 	case "income":

--- a/cmd/add_actions.go
+++ b/cmd/add_actions.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (r *addRunner) runFromFlags(flags *addFlags) (addTransactionInput, error) {
+	if len(flags.Splits) > 0 {
+		return r.runFromSplitFlags(flags)
+	}
+
 	// Flag mode: validate all required flags
 	if flags.Amount == "" || flags.From == "" || flags.To == "" {
 		return addTransactionInput{}, fmt.Errorf("when using flags, --amount, --from, and --to are all required")
@@ -221,4 +225,67 @@ var modeUIConfigs = map[model.TransactionType]struct{ Src, Dst string }{
 	model.ModeExpense:  {"Payment Source:", "Expense Type:"},
 	model.ModeIncome:   {"Revenue Type:", "Deposit To:"},
 	model.ModeTransfer: {"From Account:", "To Account:"},
+}
+
+func (r *addRunner) runFromSplitFlags(flags *addFlags) (addTransactionInput, error) {
+	if flags.Type == "" {
+		return addTransactionInput{}, fmt.Errorf("--type is required when using --split")
+	}
+	if len(flags.Splits) < 2 {
+		return addTransactionInput{}, fmt.Errorf("--split requires at least 2 splits, got %d", len(flags.Splits))
+	}
+
+	txType, err := parseTransactionType(flags.Type)
+	if err != nil {
+		return addTransactionInput{}, err
+	}
+
+	description := flags.Description
+	if description == "" {
+		description = "-"
+	}
+
+	status := model.StatusCleared
+	if strings.ToLower(flags.Status) == "pending" {
+		status = model.StatusPending
+	}
+
+	timestamp, err := r.parseDate(flags.Timestamp)
+	if err != nil {
+		return addTransactionInput{}, err
+	}
+
+	splits := make([]model.SplitDetail, 0, len(flags.Splits))
+	for _, s := range flags.Splits {
+		split, err := parseSplitFlag(s)
+		if err != nil {
+			return addTransactionInput{}, err
+		}
+		splits = append(splits, split)
+	}
+
+	return addTransactionInput{
+		Splits:      splits,
+		Description: description,
+		Timestamp:   timestamp,
+		Status:      status,
+		Type:        txType,
+	}, nil
+}
+
+func parseSplitFlag(s string) (model.SplitDetail, error) {
+	i := strings.LastIndex(s, "=")
+	if i < 0 {
+		return model.SplitDetail{}, fmt.Errorf("invalid split %q: expected format AccountName=amount", s)
+	}
+	accountName := s[:i]
+	amountStr := s[i+1:]
+	if accountName == "" {
+		return model.SplitDetail{}, fmt.Errorf("invalid split %q: account name cannot be empty", s)
+	}
+	cents, err := utils.ParseAmount(amountStr)
+	if err != nil {
+		return model.SplitDetail{}, fmt.Errorf("invalid split %q: %w", s, err)
+	}
+	return model.SplitDetail{AccountName: accountName, Amount: cents}, nil
 }

--- a/cmd/add_actions.go
+++ b/cmd/add_actions.go
@@ -264,6 +264,8 @@ func (r *addRunner) runFromSplitFlags(flags *addFlags) (addTransactionInput, err
 		splits = append(splits, split)
 	}
 
+	// Account name validity and selectability are validated by CreateTransaction
+	// (which calls GetAccountByName per split). Errors propagate with split index context.
 	return addTransactionInput{
 		Splits:      splits,
 		Description: description,

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/hance08/kea/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ──────────────────────────────────────────────
+// mockTransactionProvider
+// ──────────────────────────────────────────────
+
+type mockTransactionProvider struct {
+	createSimpleErr error
+	createSplitsErr error
+	lastSplitsInput []model.SplitDetail
+}
+
+func (m *mockTransactionProvider) GetTransactionRule(mode model.TransactionType) (model.TransactionRule, error) {
+	return model.TransactionRule{}, nil
+}
+
+func (m *mockTransactionProvider) CreateSimpleTransaction(fromAccount, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error) {
+	if m.createSimpleErr != nil {
+		return model.TransactionDetail{}, m.createSimpleErr
+	}
+	return model.TransactionDetail{}, nil
+}
+
+func (m *mockTransactionProvider) CreateTransactionFromSplits(splits []model.SplitDetail, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error) {
+	m.lastSplitsInput = splits
+	if m.createSplitsErr != nil {
+		return model.TransactionDetail{}, m.createSplitsErr
+	}
+	return model.TransactionDetail{ID: 1}, nil
+}
+
+// ──────────────────────────────────────────────
+// TestParseSplitFlag
+// ──────────────────────────────────────────────
+
+func TestParseSplitFlag(t *testing.T) {
+	t.Run("parses positive amount", func(t *testing.T) {
+		got, err := parseSplitFlag("Expenses:Food:Lunch=2000")
+		require.NoError(t, err)
+		assert.Equal(t, "Expenses:Food:Lunch", got.AccountName)
+		assert.Equal(t, int64(200000), got.Amount)
+	})
+
+	t.Run("parses negative amount", func(t *testing.T) {
+		got, err := parseSplitFlag("Assets:Bank:Bank1=-1000")
+		require.NoError(t, err)
+		assert.Equal(t, "Assets:Bank:Bank1", got.AccountName)
+		assert.Equal(t, int64(-100000), got.Amount)
+	})
+
+	t.Run("parses decimal amount", func(t *testing.T) {
+		got, err := parseSplitFlag("Assets:Cash=10.50")
+		require.NoError(t, err)
+		assert.Equal(t, int64(1050), got.Amount)
+	})
+
+	t.Run("missing equals returns error", func(t *testing.T) {
+		_, err := parseSplitFlag("Assets:Bank")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected format")
+	})
+
+	t.Run("empty account name returns error", func(t *testing.T) {
+		_, err := parseSplitFlag("=1000")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "account name")
+	})
+
+	t.Run("invalid amount returns error", func(t *testing.T) {
+		_, err := parseSplitFlag("Assets:Bank=abc")
+		require.Error(t, err)
+	})
+}
+
+// ──────────────────────────────────────────────
+// TestRunFromFlags_SplitMode
+// ──────────────────────────────────────────────
+
+func TestRunFromFlags_SplitMode(t *testing.T) {
+	runner := &addRunner{}
+
+	t.Run("valid two-split expense", func(t *testing.T) {
+		flags := &addFlags{
+			Type:        "expense",
+			Description: "team lunch",
+			Splits:      []string{"Assets:Bank=-1000", "Expenses:Food=1000"},
+		}
+		input, err := runner.runFromFlags(flags)
+		require.NoError(t, err)
+		require.Len(t, input.Splits, 2)
+		assert.Equal(t, "Assets:Bank", input.Splits[0].AccountName)
+		assert.Equal(t, int64(-100000), input.Splits[0].Amount)
+		assert.Equal(t, "Expenses:Food", input.Splits[1].AccountName)
+		assert.Equal(t, int64(100000), input.Splits[1].Amount)
+		assert.Equal(t, model.TxTypeExpense, input.Type)
+		assert.Equal(t, "team lunch", input.Description)
+	})
+
+	t.Run("three-split expense", func(t *testing.T) {
+		flags := &addFlags{
+			Type:   "expense",
+			Splits: []string{"Assets:Bank:Bank1=-1000", "Assets:Bank:Bank2=-1000", "Expenses:Food:Lunch=2000"},
+		}
+		input, err := runner.runFromFlags(flags)
+		require.NoError(t, err)
+		assert.Len(t, input.Splits, 3)
+		assert.Equal(t, int64(200000), input.Splits[2].Amount)
+	})
+
+	t.Run("missing --type returns error", func(t *testing.T) {
+		flags := &addFlags{
+			Splits: []string{"Assets:Bank=-1000", "Expenses:Food=1000"},
+		}
+		_, err := runner.runFromFlags(flags)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--type is required")
+	})
+
+	t.Run("single split returns error", func(t *testing.T) {
+		flags := &addFlags{
+			Type:   "expense",
+			Splits: []string{"Assets:Bank=-1000"},
+		}
+		_, err := runner.runFromFlags(flags)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at least 2")
+	})
+
+	t.Run("invalid type returns error", func(t *testing.T) {
+		flags := &addFlags{
+			Type:   "bogus",
+			Splits: []string{"Assets:Bank=-1000", "Expenses:Food=1000"},
+		}
+		_, err := runner.runFromFlags(flags)
+		require.Error(t, err)
+	})
+
+	t.Run("malformed split returns error", func(t *testing.T) {
+		flags := &addFlags{
+			Type:   "expense",
+			Splits: []string{"Assets:Bank=-1000", "Expenses:Food"},
+		}
+		_, err := runner.runFromFlags(flags)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected format")
+	})
+
+	t.Run("empty description defaults to dash", func(t *testing.T) {
+		flags := &addFlags{
+			Type:   "expense",
+			Splits: []string{"Assets:Bank=-500", "Expenses:Food=500"},
+		}
+		input, err := runner.runFromFlags(flags)
+		require.NoError(t, err)
+		assert.Equal(t, "-", input.Description)
+	})
+}

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -37,6 +37,8 @@ func (m *mockTransactionProvider) CreateTransactionFromSplits(splits []model.Spl
 	return model.TransactionDetail{ID: 1}, nil
 }
 
+var _ TransactionProvider = (*mockTransactionProvider)(nil)
+
 // ──────────────────────────────────────────────
 // TestParseSplitFlag
 // ──────────────────────────────────────────────

--- a/cmd/add_types.go
+++ b/cmd/add_types.go
@@ -27,6 +27,7 @@ type addFlags struct {
 	To          string
 	Status      string
 	Timestamp   string
+	Type        string
 	JSON        bool
 }
 
@@ -37,4 +38,5 @@ type addTransactionInput struct {
 	Description   string
 	Timestamp     int64
 	Status        model.TransactionStatus
+	Type          model.TransactionType
 }

--- a/cmd/add_types.go
+++ b/cmd/add_types.go
@@ -18,6 +18,7 @@ type AddProvider interface {
 type TransactionProvider interface {
 	GetTransactionRule(mode model.TransactionType) (model.TransactionRule, error)
 	CreateSimpleTransaction(fromAccount string, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error)
+	CreateTransactionFromSplits(splits []model.SplitDetail, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error)
 }
 
 type addFlags struct {
@@ -29,6 +30,7 @@ type addFlags struct {
 	Timestamp   string
 	Type        string
 	JSON        bool
+	Splits      []string
 }
 
 type addTransactionInput struct {
@@ -39,4 +41,5 @@ type addTransactionInput struct {
 	Timestamp     int64
 	Status        model.TransactionStatus
 	Type          model.TransactionType
+	Splits        []model.SplitDetail
 }

--- a/cmd/add_types.go
+++ b/cmd/add_types.go
@@ -17,7 +17,7 @@ type AddProvider interface {
 
 type TransactionProvider interface {
 	GetTransactionRule(mode model.TransactionType) (model.TransactionRule, error)
-	CreateSimpleTransaction(fromAccount string, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus) (model.TransactionDetail, error)
+	CreateSimpleTransaction(fromAccount string, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error)
 }
 
 type addFlags struct {

--- a/cmd/transaction/edit.go
+++ b/cmd/transaction/edit.go
@@ -102,6 +102,11 @@ func (r *editRunner) getAvailableMenuItems(detail *model.TransactionDetail) []me
 			Action: r.actionEditBasicInfo,
 		},
 		{
+			Label:     OptChangeType,
+			Condition: func(d *model.TransactionDetail) bool { return d.Type != model.TxTypeOpening },
+			Action:    r.actionEditType,
+		},
+		{
 			Label:     OptQuickAccount,
 			Condition: func(d *model.TransactionDetail) bool { return len(d.Splits) == 2 },
 			Action:    r.actionQuickChangeAccount,

--- a/cmd/transaction/edit_actions.go
+++ b/cmd/transaction/edit_actions.go
@@ -253,7 +253,7 @@ func (r *editRunner) actionSave(detail *model.TransactionDetail) error {
 
 	// Execute Update
 	if err := r.txSvc.UpdateTransactionComplete(
-		r.txID, detail.Description, detail.Timestamp, detail.Status, splits,
+		r.txID, detail.Description, detail.Timestamp, detail.Status, detail.Type, splits,
 	); err != nil {
 		return err
 	}

--- a/cmd/transaction/edit_actions.go
+++ b/cmd/transaction/edit_actions.go
@@ -38,11 +38,7 @@ func (r *editRunner) actionQuickChangeAccount(detail *model.TransactionDetail) e
 		return fmt.Errorf("quick edit supports only 2 splits")
 	}
 
-	// Determine Type (Asset/Expense/etc)
-	txType, err := r.txSvc.DetermineType(detail.Splits)
-	if err != nil {
-		return err
-	}
+	txType := detail.Type
 
 	if txType == model.TxTypeOpening {
 		r.view.ShowWarning("Cannot quick-edit Opening Balance transaction")

--- a/cmd/transaction/edit_actions.go
+++ b/cmd/transaction/edit_actions.go
@@ -2,9 +2,11 @@ package transaction
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/utils"
+	"github.com/hance08/kea/ui/prompts"
 )
 
 func (r *editRunner) actionEditBasicInfo(detail *model.TransactionDetail) error {
@@ -238,6 +240,36 @@ func (r *editRunner) actionDeleteSplit(detail *model.TransactionDetail) error {
 		detail.Splits = append(detail.Splits[:idx], detail.Splits[idx+1:]...)
 	}
 	return nil
+}
+
+func (r *editRunner) actionEditType(detail *model.TransactionDetail) error {
+	rawType, err := prompts.PromptTransactionType()
+	if err != nil {
+		return err
+	}
+
+	newType := r.determineMode(rawType)
+
+	if err := r.txSvc.ValidateSplitsMatchType(newType, detail.Splits); err != nil {
+		r.view.ShowWarning(fmt.Sprintf("Cannot change type to %s: %s", newType, err.Error()))
+		r.view.ShowWarning("Fix the splits first, then change the type.")
+		return nil
+	}
+
+	detail.Type = newType
+	r.view.ShowSuccess(fmt.Sprintf("Type changed to: %s", newType))
+	return nil
+}
+
+func (r *editRunner) determineMode(rawInput string) model.TransactionType {
+	lower := strings.ToLower(rawInput)
+	if strings.Contains(lower, "expense") {
+		return model.TxTypeExpense
+	}
+	if strings.Contains(lower, "income") {
+		return model.TxTypeIncome
+	}
+	return model.TxTypeTransfer
 }
 
 func (r *editRunner) actionSave(detail *model.TransactionDetail) error {

--- a/cmd/transaction/edit_types.go
+++ b/cmd/transaction/edit_types.go
@@ -33,7 +33,7 @@ type EditProvider interface {
 	DetermineType(splits []model.SplitDetail) (model.TransactionType, error)
 	GetAllowedAccounts(txType model.TransactionType, currentAccountType model.AccountType, allAccounts []*model.Account) []*model.Account
 	ValidateTransactionEdit(splits []model.SplitDetail) error
-	UpdateTransactionComplete(txID int64, description string, timestamp int64, status model.TransactionStatus, splits []model.SplitDetail) error
+	UpdateTransactionComplete(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType, splits []model.SplitDetail) error
 }
 
 type AccountProvider interface {

--- a/cmd/transaction/edit_types.go
+++ b/cmd/transaction/edit_types.go
@@ -30,9 +30,9 @@ type EditView interface {
 type EditProvider interface {
 	GetTransactionByID(txID int64) (*model.TransactionDetail, error)
 	IsEditable(detail *model.TransactionDetail) (bool, service.NotEditableReason)
-	DetermineType(splits []model.SplitDetail) (model.TransactionType, error)
 	GetAllowedAccounts(txType model.TransactionType, currentAccountType model.AccountType, allAccounts []*model.Account) []*model.Account
 	ValidateTransactionEdit(splits []model.SplitDetail) error
+	ValidateSplitsMatchType(txType model.TransactionType, splits []model.SplitDetail) error
 	UpdateTransactionComplete(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType, splits []model.SplitDetail) error
 }
 
@@ -43,6 +43,7 @@ type AccountProvider interface {
 
 const (
 	OptBasicInfo    = "Basic Info (description, date, status)"
+	OptChangeType   = "Change Type"
 	OptQuickAccount = "Change Account (quick edit)"
 	OptQuickAmount  = "Change Amount (both sides)"
 	OptEditSplits   = "Edit Splits (Advanced)"

--- a/cmd/transaction/list.go
+++ b/cmd/transaction/list.go
@@ -21,7 +21,6 @@ type ListProvider interface {
 	GetTransactionHistory(accountName string, limit int) ([]*model.Transaction, error)
 	GetRecentTransactions(limit int) ([]*model.Transaction, error)
 	GetTransactionByID(txID int64) (*model.TransactionDetail, error)
-	DetermineType(splits []model.SplitDetail) (model.TransactionType, error)
 	GetDisplayAccount(splits []model.SplitDetail, txType string) (string, error)
 	GetDisplayOffsetAccount(splits []model.SplitDetail, txType string, primaryAccount string) (string, error)
 	GetDisplayAmount(splits []model.SplitDetail) (int64, string)
@@ -114,11 +113,7 @@ func (r *listRunner) buildViewItems(transactions []*model.Transaction) []views.T
 
 func (r *listRunner) convertToViewItem(tx *model.Transaction, detail *model.TransactionDetail) views.TransactionListItem {
 	// 1. Determine Type
-	txTypeEnum, err := r.svc.DetermineType(detail.Splits)
-	txType := string(txTypeEnum)
-	if err != nil {
-		txType = "-"
-	}
+	txType := string(detail.Type)
 
 	accountName, err := r.svc.GetDisplayAccount(detail.Splits, txType)
 	if err != nil {

--- a/cmd/transaction/list.go
+++ b/cmd/transaction/list.go
@@ -112,7 +112,6 @@ func (r *listRunner) buildViewItems(transactions []*model.Transaction) []views.T
 }
 
 func (r *listRunner) convertToViewItem(tx *model.Transaction, detail *model.TransactionDetail) views.TransactionListItem {
-	// 1. Determine Type
 	txType := string(detail.Type)
 
 	accountName, err := r.svc.GetDisplayAccount(detail.Splits, txType)

--- a/docs/superpowers/plans/2026-04-23-stored-transaction-type.md
+++ b/docs/superpowers/plans/2026-04-23-stored-transaction-type.md
@@ -1,0 +1,1237 @@
+# Stored Transaction Type Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Store transaction type explicitly on the `transactions` table and wire it through every layer — migrations, model, store, service, cmd/add, cmd/edit, and display — replacing all three `DetermineType` display-time call sites with direct field reads.
+
+**Architecture:** Two SQL migrations add and backfill a `type` column. The `Type TransactionType` field is added to `model.Transaction` and `model.TransactionDetail`; the store reads/writes it via `scanTransactions` and `CreateTransactionWithSplits`; the service enforces structural validity via a new `ValidateSplitsMatchType` function driven by existing `GetTransactionRule` rules; the cmd layers wire the prompted/flagged type end-to-end.
+
+**Tech Stack:** Go, SQLite (golang-migrate embedded SQL), charmbracelet/huh, cobra, testify
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|---|---|---|
+| Create | `migrations/0005_add_transaction_type.up.sql` | Add nullable `type` column |
+| Create | `migrations/0005_add_transaction_type.down.sql` | Drop `type` column |
+| Create | `migrations/0006_backfill_transaction_type.up.sql` | Classify all existing rows |
+| Create | `migrations/0006_backfill_transaction_type.down.sql` | Reset all rows to `''` |
+| Modify | `internal/model/transaction.go` | Add `Type` to Transaction + TransactionDetail |
+| Modify | `internal/repository/interfaces.go` | Update `UpdateTransactionBasic` signature |
+| Modify | `internal/store/sqlite_transaction.go` | INSERT/SELECT/UPDATE include `type` |
+| Modify | `internal/service/transaction_classifier.go` | Add `ValidateSplitsMatchType` |
+| Modify | `internal/service/transaction_classifier_test.go` | Tests for `ValidateSplitsMatchType` |
+| Modify | `internal/service/transaction_ops.go` | `CreateTransaction`, `CreateSimpleTransaction`, `UpdateTransactionComplete` |
+| Modify | `internal/service/transaction_ops_test.go` | Update existing tests; add type to inputs |
+| Modify | `internal/service/report_service.go` | Replace `DetermineType` call in `buildReportMaps` |
+| Modify | `internal/service/testhelper_test.go` | Update mock `UpdateTransactionBasic` + `GetTransactionsByDateRange` |
+| Modify | `cmd/add_types.go` | `addFlags`, `addTransactionInput`, `TransactionProvider` interface |
+| Modify | `cmd/add.go` | Register `--type` flag |
+| Modify | `cmd/add_actions.go` | `runInteractive` sets type; `runFromFlags` parses/infers type; `parseTransactionType` helper |
+| Modify | `cmd/transaction/edit_types.go` | Update `EditProvider`; add `OptChangeType` constant |
+| Modify | `cmd/transaction/edit_actions.go` | Add `actionEditType`; update `actionSave` |
+| Modify | `cmd/transaction/edit.go` | Add Change Type menu item |
+| Modify | `cmd/transaction/list.go` | Replace `DetermineType` call; remove from `ListProvider` |
+
+---
+
+### Task 1: Migration files
+
+**Files:**
+- Create: `migrations/0005_add_transaction_type.up.sql`
+- Create: `migrations/0005_add_transaction_type.down.sql`
+- Create: `migrations/0006_backfill_transaction_type.up.sql`
+- Create: `migrations/0006_backfill_transaction_type.down.sql`
+
+- [ ] **Step 1: Create schema migration (up)**
+
+`migrations/0005_add_transaction_type.up.sql`:
+```sql
+ALTER TABLE transactions ADD COLUMN type TEXT NOT NULL DEFAULT '';
+```
+
+- [ ] **Step 2: Create schema migration (down)**
+
+`migrations/0005_add_transaction_type.down.sql`:
+```sql
+-- SQLite does not support DROP COLUMN in older versions; recreate without the column.
+CREATE TABLE transactions_new (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp   INTEGER NOT NULL,
+    description TEXT,
+    status      INTEGER NOT NULL DEFAULT 0,
+    external_id TEXT UNIQUE
+);
+
+INSERT INTO transactions_new SELECT id, timestamp, description, status, external_id FROM transactions;
+DROP TABLE transactions;
+ALTER TABLE transactions_new RENAME TO transactions;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_timestamp ON transactions (timestamp);
+```
+
+- [ ] **Step 3: Create backfill migration (up)**
+
+`migrations/0006_backfill_transaction_type.up.sql`:
+```sql
+UPDATE transactions SET type = (
+  SELECT
+    CASE
+      WHEN memo_check.has_opening = 1 THEN 'Opening'
+      WHEN agg.has_exp = 1 AND agg.has_rev = 1
+        THEN CASE WHEN agg.rev_sum >= agg.exp_sum THEN 'Income' ELSE 'Expense' END
+      WHEN agg.has_exp = 1 AND agg.al_cnt >= 1 THEN 'Expense'
+      WHEN agg.has_rev = 1 AND agg.al_cnt >= 1 THEN 'Income'
+      WHEN agg.al_cnt >= 2                       THEN 'Transfer'
+      ELSE 'Other'
+    END
+  FROM (
+    SELECT
+      MAX(CASE WHEN a.type = 'E' THEN 1 ELSE 0 END)             AS has_exp,
+      MAX(CASE WHEN a.type = 'R' THEN 1 ELSE 0 END)             AS has_rev,
+      SUM(CASE WHEN a.type IN ('A','L') THEN 1 ELSE 0 END)      AS al_cnt,
+      SUM(CASE WHEN a.type = 'E' THEN ABS(s.amount) ELSE 0 END) AS exp_sum,
+      SUM(CASE WHEN a.type = 'R' THEN ABS(s.amount) ELSE 0 END) AS rev_sum
+    FROM splits s
+    JOIN accounts a ON s.account_id = a.id
+    WHERE s.transaction_id = transactions.id
+  ) agg,
+  (
+    SELECT MAX(CASE WHEN s.memo = 'Opening Balance' THEN 1 ELSE 0 END) AS has_opening
+    FROM splits s
+    WHERE s.transaction_id = transactions.id
+  ) memo_check
+);
+```
+
+- [ ] **Step 4: Create backfill migration (down)**
+
+`migrations/0006_backfill_transaction_type.down.sql`:
+```sql
+UPDATE transactions SET type = '';
+```
+
+- [ ] **Step 5: Verify build compiles with embedded migrations**
+
+```bash
+make build
+```
+Expected: binary produced, no errors. The migrations embed via `go:embed` in the existing migration runner — no Go changes needed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add migrations/
+git commit -m "feat: add migration to store transaction type column"
+```
+
+---
+
+### Task 2: Model — add Type field
+
+**Files:**
+- Modify: `internal/model/transaction.go`
+
+- [ ] **Step 1: Add Type to Transaction**
+
+In `internal/model/transaction.go`, update `Transaction`:
+```go
+type Transaction struct {
+	ID          int64
+	Timestamp   int64
+	Description string
+	Status      TransactionStatus
+	Type        TransactionType
+	ExternalID  *string
+}
+```
+
+- [ ] **Step 2: Add Type to TransactionDetail**
+
+In `internal/model/transaction.go`, update `TransactionDetail`:
+```go
+type TransactionDetail struct {
+	ID          int64
+	Timestamp   int64
+	Description string
+	Status      TransactionStatus
+	Type        TransactionType
+	Splits      []SplitDetail
+}
+```
+
+- [ ] **Step 3: Verify build**
+
+```bash
+go build ./...
+```
+Expected: compile errors in store and service where `Transaction` or `TransactionDetail` is constructed without the new field — that is expected and will be fixed in later tasks. If you see only those, proceed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/model/transaction.go
+git commit -m "feat: add Type field to Transaction and TransactionDetail models"
+```
+
+---
+
+### Task 3: Repository interface + Store
+
+**Files:**
+- Modify: `internal/repository/interfaces.go`
+- Modify: `internal/store/sqlite_transaction.go`
+
+- [ ] **Step 1: Update repository interface**
+
+In `internal/repository/interfaces.go`, change `UpdateTransactionBasic`:
+```go
+UpdateTransactionBasic(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error
+```
+
+- [ ] **Step 2: Update CreateTransactionWithSplits INSERT**
+
+In `internal/store/sqlite_transaction.go`, update `CreateTransactionWithSplits` SQL and param:
+```go
+func (s *Store) CreateTransactionWithSplits(tx model.Transaction, splits []model.Split) (int64, error) {
+	stmtTx, err := s.db.Prepare(`
+        INSERT INTO transactions (timestamp, description, status, external_id, type)
+        VALUES (?, ?, ?, ?, ?)
+        RETURNING id;
+    `)
+	if err != nil {
+		return 0, fmt.Errorf("failed to prepare transaction SQL: %w", err)
+	}
+	defer func() { _ = stmtTx.Close() }()
+
+	var newTxID int64
+	err = stmtTx.QueryRow(tx.Timestamp, tx.Description, tx.Status, tx.ExternalID, tx.Type).Scan(&newTxID)
+	// ... rest of function unchanged
+```
+
+- [ ] **Step 3: Update GetTransactionByID SELECT**
+
+In `internal/store/sqlite_transaction.go`, update `GetTransactionByID`:
+```go
+func (s *Store) GetTransactionByID(txID int64) (*model.Transaction, error) {
+	var tx model.Transaction
+	err := s.db.QueryRow(`
+        SELECT id, timestamp, description, status, external_id, type
+        FROM transactions
+        WHERE id = ?
+    `, txID).Scan(&tx.ID, &tx.Timestamp, &tx.Description, &tx.Status, &tx.ExternalID, &tx.Type)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("transaction with ID %d not found", txID)
+		}
+		return nil, fmt.Errorf("failed to query transaction: %w", err)
+	}
+	return &tx, nil
+}
+```
+
+- [ ] **Step 4: Update scanTransactions to include type**
+
+In `internal/store/sqlite_transaction.go`, update `scanTransactions`:
+```go
+func (s *Store) scanTransactions(rows *sql.Rows) ([]*model.Transaction, error) {
+	var transactions []*model.Transaction
+	for rows.Next() {
+		tx := &model.Transaction{}
+		err := rows.Scan(&tx.ID, &tx.Timestamp, &tx.Description, &tx.Status, &tx.ExternalID, &tx.Type)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan transaction: %w", err)
+		}
+		transactions = append(transactions, tx)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows iteration error: %w", err)
+	}
+	return transactions, nil
+}
+```
+
+- [ ] **Step 5: Update SELECT queries that feed scanTransactions**
+
+In `internal/store/sqlite_transaction.go`, update the three query methods to include `type` in SELECT. `scanTransactions` is called by `GetTransactionsByAccount`, `GetTransactionsByDateRange`, and `GetAllTransactions` — update each:
+
+`GetTransactionsByAccount`:
+```go
+rows, err := s.db.Query(`
+    SELECT DISTINCT t.id, t.timestamp, t.description, t.status, t.external_id, t.type
+    FROM transactions t
+    INNER JOIN splits s ON t.id = s.transaction_id
+    WHERE s.account_id = ?
+    ORDER BY t.timestamp DESC, t.id DESC
+    LIMIT ?
+`, accountID, limit)
+```
+
+`GetTransactionsByDateRange`:
+```go
+rows, err := s.db.Query(`
+    SELECT id, timestamp, description, status, external_id, type
+    FROM transactions
+    WHERE timestamp >= ? AND timestamp <= ?
+    ORDER BY timestamp DESC, id DESC
+`, startTime, endTime)
+```
+
+`GetAllTransactions`:
+```go
+rows, err := s.db.Query(`
+    SELECT id, timestamp, description, status, external_id, type
+    FROM transactions
+    ORDER BY timestamp DESC, id DESC
+    LIMIT ?
+`, limit)
+```
+
+- [ ] **Step 6: Update UpdateTransactionBasic**
+
+In `internal/store/sqlite_transaction.go`, update `UpdateTransactionBasic`:
+```go
+func (s *Store) UpdateTransactionBasic(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error {
+	result, err := s.db.Exec(`
+        UPDATE transactions
+        SET description = ?, timestamp = ?, status = ?, type = ?
+        WHERE id = ?
+    `, description, timestamp, status, txType, txID)
+	if err != nil {
+		return fmt.Errorf("failed to update transaction: %w", err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return fmt.Errorf("transaction with ID %d not found", txID)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 7: Verify build**
+
+```bash
+go build ./...
+```
+Expected: compile errors in the mock (`testhelper_test.go`) — that is expected and fixed in the next task.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/repository/interfaces.go internal/store/sqlite_transaction.go
+git commit -m "feat: include type in all transaction store INSERT/SELECT/UPDATE"
+```
+
+---
+
+### Task 4: Update mock infrastructure
+
+**Files:**
+- Modify: `internal/service/testhelper_test.go`
+
+- [ ] **Step 1: Update mock UpdateTransactionBasic signature**
+
+In `internal/service/testhelper_test.go`, update `mockTransactionRepo.UpdateTransactionBasic`:
+```go
+func (m *mockTransactionRepo) UpdateTransactionBasic(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	tx, ok := m.transactions[txID]
+	if !ok {
+		return fmt.Errorf("transaction ID %d not found", txID)
+	}
+	tx.Description = description
+	tx.Timestamp = timestamp
+	tx.Status = status
+	tx.Type = txType
+	return nil
+}
+```
+
+- [ ] **Step 2: Update mock GetTransactionsByDateRange to return stored transactions**
+
+In `internal/service/testhelper_test.go`, update `mockTransactionRepo.GetTransactionsByDateRange` to return all seeded transactions (date range is ignored in tests):
+```go
+func (m *mockTransactionRepo) GetTransactionsByDateRange(startTime, endTime int64) ([]*model.Transaction, error) {
+	result := make([]*model.Transaction, 0, len(m.transactions))
+	for _, tx := range m.transactions {
+		result = append(result, tx)
+	}
+	return result, nil
+}
+```
+
+- [ ] **Step 3: Run tests to see what still breaks**
+
+```bash
+go test ./internal/service/... -v 2>&1 | head -60
+```
+Expected: compile errors in `transaction_ops_test.go` (missing `Type` on `TransactionDetail` inputs, and `UpdateTransactionComplete` signature mismatch). These are fixed in Task 6.
+
+---
+
+### Task 5: ValidateSplitsMatchType (TDD)
+
+**Files:**
+- Modify: `internal/service/transaction_classifier_test.go`
+- Modify: `internal/service/transaction_classifier.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `internal/service/transaction_classifier_test.go`:
+```go
+// ──────────────────────────────────────────────
+// ValidateSplitsMatchType
+// ──────────────────────────────────────────────
+
+func TestValidateSplitsMatchType(t *testing.T) {
+	svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
+
+	tests := []struct {
+		name    string
+		txType  model.TransactionType
+		splits  []model.SplitDetail
+		wantErr bool
+	}{
+		{
+			name:   "expense: E + A is valid",
+			txType: model.TxTypeExpense,
+			splits: []model.SplitDetail{
+				split("Expenses:Food", model.AccountTypeExpense, 500),
+				split("Assets:Bank", model.AccountTypeAsset, -500),
+			},
+			wantErr: false,
+		},
+		{
+			name:   "expense: missing E account",
+			txType: model.TxTypeExpense,
+			splits: []model.SplitDetail{
+				split("Assets:Bank", model.AccountTypeAsset, 500),
+				split("Assets:Cash", model.AccountTypeAsset, -500),
+			},
+			wantErr: true,
+		},
+		{
+			name:   "expense: missing A/L account",
+			txType: model.TxTypeExpense,
+			splits: []model.SplitDetail{
+				split("Expenses:Food", model.AccountTypeExpense, 500),
+				split("Expenses:Drink", model.AccountTypeExpense, -500),
+			},
+			wantErr: true,
+		},
+		{
+			name:   "income: R + A is valid",
+			txType: model.TxTypeIncome,
+			splits: []model.SplitDetail{
+				split("Revenue:Salary", model.AccountTypeRevenue, -1000),
+				split("Assets:Bank", model.AccountTypeAsset, 1000),
+			},
+			wantErr: false,
+		},
+		{
+			name:   "income: missing R account",
+			txType: model.TxTypeIncome,
+			splits: []model.SplitDetail{
+				split("Assets:Bank", model.AccountTypeAsset, 500),
+				split("Assets:Cash", model.AccountTypeAsset, -500),
+			},
+			wantErr: true,
+		},
+		{
+			name:   "income: missing A/L account",
+			txType: model.TxTypeIncome,
+			splits: []model.SplitDetail{
+				split("Revenue:Salary", model.AccountTypeRevenue, 1000),
+				split("Revenue:Bonus", model.AccountTypeRevenue, -1000),
+			},
+			wantErr: true,
+		},
+		{
+			name:   "transfer: two A accounts is valid",
+			txType: model.TxTypeTransfer,
+			splits: []model.SplitDetail{
+				split("Assets:Checking", model.AccountTypeAsset, 500),
+				split("Assets:Savings", model.AccountTypeAsset, -500),
+			},
+			wantErr: false,
+		},
+		{
+			name:   "transfer: A + L is valid",
+			txType: model.TxTypeTransfer,
+			splits: []model.SplitDetail{
+				split("Assets:Bank", model.AccountTypeAsset, 500),
+				split("Liabilities:Card", model.AccountTypeLiability, -500),
+			},
+			wantErr: false,
+		},
+		{
+			name:   "transfer: contains E account is invalid",
+			txType: model.TxTypeTransfer,
+			splits: []model.SplitDetail{
+				split("Assets:Bank", model.AccountTypeAsset, 500),
+				split("Expenses:Food", model.AccountTypeExpense, -500),
+			},
+			wantErr: true,
+		},
+		{
+			name:   "opening: always valid",
+			txType: model.TxTypeOpening,
+			splits: []model.SplitDetail{
+				split("Assets:Bank", model.AccountTypeAsset, 500),
+				split("Equity:OpeningBalances_TWD", model.AccountTypeEquity, -500),
+			},
+			wantErr: false,
+		},
+		{
+			name:   "other: always valid",
+			txType: model.TxTypeOther,
+			splits: []model.SplitDetail{
+				split("Assets:Bank", model.AccountTypeAsset, 500),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := svc.ValidateSplitsMatchType(tt.txType, tt.splits)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/service/ -run TestValidateSplitsMatchType -v
+```
+Expected: FAIL — `ValidateSplitsMatchType` undefined.
+
+- [ ] **Step 3: Implement ValidateSplitsMatchType**
+
+Add to `internal/service/transaction_classifier.go`:
+```go
+func (ts *TransactionService) ValidateSplitsMatchType(txType model.TransactionType, splits []model.SplitDetail) error {
+	resolveType := func(s model.SplitDetail) (model.AccountType, error) {
+		if s.AccountType != "" {
+			return s.AccountType, nil
+		}
+		acc, err := ts.accRepo.GetAccountByName(s.AccountName)
+		if err != nil {
+			return "", err
+		}
+		return acc.Type, nil
+	}
+
+	switch txType {
+	case model.TxTypeOpening, model.TxTypeOther, model.TxTypeDeposit, model.TxTypeWithdrawal:
+		return nil
+
+	case model.TxTypeExpense:
+		var hasExpense, hasAssetOrLiab bool
+		for _, s := range splits {
+			accType, err := resolveType(s)
+			if err != nil {
+				return err
+			}
+			if accType == model.AccountTypeExpense {
+				hasExpense = true
+			}
+			if accType == model.AccountTypeAsset || accType == model.AccountTypeLiability {
+				hasAssetOrLiab = true
+			}
+		}
+		if !hasExpense {
+			return fmt.Errorf("expense transaction requires at least one Expense account")
+		}
+		if !hasAssetOrLiab {
+			return fmt.Errorf("expense transaction requires at least one Asset or Liability account")
+		}
+
+	case model.TxTypeIncome:
+		var hasRevenue, hasAssetOrLiab bool
+		for _, s := range splits {
+			accType, err := resolveType(s)
+			if err != nil {
+				return err
+			}
+			if accType == model.AccountTypeRevenue {
+				hasRevenue = true
+			}
+			if accType == model.AccountTypeAsset || accType == model.AccountTypeLiability {
+				hasAssetOrLiab = true
+			}
+		}
+		if !hasRevenue {
+			return fmt.Errorf("income transaction requires at least one Revenue account")
+		}
+		if !hasAssetOrLiab {
+			return fmt.Errorf("income transaction requires at least one Asset or Liability account")
+		}
+
+	case model.TxTypeTransfer:
+		for _, s := range splits {
+			accType, err := resolveType(s)
+			if err != nil {
+				return err
+			}
+			if accType != model.AccountTypeAsset && accType != model.AccountTypeLiability {
+				return fmt.Errorf("transfer transaction must only contain Asset and Liability accounts (found account type %q)", accType)
+			}
+		}
+	}
+
+	return nil
+}
+```
+
+Also add `"fmt"` to the import block in `transaction_classifier.go` if not already present.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/service/ -run TestValidateSplitsMatchType -v
+```
+Expected: all subtests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/transaction_classifier.go internal/service/transaction_classifier_test.go
+git commit -m "feat: add ValidateSplitsMatchType to enforce split structure per transaction type"
+```
+
+---
+
+### Task 6: Update CreateTransaction and CreateSimpleTransaction
+
+**Files:**
+- Modify: `internal/service/transaction_ops.go`
+- Modify: `internal/service/transaction_ops_test.go`
+
+- [ ] **Step 1: Update CreateTransaction tests to include Type**
+
+In `internal/service/transaction_ops_test.go`, every `model.TransactionDetail` input passed to `CreateTransaction` needs a `Type` field. Find all test cases in `TestCreateTransaction` and add `Type: model.TxTypeExpense` (or the appropriate type for that test). For example, a test with splits of E + A accounts should use `Type: model.TxTypeExpense`. Also add a test for missing type returning an error:
+
+```go
+{
+    name: "error: missing type",
+    input: model.TransactionDetail{
+        Splits: []model.SplitDetail{
+            {AccountName: "Expenses:Food", Amount: 500},
+            {AccountName: "Assets:Bank", Amount: -500},
+        },
+    },
+    wantErr: true,
+},
+```
+
+For existing test cases that test non-type-related validation (e.g., missing splits, bad account), add `Type: model.TxTypeExpense` to avoid triggering the "missing type" error. The specific type doesn't matter for those tests — they're testing other validation paths.
+
+- [ ] **Step 2: Update CreateSimpleTransaction tests**
+
+In `internal/service/transaction_ops_test.go`, the `TestCreateSimpleTransaction` tests call `svc.CreateSimpleTransaction(...)`. Add `txType model.TransactionType` as the last argument. For each test case, pass the appropriate type (e.g., `model.TxTypeExpense` for expense tests). The function should also be called without a type (`""`) in one test to verify inference still works:
+
+```go
+{
+    name: "infers type when empty",
+    // uses an asset-to-expense setup in the mock
+    // expects type to be inferred as Expense
+},
+```
+
+- [ ] **Step 3: Update CreateTransaction implementation**
+
+In `internal/service/transaction_ops.go`, update `CreateTransaction`:
+
+After the minimum-splits check, add:
+```go
+// Require explicit type for new transactions.
+if input.Type == "" {
+    return 0, fmt.Errorf("transaction type is required")
+}
+```
+
+After the split-resolution loop (before `ValidateSplitsBalance`), add:
+```go
+if err := ts.ValidateSplitsMatchType(input.Type, input.Splits); err != nil {
+    return 0, fmt.Errorf("splits do not match transaction type %q: %w", input.Type, err)
+}
+```
+
+Update the `tx` construction to include `Type`:
+```go
+tx := model.Transaction{
+    Timestamp:   input.Timestamp,
+    Description: input.Description,
+    Status:      input.Status,
+    Type:        input.Type,
+}
+```
+
+- [ ] **Step 4: Update CreateSimpleTransaction signature and type inference**
+
+In `internal/service/transaction_ops.go`, update `CreateSimpleTransaction`:
+
+```go
+func (ts *TransactionService) CreateSimpleTransaction(fromAccount, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error) {
+	if fromAccount == toAccount {
+		return model.TransactionDetail{}, fmt.Errorf("source and destination accounts cannot be the same")
+	}
+	if amount <= 0 {
+		return model.TransactionDetail{}, fmt.Errorf("amount must be positive")
+	}
+
+	// If no type provided, infer from account types (backward compatibility for flag mode).
+	if txType == "" {
+		fromAcc, err := ts.accRepo.GetAccountByName(fromAccount)
+		if err != nil {
+			return model.TransactionDetail{}, fmt.Errorf("failed to resolve from account: %w", err)
+		}
+		toAcc, err := ts.accRepo.GetAccountByName(toAccount)
+		if err != nil {
+			return model.TransactionDetail{}, fmt.Errorf("failed to resolve to account: %w", err)
+		}
+		inferred, err := ts.DetermineType([]model.SplitDetail{
+			{AccountType: toAcc.Type, Amount: amount},
+			{AccountType: fromAcc.Type, Amount: -amount},
+		})
+		if err != nil {
+			return model.TransactionDetail{}, err
+		}
+		txType = inferred
+	}
+
+	splits := []model.SplitDetail{
+		{AccountName: toAccount, Amount: amount},
+		{AccountName: fromAccount, Amount: -amount},
+	}
+	input := model.TransactionDetail{
+		Timestamp:   timestamp,
+		Description: desc,
+		Status:      status,
+		Type:        txType,
+		Splits:      splits,
+	}
+	id, err := ts.CreateTransaction(input)
+	if err != nil {
+		return model.TransactionDetail{}, err
+	}
+	input.ID = id
+	return input, nil
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+go test ./internal/service/ -run "TestCreateTransaction|TestCreateSimpleTransaction" -v
+```
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/service/transaction_ops.go internal/service/transaction_ops_test.go
+git commit -m "feat: require and validate Type in CreateTransaction; infer in CreateSimpleTransaction"
+```
+
+---
+
+### Task 7: Update UpdateTransactionComplete
+
+**Files:**
+- Modify: `internal/service/transaction_ops.go`
+- Modify: `internal/service/transaction_ops_test.go`
+
+- [ ] **Step 1: Update UpdateTransactionComplete tests**
+
+In `internal/service/transaction_ops_test.go`, find `TestUpdateTransactionComplete` (or similar tests that call `UpdateTransactionComplete`) and add `txType model.TransactionType` as the new parameter. Pass `model.TxTypeExpense` (or appropriate type) to test calls. Add a test for type mismatch:
+
+```go
+{
+    name: "error: splits do not match declared type",
+    txID: existingTxID,
+    txType: model.TxTypeTransfer,
+    splits: []model.SplitDetail{
+        // expense + asset splits — incompatible with Transfer
+        {AccountID: expenseAccID, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "TWD"},
+        {AccountID: assetAccID, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "TWD"},
+    },
+    wantErr: true,
+},
+```
+
+- [ ] **Step 2: Update UpdateTransactionComplete signature**
+
+In `internal/service/transaction_ops.go`, update the function signature:
+```go
+func (ts *TransactionService) UpdateTransactionComplete(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType, splits []model.SplitDetail) error {
+```
+
+After the existing splits-count and balance validation, add:
+```go
+if err := ts.ValidateSplitsMatchType(txType, splits); err != nil {
+    return fmt.Errorf("splits do not match transaction type %q: %w", txType, err)
+}
+```
+
+Update the `repo.UpdateTransactionBasic` call to pass `txType`:
+```go
+if err := repo.UpdateTransactionBasic(txID, description, timestamp, status, txType); err != nil {
+    return err
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+go test ./internal/service/ -run TestUpdate -v
+```
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/service/transaction_ops.go internal/service/transaction_ops_test.go
+git commit -m "feat: add txType param and split validation to UpdateTransactionComplete"
+```
+
+---
+
+### Task 8: Update report service
+
+**Files:**
+- Modify: `internal/service/report_service.go`
+
+- [ ] **Step 1: Update buildReportMaps to read stored type**
+
+In `internal/service/report_service.go`, replace the entire `buildReportMaps` function:
+
+```go
+func (ts *TransactionService) buildReportMaps(startTime, endTime int64, includeIncome, includeExpense bool) (incomeByAccount, expenseByAccount map[string]*model.ReportRow, err error) {
+	txSplitsMap, err := ts.txRepo.GetSplitsWithAccountsByDateRange(startTime, endTime)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	txs, err := ts.txRepo.GetTransactionsByDateRange(startTime, endTime)
+	if err != nil {
+		return nil, nil, err
+	}
+	txTypeMap := make(map[int64]model.TransactionType, len(txs))
+	for _, tx := range txs {
+		txTypeMap[tx.ID] = tx.Type
+	}
+
+	incomeByAccount = map[string]*model.ReportRow{}
+	expenseByAccount = map[string]*model.ReportRow{}
+
+	for txID, details := range txSplitsMap {
+		txType := txTypeMap[txID]
+
+		if includeIncome && txType == model.TxTypeIncome {
+			offset := offsetAccountName(details, model.AccountTypeRevenue)
+			for _, split := range details {
+				if split.AccountType == model.AccountTypeRevenue {
+					key := split.AccountName + "|" + offset
+					row := getOrCreateRowWithOffset(incomeByAccount, key, split.AccountName, offset, split.Currency)
+					row.Amount += utils.AbsInt64(split.Amount)
+					row.TxCount++
+				}
+			}
+		}
+
+		if includeExpense && txType == model.TxTypeExpense {
+			offset := offsetAccountName(details, model.AccountTypeExpense)
+			for _, split := range details {
+				if split.AccountType == model.AccountTypeExpense {
+					key := split.AccountName + "|" + offset
+					row := getOrCreateRowWithOffset(expenseByAccount, key, split.AccountName, offset, split.Currency)
+					row.Amount += utils.AbsInt64(split.Amount)
+					row.TxCount++
+				}
+			}
+		}
+	}
+
+	return incomeByAccount, expenseByAccount, nil
+}
+```
+
+- [ ] **Step 2: Run report tests**
+
+```bash
+go test ./internal/service/ -run TestGenerate -v
+```
+Expected: all PASS. (The updated mock `GetTransactionsByDateRange` now returns transactions seeded in `m.transactions`. Existing report tests that inject data via `splitsWithAccts` may need transactions added to the mock — see next step if tests fail.)
+
+- [ ] **Step 3: Fix report tests if needed**
+
+If report tests fail because `txTypeMap` is empty (transactions not seeded), update the test setup to add transactions with types via `mockTransactionRepo.addTransaction`. For each txID in `splitsWithAccts`, add a corresponding transaction:
+
+```go
+// example for an income test
+repo := newMockTransactionRepo()
+repo.splitsWithAccts = map[int64][]model.SplitDetail{
+    1: {
+        split("Revenue:Salary", model.AccountTypeRevenue, -1000),
+        split("Assets:Bank", model.AccountTypeAsset, 1000),
+    },
+}
+repo.addTransaction(&model.Transaction{ID: 1, Type: model.TxTypeIncome}, nil)
+```
+
+- [ ] **Step 4: Run full service tests**
+
+```bash
+go test ./internal/service/... -v
+```
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/report_service.go
+git commit -m "feat: replace DetermineType in buildReportMaps with stored transaction type"
+```
+
+---
+
+### Task 9: Wire Type through cmd/add
+
+**Files:**
+- Modify: `cmd/add_types.go`
+- Modify: `cmd/add.go`
+- Modify: `cmd/add_actions.go`
+
+- [ ] **Step 1: Update add_types.go**
+
+In `cmd/add_types.go`:
+
+Add `Type` to `addFlags`:
+```go
+type addFlags struct {
+	Description string
+	Amount      string
+	From        string
+	To          string
+	Status      string
+	Timestamp   string
+	Type        string
+	JSON        bool
+}
+```
+
+Add `Type` to `addTransactionInput`:
+```go
+type addTransactionInput struct {
+	FromAccountID string
+	ToAccountID   string
+	AmountCents   int64
+	Description   string
+	Timestamp     int64
+	Status        model.TransactionStatus
+	Type          model.TransactionType
+}
+```
+
+Update `TransactionProvider` interface — add `txType` param to `CreateSimpleTransaction`:
+```go
+type TransactionProvider interface {
+	GetTransactionRule(mode model.TransactionType) (model.TransactionRule, error)
+	CreateSimpleTransaction(fromAccount string, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error)
+}
+```
+
+- [ ] **Step 2: Register --type flag in NewAddCmd**
+
+In `cmd/add.go`, add inside `NewAddCmd` alongside the other flag registrations:
+```go
+cmd.Flags().StringVar(&flags.Type, "type", "", "Transaction type: expense, income, transfer")
+```
+
+- [ ] **Step 3: Pass input.Type to CreateSimpleTransaction in Run**
+
+In `cmd/add.go`, update the `CreateSimpleTransaction` call:
+```go
+result, err := r.txSvc.CreateSimpleTransaction(
+    input.FromAccountID,
+    input.ToAccountID,
+    input.AmountCents,
+    input.Description,
+    input.Timestamp,
+    input.Status,
+    input.Type,
+)
+```
+
+- [ ] **Step 4: Set input.Type in runInteractive**
+
+In `cmd/add_actions.go`, in `runInteractive`, after the existing `mode := r.determineMode(rawType)` line, add before the return statement:
+```go
+return addTransactionInput{
+    FromAccountID: fromAccount,
+    ToAccountID:   toAccount,
+    AmountCents:   amountCents,
+    Description:   description,
+    Timestamp:     timestamp,
+    Status:        status,
+    Type:          mode,
+}, nil
+```
+
+(Replace the existing return statement — just add `Type: mode` to the struct literal.)
+
+- [ ] **Step 5: Add parseTransactionType helper and update runFromFlags**
+
+In `cmd/add_actions.go`, add this private helper at the bottom of the file:
+```go
+func parseTransactionType(s string) (model.TransactionType, error) {
+	switch strings.ToLower(s) {
+	case "expense":
+		return model.TxTypeExpense, nil
+	case "income":
+		return model.TxTypeIncome, nil
+	case "transfer":
+		return model.TxTypeTransfer, nil
+	default:
+		return "", fmt.Errorf("invalid type %q: must be expense, income, or transfer", s)
+	}
+}
+```
+
+In `runFromFlags`, after the status parsing block and before the account validation, add:
+```go
+var txType model.TransactionType
+if flags.Type != "" {
+    txType, err = parseTransactionType(flags.Type)
+    if err != nil {
+        return addTransactionInput{}, err
+    }
+}
+// If txType == "", CreateSimpleTransaction will infer it from account types.
+```
+
+Update the return statement to include `Type: txType`.
+
+- [ ] **Step 6: Build and verify**
+
+```bash
+go build ./...
+```
+Expected: clean build.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/add_types.go cmd/add.go cmd/add_actions.go
+git commit -m "feat: add --type flag to kea add; wire type through add flow"
+```
+
+---
+
+### Task 10: cmd/transaction/edit — Change Type action
+
+**Files:**
+- Modify: `cmd/transaction/edit_types.go`
+- Modify: `cmd/transaction/edit_actions.go`
+- Modify: `cmd/transaction/edit.go`
+
+- [ ] **Step 1: Update EditProvider interface and add constant**
+
+In `cmd/transaction/edit_types.go`:
+
+Add `OptChangeType` constant:
+```go
+const (
+	OptBasicInfo    = "Basic Info (description, date, status)"
+	OptChangeType   = "Change Type"
+	OptQuickAccount = "Change Account (quick edit)"
+	OptQuickAmount  = "Change Amount (both sides)"
+	OptEditSplits   = "Edit Splits (Advanced)"
+	OptSave         = "Save & Exit"
+	OptCancel       = "Cancel (discard changes)"
+)
+```
+
+Update `EditProvider` — remove `DetermineType`, add `ValidateSplitsMatchType`, update `UpdateTransactionComplete`:
+```go
+type EditProvider interface {
+	GetTransactionByID(txID int64) (*model.TransactionDetail, error)
+	IsEditable(detail *model.TransactionDetail) (bool, service.NotEditableReason)
+	GetAllowedAccounts(txType model.TransactionType, currentAccountType model.AccountType, allAccounts []*model.Account) []*model.Account
+	ValidateTransactionEdit(splits []model.SplitDetail) error
+	ValidateSplitsMatchType(txType model.TransactionType, splits []model.SplitDetail) error
+	UpdateTransactionComplete(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType, splits []model.SplitDetail) error
+}
+```
+
+- [ ] **Step 2: Implement actionEditType**
+
+Add to `cmd/transaction/edit_actions.go`:
+```go
+func (r *editRunner) actionEditType(detail *model.TransactionDetail) error {
+	rawType, err := prompts.PromptTransactionType()
+	if err != nil {
+		return err
+	}
+
+	newType := r.determineMode(rawType)
+
+	if err := r.txSvc.ValidateSplitsMatchType(newType, detail.Splits); err != nil {
+		r.view.ShowWarning(fmt.Sprintf("Cannot change type to %s: %s", newType, err.Error()))
+		r.view.ShowWarning("Fix the splits first, then change the type.")
+		return nil
+	}
+
+	detail.Type = newType
+	r.view.ShowSuccess(fmt.Sprintf("Type changed to: %s", newType))
+	return nil
+}
+```
+
+Also add a `determineMode` helper to `edit_actions.go` (same logic as in `add_actions.go`):
+```go
+func (r *editRunner) determineMode(rawInput string) model.TransactionType {
+	lower := strings.ToLower(rawInput)
+	if strings.Contains(lower, "expense") {
+		return model.TxTypeExpense
+	}
+	if strings.Contains(lower, "income") {
+		return model.TxTypeIncome
+	}
+	return model.TxTypeTransfer
+}
+```
+
+Add necessary imports at the top of `edit_actions.go`: `"fmt"`, `"strings"`, `"github.com/hance08/kea/ui/prompts"` (if not already present).
+
+- [ ] **Step 3: Update actionSave to pass detail.Type**
+
+In `cmd/transaction/edit_actions.go`, update `actionSave`:
+```go
+func (r *editRunner) actionSave(detail *model.TransactionDetail) error {
+	splits := detail.ToSplitInputs()
+	if err := r.txSvc.ValidateTransactionEdit(splits); err != nil {
+		return err
+	}
+	if err := r.txSvc.UpdateTransactionComplete(
+		r.txID, detail.Description, detail.Timestamp, detail.Status, detail.Type, splits,
+	); err != nil {
+		return err
+	}
+	r.view.ShowSuccess(fmt.Sprintf("Transaction (ID: %d) saved successfully", r.txID))
+	return nil
+}
+```
+
+- [ ] **Step 4: Add Change Type to the edit menu**
+
+In `cmd/transaction/edit.go`, in `getAvailableMenuItems`, add the Change Type item after the Basic Info item:
+```go
+{
+    Label:     OptChangeType,
+    Condition: func(d *model.TransactionDetail) bool { return d.Type != model.TxTypeOpening },
+    Action:    r.actionEditType,
+},
+```
+
+Also update `actionQuickChangeAccount` in `edit_actions.go` to read type from `detail.Type` instead of calling `DetermineType`:
+```go
+func (r *editRunner) actionQuickChangeAccount(detail *model.TransactionDetail) error {
+	if len(detail.Splits) != 2 {
+		return fmt.Errorf("quick edit supports only 2 splits")
+	}
+
+	txType := detail.Type
+
+	if txType == model.TxTypeOpening {
+		r.view.ShowWarning("Cannot quick-edit Opening Balance transaction")
+		return nil
+	}
+	// ... rest unchanged
+```
+
+- [ ] **Step 5: Build and verify**
+
+```bash
+go build ./...
+```
+Expected: clean build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/transaction/edit_types.go cmd/transaction/edit_actions.go cmd/transaction/edit.go
+git commit -m "feat: add Change Type action to kea edit with immediate split validation"
+```
+
+---
+
+### Task 11: Display logic cleanup
+
+**Files:**
+- Modify: `cmd/transaction/list.go`
+
+- [ ] **Step 1: Replace DetermineType call in list.go**
+
+In `cmd/transaction/list.go`, find the `DetermineType` call (around line 117). Replace:
+```go
+txTypeEnum, err := r.svc.DetermineType(detail.Splits)
+if err != nil {
+    r.view.ShowWarning("failed to determine transaction type for tx %d: %v", detail.ID, err)
+    continue
+}
+```
+with:
+```go
+txTypeEnum := detail.Type
+```
+
+- [ ] **Step 2: Remove DetermineType from ListProvider interface**
+
+In `cmd/transaction/list.go`, remove `DetermineType` from the `ListProvider` interface:
+```go
+type ListProvider interface {
+	GetTransactionHistory(accountName string, limit int) ([]*model.Transaction, error)
+	GetRecentTransactions(limit int) ([]*model.Transaction, error)
+	GetTransactionByID(txID int64) (*model.TransactionDetail, error)
+	GetDisplayAccount(splits []model.SplitDetail, txType string) (string, error)
+	GetDisplayOffsetAccount(splits []model.SplitDetail, txType string, primaryAccount string) (string, error)
+	GetDisplayAmount(splits []model.SplitDetail) (int64, string)
+}
+```
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+go test ./... -v 2>&1 | tail -30
+```
+Expected: all PASS. If any test references `DetermineType` in a mock or test double, remove it.
+
+- [ ] **Step 4: Final build check**
+
+```bash
+make build
+```
+Expected: clean binary.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/transaction/list.go
+git commit -m "feat: replace DetermineType display-time inference with stored Type field"
+```

--- a/docs/superpowers/specs/2026-04-23-transaction-type-storage-design.md
+++ b/docs/superpowers/specs/2026-04-23-transaction-type-storage-design.md
@@ -1,0 +1,179 @@
+# Transaction Type Storage Design
+
+**Date:** 2026-04-23
+**Status:** Approved
+
+## Problem
+
+`DetermineType` in `internal/service/transaction_classifier.go` infers the transaction type from splits at display time. This breaks down for complex multi-split transactions where the split shape is ambiguous and the user's intent cannot be reliably recovered. Type should be stored explicitly on the transaction record.
+
+## Goals
+
+- Store `type` as a non-nullable column on the `transactions` table.
+- Capture type as the first prompt in the interactive `kea add` flow (already done) and persist it.
+- Add a `--type` flag to `kea add` for flag mode.
+- Validate that splits are structurally consistent with the declared type at create and update time.
+- Allow type changes in `kea edit` with immediate re-validation feedback.
+- Replace all three `DetermineType` display-time call sites with direct field reads.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Type field nullability | Non-nullable, SQL backfill | Eliminates Go-side nil-checks; backfill migration covers all existing rows |
+| Validation strictness | Strict structural enforcement | Prevents data corruption; rules are fully enumerable for the three user-facing types |
+| Validation rule source | Service `GetTransactionRule` | Single source of truth; extensible when new types are added |
+| Migration structure | Two files: schema then backfill | Each file is independently rollback-safe |
+| Edit UX | Immediate re-validation on type change | User sees incompatibility before save, not at save |
+
+## Architecture
+
+### Migrations
+
+**`0005_add_transaction_type.up.sql`**
+```sql
+ALTER TABLE transactions ADD COLUMN type TEXT NOT NULL DEFAULT '';
+```
+Uses `DEFAULT ''` as a temporary sentinel required by SQLite for NOT NULL on ALTER TABLE. Overwritten by migration 0006 before any Go code reads it.
+
+**`0006_backfill_transaction_type.up.sql`**
+Classifies every existing row via a SQL correlated subquery joining splits to accounts — mirrors the logic of `DetermineType`:
+
+```sql
+UPDATE transactions SET type = (
+  SELECT
+    CASE
+      WHEN memo_check.has_opening    THEN 'Opening'
+      WHEN has_exp AND has_rev       THEN CASE WHEN rev_sum >= exp_sum THEN 'Income' ELSE 'Expense' END
+      WHEN has_exp AND al_cnt >= 1   THEN 'Expense'
+      WHEN has_rev AND al_cnt >= 1   THEN 'Income'
+      WHEN al_cnt >= 2               THEN 'Transfer'
+      ELSE 'Other'
+    END
+  FROM (
+    SELECT
+      MAX(CASE WHEN a.type = 'E' THEN 1 ELSE 0 END) AS has_exp,
+      MAX(CASE WHEN a.type = 'R' THEN 1 ELSE 0 END) AS has_rev,
+      SUM(CASE WHEN a.type IN ('A','L') THEN 1 ELSE 0 END) AS al_cnt,
+      SUM(CASE WHEN a.type = 'E' THEN ABS(s.amount) ELSE 0 END) AS exp_sum,
+      SUM(CASE WHEN a.type = 'R' THEN ABS(s.amount) ELSE 0 END) AS rev_sum
+    FROM splits s JOIN accounts a ON s.account_id = a.id
+    WHERE s.transaction_id = transactions.id
+  ) agg,
+  (
+    SELECT MAX(CASE WHEN s.memo = 'Opening Balance' THEN 1 ELSE 0 END) AS has_opening
+    FROM splits s WHERE s.transaction_id = transactions.id
+  ) memo_check
+);
+```
+
+Corresponding `.down.sql` files revert each change independently.
+
+### Model (`internal/model/transaction.go`)
+
+`Type TransactionType` added to both `Transaction` (persistence struct) and `TransactionDetail` (rich view struct). No changes to `model/types.go` — `TransactionType` and its constants already exist.
+
+### Store (`internal/store/sqlite_transaction.go`)
+
+- `CreateTransactionWithSplits` — `type` added to INSERT columns and params.
+- `scanTransactions` — `type` added to SELECT and `rows.Scan`. Cascades to all four read methods that call it.
+- `UpdateTransactionBasic` — gains `txType model.TransactionType` param; `type` added to SET clause.
+- `internal/repository/interfaces.go` — `UpdateTransactionBasic` signature updated to match.
+
+### Service (`internal/service/`)
+
+**New: `ValidateSplitsMatchType`** in `transaction_classifier.go`
+
+Validates split account types against the declared transaction type. Rules:
+
+| Type | Required split accounts |
+|---|---|
+| `Expense` | ≥1 `E` account + ≥1 `A` or `L` account |
+| `Income` | ≥1 `R` account + ≥1 `A` or `L` account |
+| `Transfer` | only `A` or `L` accounts (≥2 splits total) |
+| `Opening`, `Other`, etc. | skip (internal types) |
+
+Account types are resolved from `split.AccountType` if present, otherwise via `accRepo.GetAccountByID` (same pattern as `DetermineType`).
+
+Extensibility: adding a new user-facing type (e.g., Investment Deposit) requires adding a new rule branch here and a new entry in the service rule registry — one place to change.
+
+**`CreateTransaction`** (`transaction_ops.go`)
+
+After split resolution: call `ValidateSplitsMatchType(input.Type, resolvedSplits)` before `ValidateSplitsBalance`. Populate `tx.Type = input.Type` when building the `model.Transaction` to persist.
+
+**`UpdateTransactionComplete`** (`transaction_ops.go`)
+
+New signature:
+```go
+func (ts *TransactionService) UpdateTransactionComplete(
+    txID int64,
+    description string,
+    timestamp int64,
+    status model.TransactionStatus,
+    txType model.TransactionType,
+    splits []model.SplitDetail,
+) error
+```
+
+Calls `ValidateSplitsMatchType` and passes `txType` to `repo.UpdateTransactionBasic`.
+
+**`CreateSimpleTransaction`** (`transaction_ops.go`)
+
+Gains `txType model.TransactionType` param. Populates `input.Type` in the `TransactionDetail` it builds before calling `CreateTransaction`.
+
+**`DetermineType`** — retained in `transaction_classifier.go`. No longer called in production paths after display logic migration, but kept for testing and future tooling (imports, data repair).
+
+### `cmd/add`
+
+**`addFlags`** — new `Type string` field.
+
+**`NewAddCmd`** — registers `--type` flag:
+```go
+cmd.Flags().StringVar(&flags.Type, "type", "", "Transaction type: expense, income, transfer")
+```
+
+**`hasFlags` detection** — `"type"` added to the `cmd.Flags().Changed(...)` check per Pattern C.
+
+**`runInteractive`** — no structural change. Already calls `PromptTransactionType()` as Step 1 and derives mode. Addition: `input.Type = mode` before returning.
+
+**`runFromFlags`** — parses `flags.Type` into `model.TransactionType`, validates it is one of `expense/income/transfer`, populates `input.Type`. If `--type` is omitted in flag mode, `DetermineType` is called on the two resolved splits to infer the type — preserving backward compatibility with existing flag usage. Type-consistency against accounts is enforced downstream by `ValidateSplitsMatchType`.
+
+**`TransactionProvider` interface** — `CreateSimpleTransaction` signature updated to include `txType`.
+
+**`addTransactionInput`** — new `Type model.TransactionType` field.
+
+### `cmd/transaction/edit`
+
+**Edit menu** — "Change Type" added as a new action. Hidden for Opening Balance transactions (same guard used by existing actions).
+
+**`actionEditType`** (`edit_actions.go`):
+1. Call `prompts.PromptTransactionType()`.
+2. Call `ts.txSvc.ValidateSplitsMatchType(newType, detail.Splits)` immediately.
+3. On failure: `r.view.ShowWarning(...)` — return without mutating `detail`. User sees incompatibility before saving.
+4. On success: `detail.Type = newType` + success message.
+
+**`actionSave`** — passes `detail.Type` to the updated `UpdateTransactionComplete`.
+
+**`EditProvider` interface** — `ValidateSplitsMatchType` added; `UpdateTransactionComplete` signature updated.
+
+### Display Logic
+
+Three `DetermineType` call sites replaced with direct field reads:
+
+| File | Before | After |
+|---|---|---|
+| `cmd/transaction/list.go:117` | `r.svc.DetermineType(detail.Splits)` | `detail.Type` |
+| `cmd/transaction/edit_actions.go:42` | `r.txSvc.DetermineType(detail.Splits)` | `detail.Type` |
+| `internal/service/report_service.go:67` | `ts.DetermineType(details)` | `tx.Type` |
+
+`DetermineType` removed from `ListProvider` and `EditProvider` interfaces.
+
+## Implementation Order
+
+1. Migrations (`0005`, `0006`) — schema and backfill
+2. Model — `Type` field on `Transaction` and `TransactionDetail`
+3. Store — INSERT, SELECT (`scanTransactions`), `UpdateTransactionBasic`
+4. Service — `ValidateSplitsMatchType`, update `CreateTransaction`, `CreateSimpleTransaction`, `UpdateTransactionComplete`
+5. `cmd/add` — `--type` flag, wire `input.Type` through interactive and flag modes
+6. `cmd/transaction/edit` — "Change Type" action, update `actionSave`
+7. Display logic — replace `DetermineType` calls with field reads, clean up interfaces

--- a/internal/model/transaction.go
+++ b/internal/model/transaction.go
@@ -7,6 +7,7 @@ type Transaction struct {
 	Timestamp   int64
 	Description string
 	Status      TransactionStatus
+	Type        TransactionType
 	ExternalID  *string
 }
 
@@ -15,6 +16,7 @@ type TransactionDetail struct {
 	Timestamp   int64
 	Description string
 	Status      TransactionStatus
+	Type        TransactionType
 	Splits      []SplitDetail
 }
 

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -31,7 +31,7 @@ type TransactionRepository interface {
 
 	UpdateTransactionStatus(txID int64, status model.TransactionStatus) error
 	DeleteTransaction(txID int64) error
-	UpdateTransactionBasic(txID int64, description string, timestamp int64, status model.TransactionStatus) error
+	UpdateTransactionBasic(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error
 
 	CreateSplit(txID int64, split *model.Split) (int64, error)
 	UpdateSplit(splitID int64, accountID int64, amount int64, currency string, memo string) error

--- a/internal/service/account_ops.go
+++ b/internal/service/account_ops.go
@@ -78,6 +78,7 @@ func (as *AccountService) createOpeningBalance(account *model.Account, amountInC
 		Timestamp:   time.Now().Unix(),
 		Description: model.OpeningAccountMemo,
 		Status:      model.StatusCleared,
+		Type:        model.TxTypeOpening,
 	}
 
 	return as.tm.ExecTx(context.Background(), func(repo repository.Repository) error {

--- a/internal/service/report_service.go
+++ b/internal/service/report_service.go
@@ -60,14 +60,20 @@ func (ts *TransactionService) buildReportMaps(startTime, endTime int64, includeI
 		return nil, nil, err
 	}
 
+	txs, err := ts.txRepo.GetTransactionsByDateRange(startTime, endTime)
+	if err != nil {
+		return nil, nil, err
+	}
+	txTypeMap := make(map[int64]model.TransactionType, len(txs))
+	for _, tx := range txs {
+		txTypeMap[tx.ID] = tx.Type
+	}
+
 	incomeByAccount = map[string]*model.ReportRow{}
 	expenseByAccount = map[string]*model.ReportRow{}
 
-	for _, details := range txSplitsMap {
-		txType, err := ts.DetermineType(details)
-		if err != nil {
-			return nil, nil, err
-		}
+	for txID, details := range txSplitsMap {
+		txType := txTypeMap[txID]
 
 		if includeIncome && txType == model.TxTypeIncome {
 			offset := offsetAccountName(details, model.AccountTypeRevenue)

--- a/internal/service/report_service_test.go
+++ b/internal/service/report_service_test.go
@@ -151,6 +151,7 @@ func TestGenerateIncomeStatement(t *testing.T) {
 			split("Revenue:Salary", model.AccountTypeRevenue, -2000),
 			split("Assets:Bank", model.AccountTypeAsset, 2000),
 		)
+		txRepo.addTransaction(&model.Transaction{ID: 1, Type: model.TxTypeIncome}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
 		result, err := svc.GenerateIncomeStatement(0, 0)
@@ -168,6 +169,7 @@ func TestGenerateIncomeStatement(t *testing.T) {
 			split("Expenses:Food", model.AccountTypeExpense, 500),
 			split("Assets:Bank", model.AccountTypeAsset, -500),
 		)
+		txRepo.addTransaction(&model.Transaction{ID: 1, Type: model.TxTypeExpense}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
 		result, err := svc.GenerateIncomeStatement(0, 0)
@@ -189,6 +191,8 @@ func TestGenerateIncomeStatement(t *testing.T) {
 			split("Expenses:Food", model.AccountTypeExpense, 800),
 			split("Assets:Bank", model.AccountTypeAsset, -800),
 		)
+		txRepo.addTransaction(&model.Transaction{ID: 1, Type: model.TxTypeIncome}, nil)
+		txRepo.addTransaction(&model.Transaction{ID: 2, Type: model.TxTypeExpense}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
 		result, err := svc.GenerateIncomeStatement(0, 0)
@@ -204,6 +208,7 @@ func TestGenerateIncomeStatement(t *testing.T) {
 			split("Assets:Savings", model.AccountTypeAsset, 1000),
 			split("Assets:Checking", model.AccountTypeAsset, -1000),
 		)
+		txRepo.addTransaction(&model.Transaction{ID: 1, Type: model.TxTypeTransfer}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
 		result, err := svc.GenerateIncomeStatement(0, 0)
@@ -233,6 +238,8 @@ func TestGenerateIncomeStatement(t *testing.T) {
 			split("Revenue:Salary", model.AccountTypeRevenue, -3000),
 			split("Assets:Bank", model.AccountTypeAsset, 3000),
 		)
+		txRepo.addTransaction(&model.Transaction{ID: 1, Type: model.TxTypeIncome}, nil)
+		txRepo.addTransaction(&model.Transaction{ID: 2, Type: model.TxTypeIncome}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
 		result, err := svc.GenerateIncomeStatement(0, 0)
@@ -251,6 +258,8 @@ func TestGenerateIncomeStatement(t *testing.T) {
 			split("Expenses:Food", model.AccountTypeExpense, 200),
 			split("Assets:Bank", model.AccountTypeAsset, -200),
 		)
+		txRepo.addTransaction(&model.Transaction{ID: 1, Type: model.TxTypeExpense}, nil)
+		txRepo.addTransaction(&model.Transaction{ID: 2, Type: model.TxTypeExpense}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
 		result, err := svc.GenerateIncomeStatement(0, 0)
@@ -287,6 +296,8 @@ func TestGenerateIncomeBreakdown(t *testing.T) {
 			split("Expenses:Food", model.AccountTypeExpense, 500),
 			split("Assets:Bank", model.AccountTypeAsset, -500),
 		)
+		txRepo.addTransaction(&model.Transaction{ID: 1, Type: model.TxTypeIncome}, nil)
+		txRepo.addTransaction(&model.Transaction{ID: 2, Type: model.TxTypeExpense}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
 		result, err := svc.GenerateIncomeBreakdown(0, 0)
@@ -306,6 +317,8 @@ func TestGenerateIncomeBreakdown(t *testing.T) {
 			split("Revenue:Salary", model.AccountTypeRevenue, -5000),
 			split("Assets:Bank", model.AccountTypeAsset, 5000),
 		)
+		txRepo.addTransaction(&model.Transaction{ID: 1, Type: model.TxTypeIncome}, nil)
+		txRepo.addTransaction(&model.Transaction{ID: 2, Type: model.TxTypeIncome}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
 		result, err := svc.GenerateIncomeBreakdown(0, 0)
@@ -330,6 +343,8 @@ func TestGenerateExpenseBreakdown(t *testing.T) {
 			split("Expenses:Food", model.AccountTypeExpense, 500),
 			split("Assets:Bank", model.AccountTypeAsset, -500),
 		)
+		txRepo.addTransaction(&model.Transaction{ID: 1, Type: model.TxTypeIncome}, nil)
+		txRepo.addTransaction(&model.Transaction{ID: 2, Type: model.TxTypeExpense}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
 		result, err := svc.GenerateExpenseBreakdown(0, 0)

--- a/internal/service/report_service_test.go
+++ b/internal/service/report_service_test.go
@@ -279,6 +279,15 @@ func TestGenerateIncomeStatement(t *testing.T) {
 		_, err := svc.GenerateIncomeStatement(0, 0)
 		assert.Error(t, err)
 	})
+
+	t.Run("txs by date range error returns error", func(t *testing.T) {
+		txRepo := newMockTransactionRepo()
+		txRepo.txsByDateRangeErr = assert.AnError
+		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
+
+		_, err := svc.GenerateIncomeStatement(0, 0)
+		assert.Error(t, err)
+	})
 }
 
 // ──────────────────────────────────────────────

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -305,7 +305,11 @@ func (m *mockTransactionRepo) GetTransactionsByAccount(accountID int64, limit in
 }
 
 func (m *mockTransactionRepo) GetTransactionsByDateRange(startTime, endTime int64) ([]*model.Transaction, error) {
-	return nil, nil
+	result := make([]*model.Transaction, 0, len(m.transactions))
+	for _, tx := range m.transactions {
+		result = append(result, tx)
+	}
+	return result, nil
 }
 
 func (m *mockTransactionRepo) GetAllTransactions(limit int) ([]*model.Transaction, error) {
@@ -340,7 +344,7 @@ func (m *mockTransactionRepo) DeleteTransaction(txID int64) error {
 	return nil
 }
 
-func (m *mockTransactionRepo) UpdateTransactionBasic(txID int64, description string, timestamp int64, status model.TransactionStatus) error {
+func (m *mockTransactionRepo) UpdateTransactionBasic(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error {
 	if m.updateErr != nil {
 		return m.updateErr
 	}
@@ -351,6 +355,7 @@ func (m *mockTransactionRepo) UpdateTransactionBasic(txID int64, description str
 	tx.Description = description
 	tx.Timestamp = timestamp
 	tx.Status = status
+	tx.Type = txType
 	return nil
 }
 

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -220,6 +220,9 @@ type mockTransactionRepo struct {
 	splitsWithAccts map[int64][]model.SplitDetail
 	splitsRangeErr  error
 
+	// default return for GetTransactionsByDateRange
+	txsByDateRangeErr error
+
 	// call recorders for interaction verification
 	deleteSplitCalls []int64
 	createSplitCalls []*model.Split
@@ -305,6 +308,9 @@ func (m *mockTransactionRepo) GetTransactionsByAccount(accountID int64, limit in
 }
 
 func (m *mockTransactionRepo) GetTransactionsByDateRange(startTime, endTime int64) ([]*model.Transaction, error) {
+	if m.txsByDateRangeErr != nil {
+		return nil, m.txsByDateRangeErr
+	}
 	result := make([]*model.Transaction, 0, len(m.transactions))
 	for _, tx := range m.transactions {
 		result = append(result, tx)

--- a/internal/service/transaction_classifier.go
+++ b/internal/service/transaction_classifier.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/utils"
 )
@@ -269,6 +271,79 @@ func (ts *TransactionService) GetAllowedAccounts(txType model.TransactionType, c
 	default:
 		return allAccounts
 	}
+}
+
+func (ts *TransactionService) ValidateSplitsMatchType(txType model.TransactionType, splits []model.SplitDetail) error {
+	resolveType := func(s model.SplitDetail) (model.AccountType, error) {
+		if s.AccountType != "" {
+			return s.AccountType, nil
+		}
+		acc, err := ts.accRepo.GetAccountByName(s.AccountName)
+		if err != nil {
+			return "", err
+		}
+		return acc.Type, nil
+	}
+
+	switch txType {
+	case model.TxTypeOpening, model.TxTypeOther, model.TxTypeDeposit, model.TxTypeWithdrawal:
+		return nil
+
+	case model.TxTypeExpense:
+		var hasExpense, hasAssetOrLiab bool
+		for _, s := range splits {
+			accType, err := resolveType(s)
+			if err != nil {
+				return err
+			}
+			if accType == model.AccountTypeExpense {
+				hasExpense = true
+			}
+			if accType == model.AccountTypeAsset || accType == model.AccountTypeLiability {
+				hasAssetOrLiab = true
+			}
+		}
+		if !hasExpense {
+			return fmt.Errorf("expense transaction requires at least one Expense account")
+		}
+		if !hasAssetOrLiab {
+			return fmt.Errorf("expense transaction requires at least one Asset or Liability account")
+		}
+
+	case model.TxTypeIncome:
+		var hasRevenue, hasAssetOrLiab bool
+		for _, s := range splits {
+			accType, err := resolveType(s)
+			if err != nil {
+				return err
+			}
+			if accType == model.AccountTypeRevenue {
+				hasRevenue = true
+			}
+			if accType == model.AccountTypeAsset || accType == model.AccountTypeLiability {
+				hasAssetOrLiab = true
+			}
+		}
+		if !hasRevenue {
+			return fmt.Errorf("income transaction requires at least one Revenue account")
+		}
+		if !hasAssetOrLiab {
+			return fmt.Errorf("income transaction requires at least one Asset or Liability account")
+		}
+
+	case model.TxTypeTransfer:
+		for _, s := range splits {
+			accType, err := resolveType(s)
+			if err != nil {
+				return err
+			}
+			if accType != model.AccountTypeAsset && accType != model.AccountTypeLiability {
+				return fmt.Errorf("transfer transaction must only contain Asset and Liability accounts (found account type %q)", accType)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (ts *TransactionService) filterAccountsByTypes(accounts []*model.Account, allowedTypes []string) []*model.Account {

--- a/internal/service/transaction_classifier.go
+++ b/internal/service/transaction_classifier.go
@@ -341,6 +341,9 @@ func (ts *TransactionService) ValidateSplitsMatchType(txType model.TransactionTy
 				return fmt.Errorf("transfer transaction must only contain Asset and Liability accounts (found account type %q)", accType)
 			}
 		}
+
+	default:
+		return fmt.Errorf("unknown transaction type %q", txType)
 	}
 
 	return nil

--- a/internal/service/transaction_classifier_test.go
+++ b/internal/service/transaction_classifier_test.go
@@ -433,3 +433,128 @@ func TestGetAllowedAccounts(t *testing.T) {
 		assert.Empty(t, result)
 	})
 }
+
+// ──────────────────────────────────────────────
+// ValidateSplitsMatchType
+// ──────────────────────────────────────────────
+
+func TestValidateSplitsMatchType(t *testing.T) {
+	svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
+
+	tests := []struct {
+		name    string
+		txType  model.TransactionType
+		splits  []model.SplitDetail
+		wantErr bool
+	}{
+		{
+			name:   "expense: E + A is valid",
+			txType: model.TxTypeExpense,
+			splits: []model.SplitDetail{
+				split("Expenses:Food", model.AccountTypeExpense, 500),
+				split("Assets:Bank", model.AccountTypeAsset, -500),
+			},
+			wantErr: false,
+		},
+		{
+			name:   "expense: missing E account",
+			txType: model.TxTypeExpense,
+			splits: []model.SplitDetail{
+				split("Assets:Bank", model.AccountTypeAsset, 500),
+				split("Assets:Cash", model.AccountTypeAsset, -500),
+			},
+			wantErr: true,
+		},
+		{
+			name:   "expense: missing A/L account",
+			txType: model.TxTypeExpense,
+			splits: []model.SplitDetail{
+				split("Expenses:Food", model.AccountTypeExpense, 500),
+				split("Expenses:Drink", model.AccountTypeExpense, -500),
+			},
+			wantErr: true,
+		},
+		{
+			name:   "income: R + A is valid",
+			txType: model.TxTypeIncome,
+			splits: []model.SplitDetail{
+				split("Revenue:Salary", model.AccountTypeRevenue, -1000),
+				split("Assets:Bank", model.AccountTypeAsset, 1000),
+			},
+			wantErr: false,
+		},
+		{
+			name:   "income: missing R account",
+			txType: model.TxTypeIncome,
+			splits: []model.SplitDetail{
+				split("Assets:Bank", model.AccountTypeAsset, 500),
+				split("Assets:Cash", model.AccountTypeAsset, -500),
+			},
+			wantErr: true,
+		},
+		{
+			name:   "income: missing A/L account",
+			txType: model.TxTypeIncome,
+			splits: []model.SplitDetail{
+				split("Revenue:Salary", model.AccountTypeRevenue, 1000),
+				split("Revenue:Bonus", model.AccountTypeRevenue, -1000),
+			},
+			wantErr: true,
+		},
+		{
+			name:   "transfer: two A accounts is valid",
+			txType: model.TxTypeTransfer,
+			splits: []model.SplitDetail{
+				split("Assets:Checking", model.AccountTypeAsset, 500),
+				split("Assets:Savings", model.AccountTypeAsset, -500),
+			},
+			wantErr: false,
+		},
+		{
+			name:   "transfer: A + L is valid",
+			txType: model.TxTypeTransfer,
+			splits: []model.SplitDetail{
+				split("Assets:Bank", model.AccountTypeAsset, 500),
+				split("Liabilities:Card", model.AccountTypeLiability, -500),
+			},
+			wantErr: false,
+		},
+		{
+			name:   "transfer: contains E account is invalid",
+			txType: model.TxTypeTransfer,
+			splits: []model.SplitDetail{
+				split("Assets:Bank", model.AccountTypeAsset, 500),
+				split("Expenses:Food", model.AccountTypeExpense, -500),
+			},
+			wantErr: true,
+		},
+		{
+			name:   "opening: always valid",
+			txType: model.TxTypeOpening,
+			splits: []model.SplitDetail{
+				split("Assets:Bank", model.AccountTypeAsset, 500),
+				split("Equity:OpeningBalances_TWD", model.AccountTypeEquity, -500),
+			},
+			wantErr: false,
+		},
+		{
+			name:   "other: always valid",
+			txType: model.TxTypeOther,
+			splits: []model.SplitDetail{
+				split("Assets:Bank", model.AccountTypeAsset, 500),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := svc.ValidateSplitsMatchType(tt.txType, tt.splits)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -219,7 +219,7 @@ func (ts *TransactionService) UpdateTransactionComplete(txID int64, description 
 	}
 
 	return ts.tm.ExecTx(context.Background(), func(repo repository.Repository) error {
-		if err := repo.UpdateTransactionBasic(txID, description, timestamp, status); err != nil {
+		if err := repo.UpdateTransactionBasic(txID, description, timestamp, status, oldTx.Type); err != nil {
 			return err
 		}
 

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -155,6 +155,31 @@ func (ts *TransactionService) CreateSimpleTransaction(fromAccount, toAccount str
 	return input, nil
 }
 
+// CreateTransactionFromSplits creates a transaction from an explicit slice of splits.
+// All validation (balance, type match, ≥2 splits, account resolution) is handled
+// by CreateTransaction.
+func (ts *TransactionService) CreateTransactionFromSplits(
+	splits []model.SplitDetail,
+	desc string,
+	timestamp int64,
+	status model.TransactionStatus,
+	txType model.TransactionType,
+) (model.TransactionDetail, error) {
+	input := model.TransactionDetail{
+		Timestamp:   timestamp,
+		Description: desc,
+		Status:      status,
+		Type:        txType,
+		Splits:      splits,
+	}
+	id, err := ts.CreateTransaction(input)
+	if err != nil {
+		return model.TransactionDetail{}, err
+	}
+	input.ID = id
+	return input, nil
+}
+
 // DeleteTransaction deletes a transaction
 func (ts *TransactionService) DeleteTransaction(txID int64) error {
 	if txID == model.OpeningBalanceTransactionID {

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -26,6 +26,10 @@ func (ts *TransactionService) CreateTransaction(input model.TransactionDetail) (
 		return 0, fmt.Errorf("transaction must have at least 2 splits (got %d)", len(input.Splits))
 	}
 
+	if input.Type == "" {
+		return 0, fmt.Errorf("transaction type is required")
+	}
+
 	// Set default timestamp: Use current system time if not provided.
 	if input.Timestamp == 0 {
 		input.Timestamp = time.Now().Unix()
@@ -57,6 +61,10 @@ func (ts *TransactionService) CreateTransaction(input model.TransactionDetail) (
 		})
 	}
 
+	if err := ts.ValidateSplitsMatchType(input.Type, input.Splits); err != nil {
+		return 0, fmt.Errorf("splits do not match transaction type %q: %w", input.Type, err)
+	}
+
 	// Validate: Ensure the sum of all splits balances to zero.
 	if err := ts.ValidateSplitsBalance(splits); err != nil {
 		return 0, err
@@ -67,6 +75,7 @@ func (ts *TransactionService) CreateTransaction(input model.TransactionDetail) (
 		Timestamp:   input.Timestamp,
 		Description: input.Description,
 		Status:      input.Status,
+		Type:        input.Type,
 	}
 
 	var newTxID int64
@@ -97,43 +106,52 @@ func (ts *TransactionService) CreateTransaction(input model.TransactionDetail) (
 //   - A Credit (negative) to the fromAccount (Source).
 //   - A Debit (positive) to the toAccount (Destination).
 //
-// Returns the new TransactionID and the constructed TransactionDetail (useful for UI rendering).
-func (ts *TransactionService) CreateSimpleTransaction(fromAccount, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus) (model.TransactionDetail, error) {
+// If txType is empty, it is inferred from the account types via DetermineType.
+// Returns the constructed TransactionDetail (useful for UI rendering).
+func (ts *TransactionService) CreateSimpleTransaction(fromAccount, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error) {
 	if fromAccount == toAccount {
 		return model.TransactionDetail{}, fmt.Errorf("source and destination accounts cannot be the same")
 	}
-
 	if amount <= 0 {
 		return model.TransactionDetail{}, fmt.Errorf("amount must be positive")
 	}
 
-	splits := []model.SplitDetail{
-		{
-			AccountName: toAccount,
-			Amount:      amount,
-			Memo:        "",
-		},
-		{
-			AccountName: fromAccount,
-			Amount:      -amount,
-			Memo:        "",
-		},
+	// If no type provided, infer from account types.
+	if txType == "" {
+		fromAcc, err := ts.accRepo.GetAccountByName(fromAccount)
+		if err != nil {
+			return model.TransactionDetail{}, fmt.Errorf("failed to resolve from account: %w", err)
+		}
+		toAcc, err := ts.accRepo.GetAccountByName(toAccount)
+		if err != nil {
+			return model.TransactionDetail{}, fmt.Errorf("failed to resolve to account: %w", err)
+		}
+		inferred, err := ts.DetermineType([]model.SplitDetail{
+			{AccountType: toAcc.Type, Amount: amount},
+			{AccountType: fromAcc.Type, Amount: -amount},
+		})
+		if err != nil {
+			return model.TransactionDetail{}, err
+		}
+		txType = inferred
 	}
 
+	splits := []model.SplitDetail{
+		{AccountName: toAccount, Amount: amount},
+		{AccountName: fromAccount, Amount: -amount},
+	}
 	input := model.TransactionDetail{
 		Timestamp:   timestamp,
 		Description: desc,
 		Status:      status,
+		Type:        txType,
 		Splits:      splits,
 	}
-
 	id, err := ts.CreateTransaction(input)
 	if err != nil {
 		return model.TransactionDetail{}, err
 	}
-
 	input.ID = id
-
 	return input, nil
 }
 

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -195,7 +195,7 @@ func (ts *TransactionService) UpdateTransactionStatus(txID int64, status model.T
 
 // UpdateTransactionComplete performs a complete update of a transaction including splits
 // This operation is atomic - either all changes succeed or all fail
-func (ts *TransactionService) UpdateTransactionComplete(txID int64, description string, timestamp int64, status model.TransactionStatus, splits []model.SplitDetail) error {
+func (ts *TransactionService) UpdateTransactionComplete(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType, splits []model.SplitDetail) error {
 	// Validate status
 	if status != model.StatusPending && status != model.StatusCleared && status != model.StatusReconciled {
 		return fmt.Errorf("invalid status: must be 0 (Pending), 1 (Cleared) or 2 (Reconciled)")
@@ -228,6 +228,10 @@ func (ts *TransactionService) UpdateTransactionComplete(txID int64, description 
 		return fmt.Errorf("splits must balance to zero (current sum: %d)", total)
 	}
 
+	if err := ts.ValidateSplitsMatchType(txType, splits); err != nil {
+		return fmt.Errorf("splits do not match transaction type %q: %w", txType, err)
+	}
+
 	// Validate all accounts exist
 	for _, split := range splits {
 		_, err := ts.accRepo.GetAccountByID(split.AccountID)
@@ -237,7 +241,7 @@ func (ts *TransactionService) UpdateTransactionComplete(txID int64, description 
 	}
 
 	return ts.tm.ExecTx(context.Background(), func(repo repository.Repository) error {
-		if err := repo.UpdateTransactionBasic(txID, description, timestamp, status, oldTx.Type); err != nil {
+		if err := repo.UpdateTransactionBasic(txID, description, timestamp, status, txType); err != nil {
 			return err
 		}
 

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -34,6 +34,7 @@ func TestCreateTransaction(t *testing.T) {
 
 		input := model.TransactionDetail{
 			Description: "Lunch",
+			Type:        model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountName: "Expenses:Food", Amount: 500},
 				{AccountName: "Assets:Bank", Amount: -500},
@@ -50,6 +51,7 @@ func TestCreateTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
 
 		input := model.TransactionDetail{
+			Type: model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountName: "Assets:Bank", Amount: 1000},
 			},
@@ -61,9 +63,25 @@ func TestCreateTransaction(t *testing.T) {
 
 	t.Run("empty splits rejected", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		_, err := svc.CreateTransaction(model.TransactionDetail{})
+		_, err := svc.CreateTransaction(model.TransactionDetail{Type: model.TxTypeExpense})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "at least 2")
+	})
+
+	t.Run("error: missing type", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+		input := model.TransactionDetail{
+			Splits: []model.SplitDetail{
+				{AccountName: "Expenses:Food", Amount: 500},
+				{AccountName: "Assets:Bank", Amount: -500},
+			},
+		}
+		_, err := svc.CreateTransaction(input)
+		require.Error(t, err)
+		assert.True(t, err != nil)
 	})
 
 	t.Run("unbalanced splits rejected", func(t *testing.T) {
@@ -72,6 +90,7 @@ func TestCreateTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
 
 		input := model.TransactionDetail{
+			Type: model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountName: "Expenses:Food", Amount: 500},
 				{AccountName: "Assets:Bank", Amount: -400}, // off by 100
@@ -88,6 +107,7 @@ func TestCreateTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
 
 		input := model.TransactionDetail{
+			Type: model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountName: "Assets:Bank", Amount: -500},
 				{AccountName: "NonExistent:Account", Amount: 500},
@@ -107,6 +127,7 @@ func TestCreateTransaction(t *testing.T) {
 		before := time.Now().Unix()
 		input := model.TransactionDetail{
 			Timestamp: 0,
+			Type:      model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountName: "Expenses:Food", Amount: 500},
 				{AccountName: "Assets:Bank", Amount: -500},
@@ -128,6 +149,7 @@ func TestCreateTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		input := model.TransactionDetail{
+			Type: model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountName: "Expenses:TWDFood", Amount: 500},
 				{AccountName: "Assets:TWDBank", Amount: -500},
@@ -151,6 +173,7 @@ func TestCreateTransaction(t *testing.T) {
 
 		// Assets:Cash is TWD, Expenses:Food has no currency (falls back to USD)
 		input := model.TransactionDetail{
+			Type: model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountName: "Expenses:Food", Amount: 500},
 				{AccountName: "Assets:Cash", Amount: -500},
@@ -168,6 +191,7 @@ func TestCreateTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		input := model.TransactionDetail{
+			Type: model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountName: "Expenses:Food", Amount: 500},
 				{AccountName: "Assets:Bank", Amount: -500},
@@ -189,6 +213,7 @@ func TestCreateTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		input := model.TransactionDetail{
+			Type: model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountName: "Expenses:Food", Amount: 500},
 				{AccountName: "Assets:Bank", Amount: -500},
@@ -211,7 +236,7 @@ func TestCreateSimpleTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		detail, err := svc.CreateSimpleTransaction(
-			"Assets:Bank", "Expenses:Food", 1000, "Dinner", 0, model.StatusPending,
+			"Assets:Bank", "Expenses:Food", 1000, "Dinner", 0, model.StatusPending, model.TxTypeExpense,
 		)
 		require.NoError(t, err)
 		assert.Greater(t, detail.ID, int64(0))
@@ -233,7 +258,7 @@ func TestCreateSimpleTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		detail, err := svc.CreateSimpleTransaction(
-			"Assets:Bank", "Expenses:Food", 750, "Coffee", 0, model.StatusPending,
+			"Assets:Bank", "Expenses:Food", 750, "Coffee", 0, model.StatusPending, model.TxTypeExpense,
 		)
 		require.NoError(t, err)
 
@@ -247,7 +272,7 @@ func TestCreateSimpleTransaction(t *testing.T) {
 	t.Run("same account rejected", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
 		_, err := svc.CreateSimpleTransaction(
-			"Assets:Bank", "Assets:Bank", 1000, "Self", 0, model.StatusPending,
+			"Assets:Bank", "Assets:Bank", 1000, "Self", 0, model.StatusPending, model.TxTypeExpense,
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "same")
@@ -256,7 +281,7 @@ func TestCreateSimpleTransaction(t *testing.T) {
 	t.Run("zero amount rejected", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
 		_, err := svc.CreateSimpleTransaction(
-			"Assets:Bank", "Expenses:Food", 0, "Zero", 0, model.StatusPending,
+			"Assets:Bank", "Expenses:Food", 0, "Zero", 0, model.StatusPending, model.TxTypeExpense,
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "positive")
@@ -265,10 +290,23 @@ func TestCreateSimpleTransaction(t *testing.T) {
 	t.Run("negative amount rejected", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
 		_, err := svc.CreateSimpleTransaction(
-			"Assets:Bank", "Expenses:Food", -100, "Negative", 0, model.StatusPending,
+			"Assets:Bank", "Expenses:Food", -100, "Negative", 0, model.StatusPending, model.TxTypeExpense,
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "positive")
+	})
+
+	t.Run("empty type infers from account types", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		detail, err := svc.CreateSimpleTransaction(
+			"Assets:Bank", "Expenses:Food", 500, "Inferred", 0, model.StatusPending, "",
+		)
+		require.NoError(t, err)
+		assert.Equal(t, model.TxTypeExpense, detail.Type)
 	})
 }
 

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -81,7 +81,7 @@ func TestCreateTransaction(t *testing.T) {
 		}
 		_, err := svc.CreateTransaction(input)
 		require.Error(t, err)
-		assert.True(t, err != nil)
+		assert.Contains(t, err.Error(), "type is required")
 	})
 
 	t.Run("unbalanced splits rejected", func(t *testing.T) {

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -456,10 +456,10 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		splits := []model.SplitDetail{
-			{ID: 10, AccountID: 1, Amount: -800, Currency: "USD"},
-			{ID: 11, AccountID: 2, Amount: 800, Currency: "USD"},
+			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -800, Currency: "USD"},
+			{ID: 11, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 800, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(5, "Updated desc", 0, model.StatusCleared, splits)
+		err := svc.UpdateTransactionComplete(5, "Updated desc", 0, model.StatusCleared, model.TxTypeExpense, splits)
 		require.NoError(t, err)
 	})
 
@@ -468,14 +468,14 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionComplete(5, "", 0, model.TransactionStatus(99), nil)
+		err := svc.UpdateTransactionComplete(5, "", 0, model.TransactionStatus(99), model.TxTypeExpense, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid status")
 	})
 
 	t.Run("non-existent transaction returns error", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		err := svc.UpdateTransactionComplete(999, "", 0, model.StatusPending,
+		err := svc.UpdateTransactionComplete(999, "", 0, model.StatusPending, model.TxTypeExpense,
 			[]model.SplitDetail{{AccountID: 1, Amount: 0}, {AccountID: 2, Amount: 0}})
 		require.Error(t, err)
 	})
@@ -485,7 +485,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusReconciled}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusCleared,
+		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusCleared, model.TxTypeExpense,
 			[]model.SplitDetail{{AccountID: 1, Amount: 500}, {AccountID: 2, Amount: -500}})
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrReconciled))
@@ -496,7 +496,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending,
+		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, model.TxTypeExpense,
 			[]model.SplitDetail{{AccountID: 1, Amount: 0}})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "at least 2")
@@ -509,7 +509,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(accRepo, txRepo)
 
-		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending,
+		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, model.TxTypeExpense,
 			[]model.SplitDetail{
 				{AccountID: 1, Amount: -500},
 				{AccountID: 2, Amount: 400}, // off by 100
@@ -524,10 +524,10 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(accRepo, txRepo)
 
-		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending,
+		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, model.TxTypeExpense,
 			[]model.SplitDetail{
-				{AccountID: 1, Amount: -500},
-				{AccountID: 99, Amount: 500}, // does not exist
+				{AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -500},
+				{AccountID: 99, AccountType: model.AccountTypeExpense, Amount: 500}, // does not exist
 			})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "99")
@@ -549,10 +549,10 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		splits := []model.SplitDetail{
-			{ID: 10, AccountID: 1, Amount: -1000, Currency: "USD"},
-			{ID: 11, AccountID: 2, Amount: 1000, Currency: "USD"},
+			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -1000, Currency: "USD"},
+			{ID: 11, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 1000, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, splits)
+		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, model.TxTypeExpense, splits)
 		require.NoError(t, err)
 		assert.Contains(t, txRepo.deleteSplitCalls, int64(12), "split ID 12 should be deleted")
 	})
@@ -568,10 +568,10 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		splits := []model.SplitDetail{
-			{ID: 10, AccountID: 1, Amount: -1000, Currency: "USD"},
-			{ID: 0, AccountID: 2, Amount: 1000, Currency: "USD"}, // new split
+			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -1000, Currency: "USD"},
+			{ID: 0, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 1000, Currency: "USD"}, // new split
 		}
-		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, splits)
+		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, model.TxTypeExpense, splits)
 		require.NoError(t, err)
 		assert.Len(t, txRepo.createSplitCalls, 1, "CreateSplit should be called once")
 	})
@@ -590,13 +590,33 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		splits := []model.SplitDetail{
-			{ID: 10, AccountID: 1, Amount: -800, Currency: "USD"},
-			{ID: 11, AccountID: 2, Amount: 800, Currency: "USD"},
+			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -800, Currency: "USD"},
+			{ID: 11, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 800, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, splits)
+		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, model.TxTypeExpense, splits)
 		require.NoError(t, err)
 		assert.Contains(t, txRepo.updateSplitCalls, int64(10))
 		assert.Contains(t, txRepo.updateSplitCalls, int64(11))
+	})
+
+	t.Run("error: splits do not match declared type", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		txRepo.addTransaction(
+			&model.Transaction{ID: 5, Status: model.StatusPending},
+			makeExistingSplits(10, 11),
+		)
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		// txType = Transfer but splits contain an Expense account — should fail
+		splits := []model.SplitDetail{
+			{AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
+			{AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"},
+		}
+		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, model.TxTypeTransfer, splits)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "splits do not match transaction type")
 	})
 }
 

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -655,3 +655,42 @@ func TestIsEditable(t *testing.T) {
 		assert.Equal(t, NotEditableReconciled, reason)
 	})
 }
+
+// ──────────────────────────────────────────────
+// CreateTransactionFromSplits
+// ──────────────────────────────────────────────
+
+func TestCreateTransactionFromSplits(t *testing.T) {
+	t.Run("delegates to CreateTransaction and returns detail with ID", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		splits := []model.SplitDetail{
+			{AccountName: "Assets:Bank", Amount: -200000},
+			{AccountName: "Expenses:Food", Amount: 200000},
+		}
+		result, err := svc.CreateTransactionFromSplits(splits, "team lunch", 0, model.StatusCleared, model.TxTypeExpense)
+		require.NoError(t, err)
+		assert.Greater(t, result.ID, int64(0))
+		assert.Equal(t, "team lunch", result.Description)
+		assert.Equal(t, model.TxTypeExpense, result.Type)
+		assert.Equal(t, splits, result.Splits)
+	})
+
+	t.Run("propagates CreateTransaction error", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		txRepo.createErr = errors.New("db error")
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		splits := []model.SplitDetail{
+			{AccountName: "Assets:Bank", Amount: -200000},
+			{AccountName: "Expenses:Food", Amount: 200000},
+		}
+		_, err := svc.CreateTransactionFromSplits(splits, "team lunch", 0, model.StatusCleared, model.TxTypeExpense)
+		require.Error(t, err)
+	})
+}

--- a/internal/service/transaction_service.go
+++ b/internal/service/transaction_service.go
@@ -61,6 +61,7 @@ func (ts *TransactionService) GetTransactionByID(txID int64) (*model.Transaction
 		Timestamp:   tx.Timestamp,
 		Description: tx.Description,
 		Status:      tx.Status,
+		Type:        tx.Type,
 		Splits:      splits,
 	}, nil
 }

--- a/internal/store/sqlite_transaction.go
+++ b/internal/store/sqlite_transaction.go
@@ -13,8 +13,8 @@ import (
 // It relies on the caller (Service layer) to wrap it in ExecTx for atomicity.
 func (s *Store) CreateTransactionWithSplits(tx model.Transaction, splits []model.Split) (int64, error) {
 	stmtTx, err := s.db.Prepare(`
-        INSERT INTO transactions (timestamp, description, status, external_id)
-        VALUES (?, ?, ?, ?)
+        INSERT INTO transactions (timestamp, description, status, external_id, type)
+        VALUES (?, ?, ?, ?, ?)
         RETURNING id;
     `)
 	if err != nil {
@@ -25,7 +25,7 @@ func (s *Store) CreateTransactionWithSplits(tx model.Transaction, splits []model
 	}()
 
 	var newTxID int64
-	err = stmtTx.QueryRow(tx.Timestamp, tx.Description, tx.Status, tx.ExternalID).Scan(&newTxID)
+	err = stmtTx.QueryRow(tx.Timestamp, tx.Description, tx.Status, tx.ExternalID, tx.Type).Scan(&newTxID)
 
 	if err != nil {
 		var sqliteErr sqlite.Error
@@ -61,10 +61,10 @@ func (s *Store) CreateTransactionWithSplits(tx model.Transaction, splits []model
 func (s *Store) GetTransactionByID(txID int64) (*model.Transaction, error) {
 	var tx model.Transaction
 	err := s.db.QueryRow(`
-        SELECT id, timestamp, description, status, external_id
+        SELECT id, timestamp, description, status, external_id, type
         FROM transactions
         WHERE id = ?
-    `, txID).Scan(&tx.ID, &tx.Timestamp, &tx.Description, &tx.Status, &tx.ExternalID)
+    `, txID).Scan(&tx.ID, &tx.Timestamp, &tx.Description, &tx.Status, &tx.ExternalID, &tx.Type)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("transaction with ID %d not found", txID)
@@ -80,7 +80,7 @@ func (s *Store) GetTransactionsByAccount(accountID int64, limit int) ([]*model.T
 	}
 
 	rows, err := s.db.Query(`
-        SELECT DISTINCT t.id, t.timestamp, t.description, t.status, t.external_id
+        SELECT DISTINCT t.id, t.timestamp, t.description, t.status, t.external_id, t.type
         FROM transactions t
         INNER JOIN splits s ON t.id = s.transaction_id
         WHERE s.account_id = ?
@@ -99,7 +99,7 @@ func (s *Store) GetTransactionsByAccount(accountID int64, limit int) ([]*model.T
 
 func (s *Store) GetTransactionsByDateRange(startTime, endTime int64) ([]*model.Transaction, error) {
 	rows, err := s.db.Query(`
-        SELECT id, timestamp, description, status, external_id
+        SELECT id, timestamp, description, status, external_id, type
         FROM transactions
         WHERE timestamp >= ? AND timestamp <= ?
         ORDER BY timestamp DESC, id DESC
@@ -120,7 +120,7 @@ func (s *Store) GetAllTransactions(limit int) ([]*model.Transaction, error) {
 	}
 
 	rows, err := s.db.Query(`
-        SELECT id, timestamp, description, status, external_id
+        SELECT id, timestamp, description, status, external_id, type
         FROM transactions
         ORDER BY timestamp DESC, id DESC
         LIMIT ?
@@ -178,12 +178,12 @@ func (s *Store) DeleteTransaction(txID int64) error {
 	return nil
 }
 
-func (s *Store) UpdateTransactionBasic(txID int64, description string, timestamp int64, status model.TransactionStatus) error {
+func (s *Store) UpdateTransactionBasic(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error {
 	result, err := s.db.Exec(`
         UPDATE transactions
-        SET description = ?, timestamp = ?, status = ?
+        SET description = ?, timestamp = ?, status = ?, type = ?
         WHERE id = ?
-    `, description, timestamp, status, txID)
+    `, description, timestamp, status, txType, txID)
 	if err != nil {
 		return fmt.Errorf("failed to update transaction: %w", err)
 	}
@@ -364,7 +364,7 @@ func (s *Store) scanTransactions(rows *sql.Rows) ([]*model.Transaction, error) {
 	var transactions []*model.Transaction
 	for rows.Next() {
 		tx := &model.Transaction{}
-		err := rows.Scan(&tx.ID, &tx.Timestamp, &tx.Description, &tx.Status, &tx.ExternalID)
+		err := rows.Scan(&tx.ID, &tx.Timestamp, &tx.Description, &tx.Status, &tx.ExternalID, &tx.Type)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan transaction: %w", err)
 		}

--- a/migrations/0005_add_transaction_type.down.sql
+++ b/migrations/0005_add_transaction_type.down.sql
@@ -1,0 +1,15 @@
+-- SQLite does not support DROP COLUMN in older versions; recreate without the column.
+CREATE TABLE transactions_new (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp   INTEGER NOT NULL,
+    description TEXT,
+    status      INTEGER NOT NULL DEFAULT 0,
+    external_id TEXT UNIQUE
+);
+
+INSERT INTO transactions_new SELECT id, timestamp, description, status, external_id FROM transactions;
+DROP TABLE transactions;
+ALTER TABLE transactions_new RENAME TO transactions;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_timestamp ON transactions (timestamp);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_transactions_external_id ON transactions (external_id);

--- a/migrations/0005_add_transaction_type.up.sql
+++ b/migrations/0005_add_transaction_type.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE transactions ADD COLUMN type TEXT NOT NULL DEFAULT '';

--- a/migrations/0006_backfill_transaction_type.down.sql
+++ b/migrations/0006_backfill_transaction_type.down.sql
@@ -1,0 +1,1 @@
+UPDATE transactions SET type = '';

--- a/migrations/0006_backfill_transaction_type.up.sql
+++ b/migrations/0006_backfill_transaction_type.up.sql
@@ -1,0 +1,28 @@
+UPDATE transactions SET type = (
+  SELECT
+    CASE
+      WHEN memo_check.has_opening = 1 THEN 'Opening'
+      WHEN agg.has_exp = 1 AND agg.has_rev = 1
+        THEN CASE WHEN agg.rev_sum >= agg.exp_sum THEN 'Income' ELSE 'Expense' END
+      WHEN agg.has_exp = 1 AND agg.al_cnt >= 1 THEN 'Expense'
+      WHEN agg.has_rev = 1 AND agg.al_cnt >= 1 THEN 'Income'
+      WHEN agg.al_cnt >= 2                       THEN 'Transfer'
+      ELSE 'Other'
+    END
+  FROM (
+    SELECT
+      MAX(CASE WHEN a.type = 'E' THEN 1 ELSE 0 END)             AS has_exp,
+      MAX(CASE WHEN a.type = 'R' THEN 1 ELSE 0 END)             AS has_rev,
+      SUM(CASE WHEN a.type IN ('A','L') THEN 1 ELSE 0 END)      AS al_cnt,
+      SUM(CASE WHEN a.type = 'E' THEN ABS(s.amount) ELSE 0 END) AS exp_sum,
+      SUM(CASE WHEN a.type = 'R' THEN ABS(s.amount) ELSE 0 END) AS rev_sum
+    FROM splits s
+    JOIN accounts a ON s.account_id = a.id
+    WHERE s.transaction_id = transactions.id
+  ) agg,
+  (
+    SELECT MAX(CASE WHEN s.memo = 'Opening Balance' THEN 1 ELSE 0 END) AS has_opening
+    FROM splits s
+    WHERE s.transaction_id = transactions.id
+  ) memo_check
+);


### PR DESCRIPTION
## Summary

- Adds a `type` column to the `transactions` table (migrations 0005 + 0006) and backfills existing rows using the display-time `DetermineType` logic
- Replaces all call sites of `DetermineType` with the stored `Type` field across reports, edit actions, and the list view
- Adds `--type` flag to `kea add` and a **Change Type** action to `kea edit`, both guarded by `ValidateSplitsMatchType` to keep split structure consistent with the declared type
- Adds `--split` flag mode to `kea add` for multi-split entry and a new `CreateTransactionFromSplits` service method
- Adds `ValidateSplitsMatchType` and `parseStatus` helpers; updates `UpdateTransactionComplete`, `CreateTransaction`, and `CreateSimpleTransaction` to require/validate type

## Test plan

- [ ] `go test ./...` passes
- [ ] `make build` succeeds
- [ ] `kea add --type expense` creates an expense transaction correctly
- [ ] `kea add --split` accepts multiple splits and rejects imbalanced entries
- [ ] `kea edit` shows **Change Type** action and validates split structure on change
- [ ] Existing transactions are readable after migration (backfill sets correct types)
- [ ] Report output unchanged from pre-migration data

🤖 Generated with [Claude Code](https://claude.com/claude-code)