### PR TITLE
fix: rename OpeningBalanceTransactionID to SystemTransactionID and add missing guard in UpdateTransactionStatus

### DIFF
--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -97,7 +97,7 @@ const (
 	ModeTransfer = "Transfer"
 
 	DateFormat                        = "2006-01-02"
-	OpeningBalanceTransactionID int64 = 1
+	SystemTransactionID int64 = 1
 	MinSplitsCount                    = 2
 )
 

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -182,7 +182,7 @@ func (ts *TransactionService) CreateTransactionFromSplits(
 
 // DeleteTransaction deletes a transaction
 func (ts *TransactionService) DeleteTransaction(txID int64) error {
-	if txID == model.OpeningBalanceTransactionID {
+	if txID == model.SystemTransactionID {
 		return fmt.Errorf("cannot delete the initial opening transaction: %w", ErrNotEditable)
 	}
 
@@ -206,6 +206,10 @@ func (ts *TransactionService) UpdateTransactionStatus(txID int64, status model.T
 		return fmt.Errorf("invalid status: must be 0 (Pending) or 1 (Cleared)")
 	}
 
+	if txID == model.SystemTransactionID {
+		return fmt.Errorf("transaction #%d cannot be modified: %w", txID, ErrNotEditable)
+	}
+
 	oldTx, err := ts.txRepo.GetTransactionByID(txID)
 	if err != nil {
 		return fmt.Errorf("transaction not found: %w", err)
@@ -226,7 +230,7 @@ func (ts *TransactionService) UpdateTransactionComplete(txID int64, description 
 		return fmt.Errorf("invalid status: must be 0 (Pending), 1 (Cleared) or 2 (Reconciled)")
 	}
 
-	if txID == model.OpeningBalanceTransactionID {
+	if txID == model.SystemTransactionID {
 		return fmt.Errorf("cannot modify the initial opening transaction: %w", ErrNotEditable)
 	}
 
@@ -332,7 +336,7 @@ const (
 )
 
 func (ts *TransactionService) IsEditable(detail *model.TransactionDetail) (bool, NotEditableReason) {
-	if detail.ID == model.OpeningBalanceTransactionID {
+	if detail.ID == model.SystemTransactionID {
 		return false, NotEditableSystemTx
 	}
 

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -338,7 +338,7 @@ func TestDeleteTransaction(t *testing.T) {
 
 	t.Run("opening balance transaction (ID=1) rejected", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		err := svc.DeleteTransaction(model.OpeningBalanceTransactionID)
+		err := svc.DeleteTransaction(model.SystemTransactionID)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrNotEditable), "expected ErrNotEditable, got: %v", err)
 	})
@@ -423,6 +423,13 @@ func TestUpdateTransactionStatus(t *testing.T) {
 		err := svc.UpdateTransactionStatus(5, model.StatusCleared)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrReconciled))
+	})
+
+	t.Run("system transaction (ID=1) rejected", func(t *testing.T) {
+		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
+		err := svc.UpdateTransactionStatus(model.SystemTransactionID, model.StatusCleared)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotEditable), "expected ErrNotEditable, got: %v", err)
 	})
 
 	t.Run("non-existent transaction returns error", func(t *testing.T) {
@@ -635,7 +642,7 @@ func TestIsEditable(t *testing.T) {
 	})
 
 	t.Run("opening balance transaction (ID=1) is not editable", func(t *testing.T) {
-		detail := &model.TransactionDetail{ID: model.OpeningBalanceTransactionID}
+		detail := &model.TransactionDetail{ID: model.SystemTransactionID}
 		editable, reason := svc.IsEditable(detail)
 		assert.False(t, editable)
 		assert.Equal(t, NotEditableSystemTx, reason)


### PR DESCRIPTION
## Summary

- Renames `model.OpeningBalanceTransactionID` → `model.SystemTransactionID` to clarify that ID=1 is a system-reserved sentinel, distinct from ordinary opening-balance transactions (which are user-editable)
- Adds the missing `ErrNotEditable` guard to `UpdateTransactionStatus`, closing the gap where `kea transaction clear 1` could silently flip the system transaction's status
- Adds a service-level test `"system transaction (ID=1) rejected"` in `TestUpdateTransactionStatus`, mirroring the existing protection tests for `DeleteTransaction` and `UpdateTransactionComplete`

Closes #26

## Test plan

- [ ] `go test ./internal/service/ -run TestUpdateTransactionStatus` — all subtests pass including new `system transaction (ID=1) rejected`
- [ ] `go test ./...` — full suite green
- [ ] Confirm `kea transaction clear 1` now returns an error in a live ledger

🤖 Generated with [Claude Code](https://claude.com/claude-code)