### PR TITLE
fix: bootstrap default ledger on fresh install or empty registry

### DIFF
--- a/cmd/ledger/list_test.go
+++ b/cmd/ledger/list_test.go
@@ -11,13 +11,12 @@ import (
 )
 
 func TestListRunner_NoLedgers(t *testing.T) {
-	dir := t.TempDir()
-	r, err := internalled.Load(dir)
-	require.NoError(t, err)
+	// Construct an empty registry directly (e.g. corrupted/manually edited ledgers.yaml).
+	r := internalled.EmptyRegistry()
 
 	var buf bytes.Buffer
 	runner := &listRunner{registry: r, out: &buf}
-	err = runner.Run()
+	err := runner.Run()
 
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "No ledgers registered")

--- a/internal/ledger/registry.go
+++ b/internal/ledger/registry.go
@@ -30,45 +30,54 @@ type Registry struct {
 	filePath       string
 }
 
+// EmptyRegistry returns a Registry with no ledgers and no active ledger.
+// Intended for use in tests that need to exercise the "no ledgers" code path.
+func EmptyRegistry() *Registry {
+	return &Registry{Ledgers: make(map[string]Entry)}
+}
+
 // Load reads or initialises the ledger registry from appDir/ledgers.yaml.
 // If ledgers.yaml is absent and appDir/kea.db exists, it auto-migrates
 // by registering kea.db as the "default" ledger.
 func Load(appDir string) (*Registry, error) {
 	registryPath := filepath.Join(appDir, "ledgers.yaml")
 
+	r := &Registry{
+		Ledgers:  make(map[string]Entry),
+		filePath: registryPath,
+	}
+
 	data, err := os.ReadFile(registryPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("read ledgers.yaml: %w", err)
+	}
 	if err == nil {
-		r := &Registry{filePath: registryPath}
 		if err := yaml.Unmarshal(data, r); err != nil {
 			return nil, fmt.Errorf("parse ledgers.yaml: %w", err)
 		}
 		if r.Ledgers == nil {
 			r.Ledgers = make(map[string]Entry)
 		}
-		return r, nil
-	}
-	if !errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("read ledgers.yaml: %w", err)
-	}
-
-	r := &Registry{
-		Ledgers:  make(map[string]Entry),
-		filePath: registryPath,
+		// If the file exists but has ledgers, return as-is.
+		if len(r.Ledgers) > 0 {
+			return r, nil
+		}
 	}
 
+	// No ledgers registered yet (fresh install or empty file from old version).
+	// Auto-migrate a pre-existing kea.db if present; otherwise bootstrap a default.
 	legacyDB := filepath.Join(appDir, "kea.db")
 	if _, err := os.Stat(legacyDB); err == nil {
 		r.Ledgers["default"] = Entry{Path: legacyDB}
 		r.ActiveLedger = "default"
 		r.MigratedLegacy = true
-		if err := r.Save(); err != nil {
-			return nil, fmt.Errorf("auto-migrate: %w", err)
-		}
-		return r, nil
+	} else {
+		r.Ledgers["default"] = Entry{Path: legacyDB}
+		r.ActiveLedger = "default"
 	}
 
 	if err := r.Save(); err != nil {
-		return nil, fmt.Errorf("init ledgers.yaml: %w", err)
+		return nil, fmt.Errorf("init default ledger: %w", err)
 	}
 	return r, nil
 }

--- a/internal/ledger/registry_test.go
+++ b/internal/ledger/registry_test.go
@@ -16,8 +16,9 @@ func TestLoad_FreshInstall(t *testing.T) {
 	r, err := Load(dir)
 
 	require.NoError(t, err)
-	assert.Empty(t, r.Ledgers)
-	assert.Empty(t, r.ActiveLedger)
+	require.Contains(t, r.Ledgers, "default", "fresh install should bootstrap a default ledger")
+	assert.Equal(t, filepath.Join(dir, "kea.db"), r.Ledgers["default"].Path)
+	assert.Equal(t, "default", r.ActiveLedger)
 	_, statErr := os.Stat(filepath.Join(dir, "ledgers.yaml"))
 	assert.NoError(t, statErr, "ledgers.yaml should be created on fresh install")
 }
@@ -136,11 +137,10 @@ func TestActive_HappyPath(t *testing.T) {
 }
 
 func TestActive_NoActiveLedger(t *testing.T) {
-	dir := t.TempDir()
-	r, err := Load(dir)
-	require.NoError(t, err)
+	// Construct a registry with no active ledger directly (e.g. corrupted/manually edited ledgers.yaml).
+	r := &Registry{Ledgers: map[string]Entry{"work": {Path: "/tmp/work.db"}}}
 
-	_, err = r.Active()
+	_, err := r.Active()
 
 	assert.ErrorIs(t, err, ErrNoActiveLedger)
 }


### PR DESCRIPTION
## Summary

- `Load()` in `internal/ledger/registry.go` now bootstraps a `default` ledger pointing to `kea.db` whenever no ledgers are registered
- Covers both a true fresh install (no `ledgers.yaml`) and the legacy case where the old code had already written an empty `ledgers.yaml` (the actual root cause — the file existed with `active: ""` and `ledgers: {}`)
- Tests updated to reflect the new bootstrap behaviour; `EmptyRegistry()` helper added for tests that need to exercise the "no ledgers" code path explicitly

## Test plan

- [ ] Clone repo on a fresh machine with no prior kea data — `kea` shows all commands without warning
- [ ] On a machine that ran an older build (empty `ledgers.yaml` already present) — `kea` shows all commands without warning
- [ ] `kea ledger list` shows the auto-created `default` ledger
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)