### PR TITLE
refactor: thread context.Context through all DB-touching methods

### DIFF
--- a/cmd/account/create.go
+++ b/cmd/account/create.go
@@ -1,6 +1,7 @@
 package account
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -42,7 +43,7 @@ Example:
 				view:            views.NewAccountCreateView(),
 			}
 
-			return runner.Run(flags, cmd)
+			return runner.Run(cmd.Context(), flags, cmd)
 		},
 	}
 	cmd.Flags().StringVarP(&flags.Name, "name", "n", "", "Account name")
@@ -56,7 +57,7 @@ Example:
 	return cmd
 }
 
-func (r *createRunner) Run(flags *createFlags, cmd *cobra.Command) error {
+func (r *createRunner) Run(ctx context.Context, flags *createFlags, cmd *cobra.Command) error {
 	hasFlags := cmd.Flags().Changed("name") ||
 		cmd.Flags().Changed("type") ||
 		cmd.Flags().Changed("parent") || cmd.Flags().Changed("balance") ||
@@ -70,9 +71,9 @@ func (r *createRunner) Run(flags *createFlags, cmd *cobra.Command) error {
 	var err error
 
 	if hasFlags {
-		input, err = r.runFromFlags(flags)
+		input, err = r.runFromFlags(ctx, flags)
 	} else {
-		input, err = r.runInteractive()
+		input, err = r.runInteractive(ctx)
 	}
 	if err != nil {
 		if errors.Is(err, service.ErrAlreadyExists) {
@@ -85,13 +86,13 @@ func (r *createRunner) Run(flags *createFlags, cmd *cobra.Command) error {
 		return err
 	}
 
-	newAccount, err := r.createAccount(input)
+	newAccount, err := r.createAccount(ctx, input)
 	if err != nil {
 		return err
 	}
 
 	if flags.JSON {
-		bal, err := r.accSvc.GetAccountBalance(newAccount.ID)
+		bal, err := r.accSvc.GetAccountBalance(ctx, newAccount.ID)
 		if err != nil {
 			return err
 		}
@@ -101,7 +102,7 @@ func (r *createRunner) Run(flags *createFlags, cmd *cobra.Command) error {
 	return nil
 }
 
-func (r *createRunner) runFromFlags(flags *createFlags) (createInput, error) {
+func (r *createRunner) runFromFlags(ctx context.Context, flags *createFlags) (createInput, error) {
 	if flags.Parent == "" && flags.Type == "" {
 		return createInput{}, fmt.Errorf("must enter at least one of --type or --parent flag")
 	}
@@ -117,7 +118,7 @@ func (r *createRunner) runFromFlags(flags *createFlags) (createInput, error) {
 	input.description = flags.Description
 
 	if flags.Parent != "" {
-		if err := r.buildFromParentName(flags.Parent, flags.Currency, &input); err != nil {
+		if err := r.buildFromParentName(ctx, flags.Parent, flags.Currency, &input); err != nil {
 			return createInput{}, err
 		}
 	} else {
@@ -142,7 +143,7 @@ func (r *createRunner) runFromFlags(flags *createFlags) (createInput, error) {
 	return input, nil
 }
 
-func (r *createRunner) runInteractive() (createInput, error) {
+func (r *createRunner) runInteractive(ctx context.Context) (createInput, error) {
 	var input createInput
 
 	isSubAccount, err := prompts.PromptIsSubAccount()
@@ -151,11 +152,11 @@ func (r *createRunner) runInteractive() (createInput, error) {
 	}
 
 	if isSubAccount {
-		parentAccount, err := r.promptParent()
+		parentAccount, err := r.promptParent(ctx)
 		if err != nil {
 			return createInput{}, err
 		}
-		nameInput, err := r.promptName(parentAccount.Name)
+		nameInput, err := r.promptName(ctx, parentAccount.Name)
 		if err != nil {
 			return createInput{}, err
 		}
@@ -170,11 +171,11 @@ func (r *createRunner) runInteractive() (createInput, error) {
 		if err != nil {
 			return createInput{}, err
 		}
-		nameInput, err := r.promptName(rootName)
+		nameInput, err := r.promptName(ctx, rootName)
 		if err != nil {
 			return createInput{}, err
 		}
-		if err := r.applyTypeSettings(rootName, accType, "", &input); err != nil {
+		if err := r.applyTypeSettings(accType, "", &input); err != nil {
 			return createInput{}, err
 		}
 		input.fullName = r.accSvc.FormatAccountName(rootName, nameInput)

--- a/cmd/account/create_actions.go
+++ b/cmd/account/create_actions.go
@@ -1,6 +1,7 @@
 package account
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -9,8 +10,9 @@ import (
 	"github.com/hance08/kea/ui/prompts"
 )
 
-func (r *createRunner) createAccount(input createInput) (*model.Account, error) {
+func (r *createRunner) createAccount(ctx context.Context, input createInput) (*model.Account, error) {
 	return r.accSvc.CreateAccountWithBalance(
+		ctx,
 		input.fullName,
 		input.accountType,
 		input.currency,
@@ -20,7 +22,7 @@ func (r *createRunner) createAccount(input createInput) (*model.Account, error) 
 	)
 }
 
-func (r *createRunner) applyTypeSettings(rootName, accType, currencyOverride string, input *createInput) error {
+func (r *createRunner) applyTypeSettings(accType, currencyOverride string, input *createInput) error {
 	input.accountType = model.AccountType(accType)
 	if currencyOverride != "" {
 		if err := r.accSvc.ValidateCurrency(currencyOverride); err != nil {
@@ -43,8 +45,8 @@ func (r *createRunner) applyParentSettings(parent *model.Account, currencyOverri
 	}
 }
 
-func (r *createRunner) buildFromParentName(parentName, currency string, input *createInput) error {
-	parentAccount, err := r.accSvc.GetAccountByName(parentName)
+func (r *createRunner) buildFromParentName(ctx context.Context, parentName, currency string, input *createInput) error {
+	parentAccount, err := r.accSvc.GetAccountByName(ctx, parentName)
 	if err != nil {
 		return err
 	}
@@ -58,7 +60,7 @@ func (r *createRunner) buildFromTypeFlag(accType, currency string, input *create
 	if err != nil {
 		return fmt.Errorf("get root name: %w", err)
 	}
-	if err := r.applyTypeSettings(rootName, accType, currency, input); err != nil {
+	if err := r.applyTypeSettings(accType, currency, input); err != nil {
 		return err
 	}
 	input.fullName = rootName // prefix for FormatAccountName in runFromFlags
@@ -69,8 +71,8 @@ func (r *createRunner) promptType() (string, error) {
 	return prompts.PromptAccountType()
 }
 
-func (r *createRunner) promptParent() (*model.Account, error) {
-	allAccounts, err := r.accSvc.GetAllAccounts()
+func (r *createRunner) promptParent(ctx context.Context) (*model.Account, error) {
+	allAccounts, err := r.accSvc.GetAllAccounts(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve accounts: %w", err)
 	}
@@ -87,7 +89,7 @@ func (r *createRunner) promptParent() (*model.Account, error) {
 	return selectedAccount, nil
 }
 
-func (r *createRunner) promptName(prefix string) (string, error) {
+func (r *createRunner) promptName(ctx context.Context, prefix string) (string, error) {
 	surveyValidator := func(inputStr string) error {
 		if err := r.accSvc.ValidateAccountName(inputStr); err != nil {
 			return err
@@ -95,7 +97,7 @@ func (r *createRunner) promptName(prefix string) (string, error) {
 
 		fullName := r.accSvc.FormatAccountName(prefix, inputStr)
 
-		exists, err := r.accSvc.CheckAccountExists(fullName)
+		exists, err := r.accSvc.CheckAccountExists(ctx, fullName)
 		if err != nil {
 			return fmt.Errorf("failed to validate: %w", err)
 		}

--- a/cmd/account/create_types.go
+++ b/cmd/account/create_types.go
@@ -1,6 +1,8 @@
 package account
 
 import (
+	"context"
+
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/ui/views"
 )
@@ -11,16 +13,16 @@ type CreateView interface {
 }
 
 type CreateProvider interface {
-	GetAllAccounts() ([]*model.Account, error)
-	GetAccountByName(name string) (*model.Account, error)
+	GetAllAccounts(ctx context.Context) ([]*model.Account, error)
+	GetAccountByName(ctx context.Context, name string) (*model.Account, error)
 	GetRootNameByType(accType string) (string, error)
-	CheckAccountExists(name string) (bool, error)
+	CheckAccountExists(ctx context.Context, name string) (bool, error)
 	FormatAccountName(prefix string, name string) string
-	CreateAccountWithBalance(name string, accType model.AccountType, currency, description string, parentID *int64, balance int64) (*model.Account, error)
+	CreateAccountWithBalance(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64, balance int64) (*model.Account, error)
 	ValidateAccountName(name string) error
 	ValidateFullAccountName(name string) error
 	ValidateCurrency(currency string) error
-	GetAccountBalance(id int64) (int64, error)
+	GetAccountBalance(ctx context.Context, id int64) (int64, error)
 }
 
 type createInput struct {

--- a/cmd/account/delete.go
+++ b/cmd/account/delete.go
@@ -1,6 +1,7 @@
 package account
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hance08/kea/internal/model"
@@ -12,13 +13,13 @@ import (
 )
 
 type AccountDeleteProvider interface {
-	GetAccountByName(name string) (*model.Account, error)
-	DeleteAccountByName(name string) error
+	GetAccountByName(ctx context.Context, name string) (*model.Account, error)
+	DeleteAccountByName(ctx context.Context, name string) error
 }
 
 type deleteFlags struct {
-	Yes     bool
-	JSON    bool
+	Yes  bool
+	JSON bool
 }
 
 type deleteRunner struct {
@@ -38,7 +39,7 @@ func NewDeleteCmd(svc *service.Service) *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner := &deleteRunner{svc: svc.Account(), yes: flags.Yes || flags.JSON, json: flags.JSON}
-			return runner.Run(args[0])
+			return runner.Run(cmd.Context(), args[0])
 		},
 	}
 
@@ -48,8 +49,8 @@ func NewDeleteCmd(svc *service.Service) *cobra.Command {
 	return cmd
 }
 
-func (r *deleteRunner) Run(name string) error {
-	acc, err := r.svc.GetAccountByName(name)
+func (r *deleteRunner) Run(ctx context.Context, name string) error {
+	acc, err := r.svc.GetAccountByName(ctx, name)
 	if err != nil {
 		return fmt.Errorf("failed to find account: %w", err)
 	}
@@ -69,7 +70,7 @@ func (r *deleteRunner) Run(name string) error {
 		}
 	}
 
-	if err := r.svc.DeleteAccountByName(acc.Name); err != nil {
+	if err := r.svc.DeleteAccountByName(ctx, acc.Name); err != nil {
 		return fmt.Errorf("failed to delete account: %w", err)
 	}
 

--- a/cmd/account/edit.go
+++ b/cmd/account/edit.go
@@ -1,6 +1,7 @@
 package account
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hance08/kea/internal/service"
@@ -32,7 +33,7 @@ Example:
 				svc:  svc.Account(),
 				view: views.NewCommonView(),
 			}
-			return runner.Run(args[0], flags, cmd)
+			return runner.Run(cmd.Context(), args[0], flags, cmd)
 		},
 	}
 
@@ -47,8 +48,8 @@ Example:
 	return cmd
 }
 
-func (r *editRunner) Run(accName string, flags *editFlags, cmd *cobra.Command) error {
-	acc, err := r.svc.GetAccountByName(accName)
+func (r *editRunner) Run(ctx context.Context, accName string, flags *editFlags, cmd *cobra.Command) error {
+	acc, err := r.svc.GetAccountByName(ctx, accName)
 	if err != nil {
 		return fmt.Errorf("account not found: %w", err)
 	}
@@ -62,9 +63,9 @@ func (r *editRunner) Run(accName string, flags *editFlags, cmd *cobra.Command) e
 
 	var input editInput
 	if hasFlags {
-		input, err = r.runFromFlags(acc, flags, cmd)
+		input, err = r.runFromFlags(flags, cmd)
 	} else {
-		input, err = r.runInteractive(acc)
+		input, err = r.runInteractive(ctx, acc)
 	}
 	if err != nil {
 		return err
@@ -75,17 +76,17 @@ func (r *editRunner) Run(accName string, flags *editFlags, cmd *cobra.Command) e
 		return nil
 	}
 
-	finalName, err := r.applyChanges(acc, input)
+	finalName, err := r.applyChanges(ctx, acc, input)
 	if err != nil {
 		return err
 	}
 
 	if flags.JSON {
-		updatedAcc, err := r.svc.GetAccountByName(finalName)
+		updatedAcc, err := r.svc.GetAccountByName(ctx, finalName)
 		if err != nil {
 			return err
 		}
-		bal, err := r.svc.GetAccountBalance(updatedAcc.ID)
+		bal, err := r.svc.GetAccountBalance(ctx, updatedAcc.ID)
 		if err != nil {
 			return err
 		}

--- a/cmd/account/edit_actions.go
+++ b/cmd/account/edit_actions.go
@@ -1,6 +1,7 @@
 package account
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -10,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (r *editRunner) runFromFlags(acc *model.Account, flags *editFlags, cmd *cobra.Command) (editInput, error) {
+func (r *editRunner) runFromFlags(flags *editFlags, cmd *cobra.Command) (editInput, error) {
 	var input editInput
 
 	if cmd.Flags().Changed("name") {
@@ -34,7 +35,7 @@ func (r *editRunner) runFromFlags(acc *model.Account, flags *editFlags, cmd *cob
 	return input, nil
 }
 
-func (r *editRunner) runInteractive(acc *model.Account) (editInput, error) {
+func (r *editRunner) runInteractive(ctx context.Context, acc *model.Account) (editInput, error) {
 	var input editInput
 
 	currentSegment := acc.Name
@@ -42,7 +43,7 @@ func (r *editRunner) runInteractive(acc *model.Account) (editInput, error) {
 		currentSegment = acc.Name[idx+1:]
 	}
 
-	newSegment, err := r.promptNameSegment(currentSegment, acc.Name)
+	newSegment, err := r.promptNameSegment(ctx, currentSegment, acc.Name)
 	if err != nil {
 		return editInput{}, err
 	}
@@ -90,7 +91,7 @@ func (r *editRunner) runInteractive(acc *model.Account) (editInput, error) {
 	return input, nil
 }
 
-func (r *editRunner) promptNameSegment(currentSegment, currentFullName string) (string, error) {
+func (r *editRunner) promptNameSegment(ctx context.Context, currentSegment, currentFullName string) (string, error) {
 	prefix := ""
 	if idx := strings.LastIndex(currentFullName, ":"); idx >= 0 {
 		prefix = currentFullName[:idx]
@@ -109,7 +110,7 @@ func (r *editRunner) promptNameSegment(currentSegment, currentFullName string) (
 		} else {
 			newFullName = s
 		}
-		exists, err := r.svc.CheckAccountExists(newFullName)
+		exists, err := r.svc.CheckAccountExists(ctx, newFullName)
 		if err != nil {
 			return fmt.Errorf("failed to check existence: %w", err)
 		}
@@ -142,11 +143,11 @@ func (r *editRunner) showChangeSummary(acc *model.Account, input editInput) {
 	}
 }
 
-func (r *editRunner) applyChanges(acc *model.Account, input editInput) (string, error) {
+func (r *editRunner) applyChanges(ctx context.Context, acc *model.Account, input editInput) (string, error) {
 	finalName := acc.Name
 
 	if input.newName != nil {
-		if err := r.svc.RenameAccount(acc.Name, *input.newName); err != nil {
+		if err := r.svc.RenameAccount(ctx, acc.Name, *input.newName); err != nil {
 			return "", fmt.Errorf("failed to rename account: %w", err)
 		}
 		if idx := strings.LastIndex(acc.Name, ":"); idx >= 0 {
@@ -165,7 +166,7 @@ func (r *editRunner) applyChanges(acc *model.Account, input editInput) (string, 
 		if input.isHidden != nil {
 			hidden = *input.isHidden
 		}
-		if err := r.svc.UpdateAccountMetadata(acc.ID, desc, hidden); err != nil {
+		if err := r.svc.UpdateAccountMetadata(ctx, acc.ID, desc, hidden); err != nil {
 			return "", fmt.Errorf("failed to update account: %w", err)
 		}
 	}

--- a/cmd/account/edit_types.go
+++ b/cmd/account/edit_types.go
@@ -1,15 +1,19 @@
 package account
 
-import "github.com/hance08/kea/internal/model"
+import (
+	"context"
+
+	"github.com/hance08/kea/internal/model"
+)
 
 // EditProvider is the service interface required by the edit command.
 type EditProvider interface {
-	GetAccountByName(name string) (*model.Account, error)
-	GetAccountBalance(id int64) (int64, error)
-	RenameAccount(oldName, newSegment string) error
-	UpdateAccountMetadata(id int64, description string, isHidden bool) error
+	GetAccountByName(ctx context.Context, name string) (*model.Account, error)
+	GetAccountBalance(ctx context.Context, id int64) (int64, error)
+	RenameAccount(ctx context.Context, oldName, newSegment string) error
+	UpdateAccountMetadata(ctx context.Context, id int64, description string, isHidden bool) error
 	ValidateAccountName(name string) error
-	CheckAccountExists(name string) (bool, error)
+	CheckAccountExists(ctx context.Context, name string) (bool, error)
 }
 
 // EditView is the display interface required by the edit command.

--- a/cmd/account/list.go
+++ b/cmd/account/list.go
@@ -1,6 +1,7 @@
 package account
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hance08/kea/internal/model"
@@ -16,10 +17,10 @@ type listFlags struct {
 }
 
 type AccountListProvider interface {
-	GetAccountsByType(accType model.AccountType) ([]*model.Account, error)
-	GetAllAccounts() ([]*model.Account, error)
-	GetAccountBalance(id int64) (int64, error)
-	GetAccountBalanceFormatted(id int64) (string, error)
+	GetAccountsByType(ctx context.Context, accType model.AccountType) ([]*model.Account, error)
+	GetAllAccounts(ctx context.Context) ([]*model.Account, error)
+	GetAccountBalance(ctx context.Context, id int64) (int64, error)
+	GetAccountBalanceFormatted(ctx context.Context, id int64) (string, error)
 }
 
 type listRunner struct {
@@ -41,7 +42,7 @@ You can filter by account type or show hidden accounts.`,
 				svc:   svc.Account(),
 				flags: flags,
 			}
-			return runner.Run()
+			return runner.Run(cmd.Context())
 		},
 	}
 
@@ -52,15 +53,15 @@ You can filter by account type or show hidden accounts.`,
 	return cmd
 }
 
-func (r *listRunner) Run() error {
+func (r *listRunner) Run(ctx context.Context) error {
 
 	var accounts []*model.Account
 	var err error
 
 	if r.flags.Type != "" {
-		accounts, err = r.svc.GetAccountsByType(model.AccountType(r.flags.Type))
+		accounts, err = r.svc.GetAccountsByType(ctx, model.AccountType(r.flags.Type))
 	} else {
-		accounts, err = r.svc.GetAllAccounts()
+		accounts, err = r.svc.GetAllAccounts(ctx)
 	}
 
 	if err != nil {
@@ -74,7 +75,7 @@ func (r *listRunner) Run() error {
 	if r.flags.JSON {
 		items := make([]views.JSONAccount, 0, len(accounts))
 		for _, acc := range accounts {
-			bal, err := r.svc.GetAccountBalance(acc.ID)
+			bal, err := r.svc.GetAccountBalance(ctx, acc.ID)
 			if err != nil {
 				return fmt.Errorf("failed to get balance for %s: %w", acc.Name, err)
 			}
@@ -82,7 +83,9 @@ func (r *listRunner) Run() error {
 		}
 		return views.WriteJSON(items)
 	}
-	return views.NewAccountListView().Render(accounts, r.svc.GetAccountBalanceFormatted)
+	return views.NewAccountListView().Render(accounts, func(id int64) (string, error) {
+		return r.svc.GetAccountBalanceFormatted(ctx, id)
+	})
 }
 
 func (r *listRunner) filterHiddenAccounts(accounts []*model.Account) []*model.Account {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hance08/kea/internal/model"
@@ -37,7 +38,7 @@ Examples:
 				view:   views.NewTransactionDetailView(),
 			}
 
-			return runner.Run(flags, cmd)
+			return runner.Run(cmd.Context(), flags, cmd)
 		},
 	}
 	cmd.Flags().StringVarP(&flags.Description, "desc", "d", "", "Transaction description")
@@ -57,7 +58,7 @@ Examples:
 	return cmd
 }
 
-func (r *addRunner) Run(flags *addFlags, cmd *cobra.Command) error {
+func (r *addRunner) Run(ctx context.Context, flags *addFlags, cmd *cobra.Command) error {
 	var input addTransactionInput
 	var err error
 
@@ -72,10 +73,10 @@ func (r *addRunner) Run(flags *addFlags, cmd *cobra.Command) error {
 
 	if hasFlags {
 		// Flag mode: validate all required flags
-		input, err = r.runFromFlags(flags)
+		input, err = r.runFromFlags(ctx, flags)
 	} else {
 		// Interactive mode
-		input, err = r.runInteractive()
+		input, err = r.runInteractive(ctx)
 	}
 	if err != nil {
 		return err
@@ -84,10 +85,11 @@ func (r *addRunner) Run(flags *addFlags, cmd *cobra.Command) error {
 	var result model.TransactionDetail
 	if len(input.Splits) > 0 {
 		result, err = r.txSvc.CreateTransactionFromSplits(
-			input.Splits, input.Description, input.Timestamp, input.Status, input.Type,
+			ctx, input.Splits, input.Description, input.Timestamp, input.Status, input.Type,
 		)
 	} else {
 		result, err = r.txSvc.CreateSimpleTransaction(
+			ctx,
 			input.FromAccountID,
 			input.ToAccountID,
 			input.AmountCents,

--- a/cmd/add_actions.go
+++ b/cmd/add_actions.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -10,7 +11,7 @@ import (
 	"github.com/hance08/kea/ui/prompts"
 )
 
-func (r *addRunner) runFromFlags(flags *addFlags) (addTransactionInput, error) {
+func (r *addRunner) runFromFlags(ctx context.Context, flags *addFlags) (addTransactionInput, error) {
 	if len(flags.Splits) > 0 {
 		return r.runFromSplitFlags(flags)
 	}
@@ -48,11 +49,11 @@ func (r *addRunner) runFromFlags(flags *addFlags) (addTransactionInput, error) {
 		}
 	}
 
-	if err := r.validateAccountSelectable(flags.From, nil, "--from"); err != nil {
+	if err := r.validateAccountSelectable(ctx, flags.From, nil, "--from"); err != nil {
 		return addTransactionInput{}, err
 	}
 
-	if err := r.validateAccountSelectable(flags.To, nil, "--to"); err != nil {
+	if err := r.validateAccountSelectable(ctx, flags.To, nil, "--to"); err != nil {
 		return addTransactionInput{}, err
 	}
 
@@ -67,9 +68,9 @@ func (r *addRunner) runFromFlags(flags *addFlags) (addTransactionInput, error) {
 	}, nil
 }
 
-func (r *addRunner) runInteractive() (addTransactionInput, error) {
+func (r *addRunner) runInteractive(ctx context.Context) (addTransactionInput, error) {
 	// Get all accounts
-	accounts, err := r.accSvc.GetAllAccounts()
+	accounts, err := r.accSvc.GetAllAccounts(ctx)
 	if err != nil {
 		return addTransactionInput{}, fmt.Errorf("failed to load accounts: %w", err)
 	}
@@ -117,19 +118,19 @@ func (r *addRunner) runInteractive() (addTransactionInput, error) {
 		return addTransactionInput{}, fmt.Errorf("UI config missing for mode: %s", mode)
 	}
 
-	fromAccount, err := r.selectAccount(accounts, rule.SourceTypes, uiConf.Src, true, "")
+	fromAccount, err := r.selectAccount(ctx, accounts, rule.SourceTypes, uiConf.Src, true, "")
 	if err != nil {
 		return addTransactionInput{}, err
 	}
 
 	// Resolve the selected account's currency so the offset account list
 	// is filtered to the same currency, preventing mixed-currency splits.
-	fromAcc, err := r.accSvc.GetAccountByName(fromAccount)
+	fromAcc, err := r.accSvc.GetAccountByName(ctx, fromAccount)
 	if err != nil {
 		return addTransactionInput{}, fmt.Errorf("failed to load account %q: %w", fromAccount, err)
 	}
 
-	toAccount, err := r.selectAccount(accounts, rule.DestTypes, uiConf.Dst, mode != model.TxTypeExpense, fromAcc.Currency)
+	toAccount, err := r.selectAccount(ctx, accounts, rule.DestTypes, uiConf.Dst, mode != model.TxTypeExpense, fromAcc.Currency)
 	if err != nil {
 		return addTransactionInput{}, err
 	}
@@ -167,17 +168,19 @@ func (r *addRunner) runInteractive() (addTransactionInput, error) {
 	}, nil
 }
 
-func (r *addRunner) selectAccount(accounts []*model.Account, allowedTypes []string, message string, showBalance bool, allowedCurrency string) (string, error) {
+func (r *addRunner) selectAccount(ctx context.Context, accounts []*model.Account, allowedTypes []string, message string, showBalance bool, allowedCurrency string) (string, error) {
 	var balanceGetter func(int64) (string, error)
 	if showBalance {
-		balanceGetter = r.accSvc.GetAccountBalanceFormatted
+		balanceGetter = func(id int64) (string, error) {
+			return r.accSvc.GetAccountBalanceFormatted(ctx, id)
+		}
 	}
 
 	return prompts.PromptAccountSelection(accounts, allowedTypes, message, showBalance, balanceGetter, allowedCurrency)
 }
 
-func (r *addRunner) validateAccountSelectable(accountName string, allowedTypes []string, flagName string) error {
-	if err := r.accSvc.ValidateSelectableAccount(accountName, allowedTypes); err != nil {
+func (r *addRunner) validateAccountSelectable(ctx context.Context, accountName string, allowedTypes []string, flagName string) error {
+	if err := r.accSvc.ValidateSelectableAccount(ctx, accountName, allowedTypes); err != nil {
 		return fmt.Errorf("%s: %w", flagName, err)
 	}
 	return nil

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hance08/kea/internal/model"
@@ -22,14 +23,14 @@ func (m *mockTransactionProvider) GetTransactionRule(mode model.TransactionType)
 	return model.TransactionRule{}, nil
 }
 
-func (m *mockTransactionProvider) CreateSimpleTransaction(fromAccount, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error) {
+func (m *mockTransactionProvider) CreateSimpleTransaction(_ context.Context, fromAccount, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error) {
 	if m.createSimpleErr != nil {
 		return model.TransactionDetail{}, m.createSimpleErr
 	}
 	return model.TransactionDetail{}, nil
 }
 
-func (m *mockTransactionProvider) CreateTransactionFromSplits(splits []model.SplitDetail, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error) {
+func (m *mockTransactionProvider) CreateTransactionFromSplits(_ context.Context, splits []model.SplitDetail, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error) {
 	m.lastSplitsInput = splits
 	if m.createSplitsErr != nil {
 		return model.TransactionDetail{}, m.createSplitsErr
@@ -95,7 +96,7 @@ func TestRunFromFlags_SplitMode(t *testing.T) {
 			Description: "team lunch",
 			Splits:      []string{"Assets:Bank=-1000", "Expenses:Food=1000"},
 		}
-		input, err := runner.runFromFlags(flags)
+		input, err := runner.runFromFlags(context.Background(), flags)
 		require.NoError(t, err)
 		require.Len(t, input.Splits, 2)
 		assert.Equal(t, "Assets:Bank", input.Splits[0].AccountName)
@@ -111,7 +112,7 @@ func TestRunFromFlags_SplitMode(t *testing.T) {
 			Type:   "expense",
 			Splits: []string{"Assets:Bank:Bank1=-1000", "Assets:Bank:Bank2=-1000", "Expenses:Food:Lunch=2000"},
 		}
-		input, err := runner.runFromFlags(flags)
+		input, err := runner.runFromFlags(context.Background(), flags)
 		require.NoError(t, err)
 		assert.Len(t, input.Splits, 3)
 		assert.Equal(t, int64(200000), input.Splits[2].Amount)
@@ -121,7 +122,7 @@ func TestRunFromFlags_SplitMode(t *testing.T) {
 		flags := &addFlags{
 			Splits: []string{"Assets:Bank=-1000", "Expenses:Food=1000"},
 		}
-		_, err := runner.runFromFlags(flags)
+		_, err := runner.runFromFlags(context.Background(), flags)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "--type is required")
 	})
@@ -131,7 +132,7 @@ func TestRunFromFlags_SplitMode(t *testing.T) {
 			Type:   "expense",
 			Splits: []string{"Assets:Bank=-1000"},
 		}
-		_, err := runner.runFromFlags(flags)
+		_, err := runner.runFromFlags(context.Background(), flags)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "at least 2")
 	})
@@ -141,7 +142,7 @@ func TestRunFromFlags_SplitMode(t *testing.T) {
 			Type:   "bogus",
 			Splits: []string{"Assets:Bank=-1000", "Expenses:Food=1000"},
 		}
-		_, err := runner.runFromFlags(flags)
+		_, err := runner.runFromFlags(context.Background(), flags)
 		require.Error(t, err)
 	})
 
@@ -150,7 +151,7 @@ func TestRunFromFlags_SplitMode(t *testing.T) {
 			Type:   "expense",
 			Splits: []string{"Assets:Bank=-1000", "Expenses:Food"},
 		}
-		_, err := runner.runFromFlags(flags)
+		_, err := runner.runFromFlags(context.Background(), flags)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "expected format")
 	})
@@ -160,7 +161,7 @@ func TestRunFromFlags_SplitMode(t *testing.T) {
 			Type:   "expense",
 			Splits: []string{"Assets:Bank=-500", "Expenses:Food=500"},
 		}
-		input, err := runner.runFromFlags(flags)
+		input, err := runner.runFromFlags(context.Background(), flags)
 		require.NoError(t, err)
 		assert.Equal(t, "-", input.Description)
 	})

--- a/cmd/add_types.go
+++ b/cmd/add_types.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/hance08/kea/internal/model"
 )
 
@@ -9,16 +11,16 @@ type AddView interface {
 }
 
 type AddProvider interface {
-	GetAllAccounts() ([]*model.Account, error)
-	GetAccountBalanceFormatted(accountID int64) (string, error)
-	GetAccountByName(name string) (*model.Account, error)
-	ValidateSelectableAccount(name string, allowedTypes []string) error
+	GetAllAccounts(ctx context.Context) ([]*model.Account, error)
+	GetAccountBalanceFormatted(ctx context.Context, accountID int64) (string, error)
+	GetAccountByName(ctx context.Context, name string) (*model.Account, error)
+	ValidateSelectableAccount(ctx context.Context, name string, allowedTypes []string) error
 }
 
 type TransactionProvider interface {
 	GetTransactionRule(mode model.TransactionType) (model.TransactionRule, error)
-	CreateSimpleTransaction(fromAccount string, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error)
-	CreateTransactionFromSplits(splits []model.SplitDetail, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error)
+	CreateSimpleTransaction(ctx context.Context, fromAccount string, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error)
+	CreateTransactionFromSplits(ctx context.Context, splits []model.SplitDetail, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error)
 }
 
 type addFlags struct {

--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/service"
 	"github.com/spf13/cobra"
@@ -8,13 +10,13 @@ import (
 
 // reconcileAccountProvider is the subset of AccountService used by the runner.
 type reconcileAccountProvider interface {
-	GetAccountByName(name string) (*model.Account, error)
+	GetAccountByName(ctx context.Context, name string) (*model.Account, error)
 }
 
 // reconcileTxProvider is the subset of TransactionService used by the runner.
 type reconcileTxProvider interface {
-	GetUnreconciledByAccount(accountID int64) ([]*model.ReconcileEntry, int64, error)
-	ReconcileTransactions(accountID int64, statementBalance int64, txIDs []int64) (int64, error)
+	GetUnreconciledByAccount(ctx context.Context, accountID int64) ([]*model.ReconcileEntry, int64, error)
+	ReconcileTransactions(ctx context.Context, accountID int64, statementBalance int64, txIDs []int64) (int64, error)
 }
 
 type reconcileFlags struct {

--- a/cmd/reconcile_actions.go
+++ b/cmd/reconcile_actions.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -16,10 +17,11 @@ import (
 )
 
 func (r *reconcileRunner) Run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
 	accountName := args[0]
 
 	// Resolve account.
-	acc, err := r.accSvc.GetAccountByName(accountName)
+	acc, err := r.accSvc.GetAccountByName(ctx, accountName)
 	if err != nil {
 		return fmt.Errorf("account %q not found: %w", accountName, err)
 	}
@@ -27,14 +29,14 @@ func (r *reconcileRunner) Run(cmd *cobra.Command, args []string) error {
 	nonInteractive := cmd.Flags().Changed("balance") && cmd.Flags().Changed("ids")
 
 	if nonInteractive {
-		return r.runNonInteractive(acc)
+		return r.runNonInteractive(ctx, acc)
 	}
-	return r.runInteractive(acc)
+	return r.runInteractive(ctx, acc)
 }
 
 // ── Non-interactive (agent / script) mode ────────────────────────────────────
 
-func (r *reconcileRunner) runNonInteractive(acc *model.Account) error {
+func (r *reconcileRunner) runNonInteractive(ctx context.Context, acc *model.Account) error {
 	statementBalance, err := utils.ParseAmount(r.flags.Balance)
 	if err != nil {
 		return fmt.Errorf("invalid --balance value %q: %w", r.flags.Balance, err)
@@ -45,7 +47,7 @@ func (r *reconcileRunner) runNonInteractive(acc *model.Account) error {
 		return fmt.Errorf("invalid --ids value %q: %w", r.flags.IDs, err)
 	}
 
-	diff, err := r.txSvc.ReconcileTransactions(acc.ID, statementBalance, txIDs)
+	diff, err := r.txSvc.ReconcileTransactions(ctx, acc.ID, statementBalance, txIDs)
 	if err != nil {
 		return err
 	}
@@ -69,7 +71,7 @@ func (r *reconcileRunner) runNonInteractive(acc *model.Account) error {
 
 // ── Interactive mode ──────────────────────────────────────────────────────────
 
-func (r *reconcileRunner) runInteractive(acc *model.Account) error {
+func (r *reconcileRunner) runInteractive(ctx context.Context, acc *model.Account) error {
 	// 1. Prompt for statement balance.
 	balanceStr, err := prompts.PromptAmount(
 		"Statement ending balance:",
@@ -86,7 +88,7 @@ func (r *reconcileRunner) runInteractive(acc *model.Account) error {
 	}
 
 	// 2. Load unreconciled entries and the last reconciled balance.
-	entries, lastReconciledBalance, err := r.txSvc.GetUnreconciledByAccount(acc.ID)
+	entries, lastReconciledBalance, err := r.txSvc.GetUnreconciledByAccount(ctx, acc.ID)
 	if err != nil {
 		return err
 	}
@@ -115,7 +117,7 @@ func (r *reconcileRunner) runInteractive(acc *model.Account) error {
 	}
 
 	// 4. Persist.
-	diff, err := r.txSvc.ReconcileTransactions(acc.ID, statementBalance, selectedIDs)
+	diff, err := r.txSvc.ReconcileTransactions(ctx, acc.ID, statementBalance, selectedIDs)
 	if err != nil {
 		return err
 	}

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -39,7 +39,7 @@ Examples:
 				provider: svc.Transaction(),
 				view:     newReportView(flags),
 			}
-			return runner.run()
+			return runner.run(cmd.Context())
 		},
 	}
 

--- a/cmd/report_actions.go
+++ b/cmd/report_actions.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -9,7 +10,7 @@ import (
 )
 
 // run is the main entry point called by the cobra command.
-func (r *reportRunner) run() error {
+func (r *reportRunner) run(ctx context.Context) error {
 	reportType := r.flags.Type
 	if reportType == "" {
 		reportType = "is"
@@ -17,39 +18,39 @@ func (r *reportRunner) run() error {
 
 	switch reportType {
 	case "is":
-		return r.runIncomeStatement()
+		return r.runIncomeStatement(ctx)
 	case "ib":
-		return r.runIncomeBreakdown()
+		return r.runIncomeBreakdown(ctx)
 	case "eb":
-		return r.runExpenseBreakdown()
+		return r.runExpenseBreakdown(ctx)
 	case "bs":
-		return r.runBalanceSheet()
+		return r.runBalanceSheet(ctx)
 	default:
 		return fmt.Errorf("unknown report type %q — use: is, ib, eb, bs", reportType)
 	}
 }
 
-func (r *reportRunner) runIncomeStatement() error {
+func (r *reportRunner) runIncomeStatement(ctx context.Context) error {
 	start, end, period, err := r.resolveDateRange()
 	if err != nil {
 		return err
 	}
 
-	result, err := r.provider.GenerateIncomeStatement(start, end)
+	result, err := r.provider.GenerateIncomeStatement(ctx, start, end)
 	if err != nil {
 		return fmt.Errorf("failed to generate income statement: %w", err)
 	}
 
 	result.Period = period
 
-	currentNetWorth, err := r.provider.GetNetWorthAt(end)
+	currentNetWorth, err := r.provider.GetNetWorthAt(ctx, end)
 	if err != nil {
 		return fmt.Errorf("failed to fetch net worth for current period: %w", err)
 	}
 	result.NetWorth = currentNetWorth
 
 	_, prevEnd := previousPeriodRange(start, end)
-	previousNetWorth, err := r.provider.GetNetWorthAt(prevEnd)
+	previousNetWorth, err := r.provider.GetNetWorthAt(ctx, prevEnd)
 	if err != nil {
 		return fmt.Errorf("failed to fetch net worth for previous period: %w", err)
 	}
@@ -59,13 +60,13 @@ func (r *reportRunner) runIncomeStatement() error {
 	return r.view.RenderIncomeStatement(result)
 }
 
-func (r *reportRunner) runExpenseBreakdown() error {
+func (r *reportRunner) runExpenseBreakdown(ctx context.Context) error {
 	start, end, period, err := r.resolveDateRange()
 	if err != nil {
 		return err
 	}
 
-	result, err := r.provider.GenerateExpenseBreakdown(start, end)
+	result, err := r.provider.GenerateExpenseBreakdown(ctx, start, end)
 	if err != nil {
 		return fmt.Errorf("failed to generate expense breakdown: %w", err)
 	}
@@ -74,13 +75,13 @@ func (r *reportRunner) runExpenseBreakdown() error {
 	return r.view.RenderExpenseBreakdown(result)
 }
 
-func (r *reportRunner) runIncomeBreakdown() error {
+func (r *reportRunner) runIncomeBreakdown(ctx context.Context) error {
 	start, end, period, err := r.resolveDateRange()
 	if err != nil {
 		return err
 	}
 
-	result, err := r.provider.GenerateIncomeBreakdown(start, end)
+	result, err := r.provider.GenerateIncomeBreakdown(ctx, start, end)
 	if err != nil {
 		return fmt.Errorf("failed to generate income breakdown: %w", err)
 	}
@@ -89,13 +90,13 @@ func (r *reportRunner) runIncomeBreakdown() error {
 	return r.view.RenderIncomeBreakdown(result)
 }
 
-func (r *reportRunner) runBalanceSheet() error {
+func (r *reportRunner) runBalanceSheet(ctx context.Context) error {
 	_, end, _, err := r.resolveDateRange()
 	if err != nil {
 		return err
 	}
 
-	result, err := r.provider.GenerateBalanceSheet(end)
+	result, err := r.provider.GenerateBalanceSheet(ctx, end)
 	if err != nil {
 		return fmt.Errorf("failed to generate balance sheet: %w", err)
 	}

--- a/cmd/report_types.go
+++ b/cmd/report_types.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "github.com/hance08/kea/internal/model"
+import (
+	"context"
+
+	"github.com/hance08/kea/internal/model"
+)
 
 // reportFlags holds the parsed CLI flags for the report command.
 type reportFlags struct {
@@ -13,11 +17,11 @@ type reportFlags struct {
 
 // ReportProvider is the service interface required by the report command.
 type ReportProvider interface {
-	GenerateIncomeStatement(startTime, endTime int64) (*model.ReportResult, error)
-	GenerateIncomeBreakdown(startTime, endTime int64) (*model.ReportResult, error)
-	GenerateExpenseBreakdown(startTime, endTime int64) (*model.ReportResult, error)
-	GenerateBalanceSheet(asOf int64) (*model.BalanceSheetResult, error)
-	GetNetWorthAt(endTime int64) (int64, error)
+	GenerateIncomeStatement(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error)
+	GenerateIncomeBreakdown(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error)
+	GenerateExpenseBreakdown(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error)
+	GenerateBalanceSheet(ctx context.Context, asOf int64) (*model.BalanceSheetResult, error)
+	GetNetWorthAt(ctx context.Context, endTime int64) (int64, error)
 }
 
 // ReportView is the view interface used to render report output.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -137,7 +138,7 @@ func initSysAcc(svc *service.Service, cfg *config.Config) error {
 	}
 
 	targetName := model.OpeningBalancesAccountName(cfg.Defaults.Currency)
-	_, err := svc.Account().GetAccountByName(targetName)
+	_, err := svc.Account().GetAccountByName(context.Background(), targetName)
 	if err == nil {
 		return nil
 	}
@@ -146,6 +147,7 @@ func initSysAcc(svc *service.Service, cfg *config.Config) error {
 	}
 
 	_, err = svc.Account().CreateAccount(
+		context.Background(),
 		targetName,
 		model.AccountTypeEquity,
 		cfg.Defaults.Currency,
@@ -167,7 +169,7 @@ func migrateLegacySysAcc(svc *service.Service, cfg *config.Config) error {
 	targetName := model.OpeningBalancesAccountName(cfg.Defaults.Currency)
 
 	// Nothing to migrate if legacy account is already gone.
-	_, err := svc.Account().GetAccountByName(legacyName)
+	_, err := svc.Account().GetAccountByName(context.Background(), legacyName)
 	if errors.Is(err, service.ErrNotFound) {
 		return nil
 	}
@@ -176,7 +178,7 @@ func migrateLegacySysAcc(svc *service.Service, cfg *config.Config) error {
 	}
 
 	// Target already exists — already migrated.
-	_, err = svc.Account().GetAccountByName(targetName)
+	_, err = svc.Account().GetAccountByName(context.Background(), targetName)
 	if err == nil {
 		return nil
 	}
@@ -184,7 +186,7 @@ func migrateLegacySysAcc(svc *service.Service, cfg *config.Config) error {
 		return fmt.Errorf("failed to check target system account: %w", err)
 	}
 
-	if err := svc.Account().RenameAccount(legacyName, targetName); err != nil {
+	if err := svc.Account().RenameAccount(context.Background(), legacyName, targetName); err != nil {
 		return fmt.Errorf("failed to migrate legacy system account: %w", err)
 	}
 

--- a/cmd/transaction/clear.go
+++ b/cmd/transaction/clear.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hance08/kea/internal/model"
@@ -11,11 +12,11 @@ import (
 )
 
 type ClearProvider interface {
-	UpdateTransactionStatus(txID int64, status model.TransactionStatus) error
+	UpdateTransactionStatus(ctx context.Context, txID int64, status model.TransactionStatus) error
 }
 
 type clearFlags struct {
-	JSON    bool
+	JSON bool
 }
 
 type clearRunner struct {
@@ -32,20 +33,20 @@ func NewClearCmd(svc *service.Service) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner := &clearRunner{svc: svc.Transaction(), json: flags.JSON}
-			return runner.Run(args)
+			return runner.Run(cmd.Context(), args)
 		},
 	}
 	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output result as JSON")
 	return cmd
 }
 
-func (r *clearRunner) Run(args []string) error {
+func (r *clearRunner) Run(ctx context.Context, args []string) error {
 	var txID int64
 	if _, err := fmt.Sscanf(args[0], "%d", &txID); err != nil {
 		return fmt.Errorf("invalid transaction ID: %s", args[0])
 	}
 
-	if err := r.svc.UpdateTransactionStatus(txID, model.StatusCleared); err != nil {
+	if err := r.svc.UpdateTransactionStatus(ctx, txID, model.StatusCleared); err != nil {
 		return fmt.Errorf("failed to update transaction status: %w", err)
 	}
 

--- a/cmd/transaction/delete.go
+++ b/cmd/transaction/delete.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hance08/kea/internal/model"
@@ -17,13 +18,13 @@ type TransactionDeleteView interface {
 }
 
 type TxDeleteProvider interface {
-	GetTransactionByID(txID int64) (*model.TransactionDetail, error)
-	DeleteTransaction(txID int64) error
+	GetTransactionByID(ctx context.Context, txID int64) (*model.TransactionDetail, error)
+	DeleteTransaction(ctx context.Context, txID int64) error
 }
 
 type deleteFlags struct {
-	Yes     bool
-	JSON    bool
+	Yes  bool
+	JSON bool
 }
 
 type deleteRunner struct {
@@ -49,7 +50,7 @@ func NewDeleteCmd(svc *service.Service) *cobra.Command {
 				yes:  flags.Yes || flags.JSON,
 				json: flags.JSON,
 			}
-			return runner.Run(args)
+			return runner.Run(cmd.Context(), args)
 		},
 	}
 
@@ -59,13 +60,13 @@ func NewDeleteCmd(svc *service.Service) *cobra.Command {
 	return cmd
 }
 
-func (r *deleteRunner) Run(args []string) error {
+func (r *deleteRunner) Run(ctx context.Context, args []string) error {
 	var txID int64
 	if _, err := fmt.Sscanf(args[0], "%d", &txID); err != nil {
 		return fmt.Errorf("invalid transaction ID: %s", args[0])
 	}
 
-	detail, err := r.svc.GetTransactionByID(txID)
+	detail, err := r.svc.GetTransactionByID(ctx, txID)
 	if err != nil {
 		return fmt.Errorf("failed to get transaction: %w", err)
 	}
@@ -92,7 +93,7 @@ func (r *deleteRunner) Run(args []string) error {
 		}
 	}
 
-	if err := r.svc.DeleteTransaction(txID); err != nil {
+	if err := r.svc.DeleteTransaction(ctx, txID); err != nil {
 		return fmt.Errorf("failed to delete transaction: %w", err)
 	}
 

--- a/cmd/transaction/edit.go
+++ b/cmd/transaction/edit.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -31,12 +32,12 @@ func NewEditCmd(svc *service.Service) *cobra.Command {
 				accSvc: svc.Account(),
 				view:   views.NewTransactionEditView(),
 			}
-			return runner.Run(args)
+			return runner.Run(cmd.Context(), args)
 		},
 	}
 }
 
-func (r *editRunner) Run(args []string) error {
+func (r *editRunner) Run(ctx context.Context, args []string) error {
 	id, err := strconv.ParseInt(args[0], 10, 64)
 	if err != nil {
 		return fmt.Errorf("invalid transaction ID '%s': %w", args[0], err)
@@ -44,7 +45,7 @@ func (r *editRunner) Run(args []string) error {
 	r.txID = id
 
 	// Fetch Data
-	detail, err := r.txSvc.GetTransactionByID(r.txID)
+	detail, err := r.txSvc.GetTransactionByID(ctx, r.txID)
 	if err != nil {
 		r.view.ShowError("Failed to get transaction", err)
 		return nil
@@ -65,12 +66,12 @@ func (r *editRunner) Run(args []string) error {
 		return err
 	}
 
-	return r.runEditMenu(detail)
+	return r.runEditMenu(ctx, detail)
 }
 
-func (r *editRunner) runEditMenu(detail *model.TransactionDetail) error {
+func (r *editRunner) runEditMenu(ctx context.Context, detail *model.TransactionDetail) error {
 	for {
-		items := r.getAvailableMenuItems(detail)
+		items := r.getAvailableMenuItems(ctx, detail)
 
 		var options []string
 		itemMap := make(map[string]menuItem)
@@ -95,7 +96,7 @@ func (r *editRunner) runEditMenu(detail *model.TransactionDetail) error {
 	}
 }
 
-func (r *editRunner) getAvailableMenuItems(detail *model.TransactionDetail) []menuItem {
+func (r *editRunner) getAvailableMenuItems(ctx context.Context, detail *model.TransactionDetail) []menuItem {
 	allActions := []menuItem{
 		{
 			Label:  OptBasicInfo,
@@ -104,12 +105,16 @@ func (r *editRunner) getAvailableMenuItems(detail *model.TransactionDetail) []me
 		{
 			Label:     OptChangeType,
 			Condition: func(d *model.TransactionDetail) bool { return d.Type != model.TxTypeOpening },
-			Action:    r.actionEditType,
+			Action: func(d *model.TransactionDetail) error {
+				return r.actionEditType(ctx, d)
+			},
 		},
 		{
 			Label:     OptQuickAccount,
 			Condition: func(d *model.TransactionDetail) bool { return len(d.Splits) == 2 },
-			Action:    r.actionQuickChangeAccount,
+			Action: func(d *model.TransactionDetail) error {
+				return r.actionQuickChangeAccount(ctx, d)
+			},
 		},
 		{
 			Label:     OptQuickAmount,
@@ -117,13 +122,15 @@ func (r *editRunner) getAvailableMenuItems(detail *model.TransactionDetail) []me
 			Action:    r.actionQuickChangeAmount,
 		},
 		{
-			Label:  OptEditSplits,
-			Action: r.runSplitsMenu,
+			Label: OptEditSplits,
+			Action: func(d *model.TransactionDetail) error {
+				return r.runSplitsMenu(ctx, d)
+			},
 		},
 		{
 			Label: OptSave,
 			Action: func(d *model.TransactionDetail) error {
-				if err := r.actionSave(d); err != nil {
+				if err := r.actionSave(ctx, d); err != nil {
 					r.view.ShowError("Cannot save", err)
 					r.view.ShowWarning("Please fix the errors before saving")
 					return nil

--- a/cmd/transaction/edit_actions.go
+++ b/cmd/transaction/edit_actions.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -35,7 +36,7 @@ func (r *editRunner) actionEditBasicInfo(detail *model.TransactionDetail) error 
 	return nil
 }
 
-func (r *editRunner) actionQuickChangeAccount(detail *model.TransactionDetail) error {
+func (r *editRunner) actionQuickChangeAccount(ctx context.Context, detail *model.TransactionDetail) error {
 	if len(detail.Splits) != 2 {
 		return fmt.Errorf("quick edit supports only 2 splits")
 	}
@@ -59,12 +60,12 @@ func (r *editRunner) actionQuickChangeAccount(detail *model.TransactionDetail) e
 	targetSplit := &detail.Splits[splitIndex]
 
 	// Filter compatible accounts
-	allAccounts, err := r.accSvc.GetAllAccounts()
+	allAccounts, err := r.accSvc.GetAllAccounts(ctx)
 	if err != nil {
 		return err
 	}
 
-	currentAcc, err := r.accSvc.GetAccountByName(targetSplit.AccountName)
+	currentAcc, err := r.accSvc.GetAccountByName(ctx, targetSplit.AccountName)
 	if err != nil {
 		return fmt.Errorf("failed to load account details for '%s': %w", targetSplit.AccountName, err)
 	}
@@ -82,7 +83,7 @@ func (r *editRunner) actionQuickChangeAccount(detail *model.TransactionDetail) e
 		return err
 	}
 
-	newAcc, _ := r.accSvc.GetAccountByName(newAccName)
+	newAcc, _ := r.accSvc.GetAccountByName(ctx, newAccName)
 
 	// Apply Change
 	targetSplit.AccountID = newAcc.ID
@@ -119,7 +120,7 @@ func (r *editRunner) actionQuickChangeAmount(detail *model.TransactionDetail) er
 	return nil
 }
 
-func (r *editRunner) runSplitsMenu(detail *model.TransactionDetail) error {
+func (r *editRunner) runSplitsMenu(ctx context.Context, detail *model.TransactionDetail) error {
 	for {
 		if err := r.view.RenderDetail(detail); err != nil {
 			return err
@@ -134,11 +135,11 @@ func (r *editRunner) runSplitsMenu(detail *model.TransactionDetail) error {
 
 		switch action {
 		case "Add Split":
-			if err := r.actionAddSplit(detail); err != nil {
+			if err := r.actionAddSplit(ctx, detail); err != nil {
 				return err
 			}
 		case "Edit Split":
-			if err := r.actionEditSplit(detail); err != nil {
+			if err := r.actionEditSplit(ctx, detail); err != nil {
 				return err
 			}
 		case "Delete Split":
@@ -151,9 +152,9 @@ func (r *editRunner) runSplitsMenu(detail *model.TransactionDetail) error {
 	}
 }
 
-func (r *editRunner) actionAddSplit(detail *model.TransactionDetail) error {
+func (r *editRunner) actionAddSplit(ctx context.Context, detail *model.TransactionDetail) error {
 	// Prepare Data
-	accounts, err := r.accSvc.GetAllAccounts()
+	accounts, err := r.accSvc.GetAllAccounts(ctx)
 	if err != nil {
 		return err
 	}
@@ -175,7 +176,7 @@ func (r *editRunner) actionAddSplit(detail *model.TransactionDetail) error {
 	}
 
 	// Update Model
-	acc, _ := r.accSvc.GetAccountByName(accName)
+	acc, _ := r.accSvc.GetAccountByName(ctx, accName)
 	detail.Splits = append(detail.Splits, model.SplitDetail{
 		AccountID: acc.ID, AccountName: acc.Name, Currency: acc.Currency,
 		Amount: amount, Memo: memo,
@@ -183,7 +184,7 @@ func (r *editRunner) actionAddSplit(detail *model.TransactionDetail) error {
 	return nil
 }
 
-func (r *editRunner) actionEditSplit(detail *model.TransactionDetail) error {
+func (r *editRunner) actionEditSplit(ctx context.Context, detail *model.TransactionDetail) error {
 	// Select Split
 	idx, err := r.view.AskSplitSelection(detail.Splits)
 	if err != nil || idx == -1 {
@@ -192,7 +193,7 @@ func (r *editRunner) actionEditSplit(detail *model.TransactionDetail) error {
 	split := &detail.Splits[idx]
 
 	// Prepare Data
-	accounts, err := r.accSvc.GetAllAccounts()
+	accounts, err := r.accSvc.GetAllAccounts(ctx)
 	if err != nil {
 		return err
 	}
@@ -214,7 +215,7 @@ func (r *editRunner) actionEditSplit(detail *model.TransactionDetail) error {
 	}
 
 	// Update Model
-	acc, _ := r.accSvc.GetAccountByName(newAccName)
+	acc, _ := r.accSvc.GetAccountByName(ctx, newAccName)
 	split.AccountID = acc.ID
 	split.AccountName = acc.Name
 	split.Currency = acc.Currency
@@ -242,7 +243,7 @@ func (r *editRunner) actionDeleteSplit(detail *model.TransactionDetail) error {
 	return nil
 }
 
-func (r *editRunner) actionEditType(detail *model.TransactionDetail) error {
+func (r *editRunner) actionEditType(ctx context.Context, detail *model.TransactionDetail) error {
 	rawType, err := prompts.PromptTransactionType()
 	if err != nil {
 		return err
@@ -250,7 +251,7 @@ func (r *editRunner) actionEditType(detail *model.TransactionDetail) error {
 
 	newType := r.determineMode(rawType)
 
-	if err := r.txSvc.ValidateSplitsMatchType(newType, detail.Splits); err != nil {
+	if err := r.txSvc.ValidateSplitsMatchType(ctx, newType, detail.Splits); err != nil {
 		r.view.ShowWarning(fmt.Sprintf("Cannot change type to %s: %s", newType, err.Error()))
 		r.view.ShowWarning("Fix the splits first, then change the type.")
 		return nil
@@ -272,16 +273,16 @@ func (r *editRunner) determineMode(rawInput string) model.TransactionType {
 	return model.TxTypeTransfer
 }
 
-func (r *editRunner) actionSave(detail *model.TransactionDetail) error {
+func (r *editRunner) actionSave(ctx context.Context, detail *model.TransactionDetail) error {
 	// Validate via Service
 	splits := detail.ToSplitInputs()
-	if err := r.txSvc.ValidateTransactionEdit(splits); err != nil {
+	if err := r.txSvc.ValidateTransactionEdit(ctx, splits); err != nil {
 		return err
 	}
 
 	// Execute Update
 	if err := r.txSvc.UpdateTransactionComplete(
-		r.txID, detail.Description, detail.Timestamp, detail.Status, detail.Type, splits,
+		ctx, r.txID, detail.Description, detail.Timestamp, detail.Status, detail.Type, splits,
 	); err != nil {
 		return err
 	}

--- a/cmd/transaction/edit_types.go
+++ b/cmd/transaction/edit_types.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"context"
 	"errors"
 
 	"github.com/hance08/kea/internal/model"
@@ -28,17 +29,17 @@ type EditView interface {
 }
 
 type EditProvider interface {
-	GetTransactionByID(txID int64) (*model.TransactionDetail, error)
+	GetTransactionByID(ctx context.Context, txID int64) (*model.TransactionDetail, error)
 	IsEditable(detail *model.TransactionDetail) (bool, service.NotEditableReason)
 	GetAllowedAccounts(txType model.TransactionType, currentAccountType model.AccountType, allAccounts []*model.Account) []*model.Account
-	ValidateTransactionEdit(splits []model.SplitDetail) error
-	ValidateSplitsMatchType(txType model.TransactionType, splits []model.SplitDetail) error
-	UpdateTransactionComplete(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType, splits []model.SplitDetail) error
+	ValidateTransactionEdit(ctx context.Context, splits []model.SplitDetail) error
+	ValidateSplitsMatchType(ctx context.Context, txType model.TransactionType, splits []model.SplitDetail) error
+	UpdateTransactionComplete(ctx context.Context, txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType, splits []model.SplitDetail) error
 }
 
 type AccountProvider interface {
-	GetAccountByName(name string) (*model.Account, error)
-	GetAllAccounts() ([]*model.Account, error)
+	GetAccountByName(ctx context.Context, name string) (*model.Account, error)
+	GetAllAccounts(ctx context.Context) ([]*model.Account, error)
 }
 
 const (

--- a/cmd/transaction/list.go
+++ b/cmd/transaction/list.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -18,11 +19,11 @@ type ListView interface {
 }
 
 type ListProvider interface {
-	GetTransactionHistory(accountName string, limit int) ([]*model.Transaction, error)
-	GetRecentTransactions(limit int) ([]*model.Transaction, error)
-	GetTransactionByID(txID int64) (*model.TransactionDetail, error)
-	GetDisplayAccount(splits []model.SplitDetail, txType string) (string, error)
-	GetDisplayOffsetAccount(splits []model.SplitDetail, txType string, primaryAccount string) (string, error)
+	GetTransactionHistory(ctx context.Context, accountName string, limit int) ([]*model.Transaction, error)
+	GetRecentTransactions(ctx context.Context, limit int) ([]*model.Transaction, error)
+	GetTransactionByID(ctx context.Context, txID int64) (*model.TransactionDetail, error)
+	GetDisplayAccount(ctx context.Context, splits []model.SplitDetail, txType string) (string, error)
+	GetDisplayOffsetAccount(ctx context.Context, splits []model.SplitDetail, txType string, primaryAccount string) (string, error)
 	GetDisplayAmount(splits []model.SplitDetail) (int64, string)
 }
 
@@ -55,7 +56,7 @@ date, type, account, description, amount, and status.`,
 				view:  views.NewTransactionListView(),
 				flags: flags,
 			}
-			return runner.Run()
+			return runner.Run(cmd.Context())
 		},
 	}
 
@@ -66,15 +67,15 @@ date, type, account, description, amount, and status.`,
 	return cmd
 }
 
-func (r *listRunner) Run() error {
+func (r *listRunner) Run(ctx context.Context) error {
 	// 1. Fetch Data
-	transactions, err := r.fetchTransactions()
+	transactions, err := r.fetchTransactions(ctx)
 	if err != nil {
 		return err
 	}
 
 	// 2. Transform Data (Model -> View Model)
-	viewItems := r.buildViewItems(transactions)
+	viewItems := r.buildViewItems(ctx, transactions)
 
 	// 3. Render
 	if r.flags.JSON {
@@ -87,18 +88,18 @@ func (r *listRunner) Run() error {
 	return r.view.Render(viewItems, r.flags.Limit)
 }
 
-func (r *listRunner) fetchTransactions() ([]*model.Transaction, error) {
+func (r *listRunner) fetchTransactions(ctx context.Context) ([]*model.Transaction, error) {
 	if r.flags.Account != "" {
-		return r.svc.GetTransactionHistory(r.flags.Account, r.flags.Limit)
+		return r.svc.GetTransactionHistory(ctx, r.flags.Account, r.flags.Limit)
 	}
-	return r.svc.GetRecentTransactions(r.flags.Limit)
+	return r.svc.GetRecentTransactions(ctx, r.flags.Limit)
 }
 
-func (r *listRunner) buildViewItems(transactions []*model.Transaction) []views.TransactionListItem {
+func (r *listRunner) buildViewItems(ctx context.Context, transactions []*model.Transaction) []views.TransactionListItem {
 	var viewItems []views.TransactionListItem
 
 	for _, tx := range transactions {
-		detail, err := r.svc.GetTransactionByID(tx.ID)
+		detail, err := r.svc.GetTransactionByID(ctx, tx.ID)
 		if err != nil {
 			if !r.flags.JSON {
 				r.view.ShowWarning("Skipping transaction %d: %v\n", tx.ID, err)
@@ -106,20 +107,20 @@ func (r *listRunner) buildViewItems(transactions []*model.Transaction) []views.T
 			continue
 		}
 
-		viewItems = append(viewItems, r.convertToViewItem(tx, detail))
+		viewItems = append(viewItems, r.convertToViewItem(ctx, tx, detail))
 	}
 	return viewItems
 }
 
-func (r *listRunner) convertToViewItem(tx *model.Transaction, detail *model.TransactionDetail) views.TransactionListItem {
+func (r *listRunner) convertToViewItem(ctx context.Context, tx *model.Transaction, detail *model.TransactionDetail) views.TransactionListItem {
 	txType := string(detail.Type)
 
-	accountName, err := r.svc.GetDisplayAccount(detail.Splits, txType)
+	accountName, err := r.svc.GetDisplayAccount(ctx, detail.Splits, txType)
 	if err != nil {
 		accountName = "-"
 	}
 
-	offsetAccount, err := r.svc.GetDisplayOffsetAccount(detail.Splits, txType, accountName)
+	offsetAccount, err := r.svc.GetDisplayOffsetAccount(ctx, detail.Splits, txType, accountName)
 	if err != nil {
 		offsetAccount = "-"
 	}

--- a/cmd/transaction/show.go
+++ b/cmd/transaction/show.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hance08/kea/internal/model"
@@ -14,11 +15,11 @@ type ShowView interface {
 }
 
 type ShowProvider interface {
-	GetTransactionByID(txID int64) (*model.TransactionDetail, error)
+	GetTransactionByID(ctx context.Context, txID int64) (*model.TransactionDetail, error)
 }
 
 type showFlags struct {
-	JSON    bool
+	JSON bool
 }
 
 type showRunner struct {
@@ -39,20 +40,20 @@ func NewShowCmd(svc *service.Service) *cobra.Command {
 				view: views.NewTransactionDetailView(),
 				json: flags.JSON,
 			}
-			return runner.Run(args)
+			return runner.Run(cmd.Context(), args)
 		},
 	}
 	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output as JSON")
 	return cmd
 }
 
-func (r *showRunner) Run(args []string) error {
+func (r *showRunner) Run(ctx context.Context, args []string) error {
 	var txID int64
 	if _, err := fmt.Sscanf(args[0], "%d", &txID); err != nil {
 		return fmt.Errorf("invalid transaction ID: %s", args[0])
 	}
 
-	detail, err := r.svc.GetTransactionByID(txID)
+	detail, err := r.svc.GetTransactionByID(ctx, txID)
 	if err != nil {
 		return fmt.Errorf("failed to get transaction: %w", err)
 	}

--- a/docs/superpowers/plans/2026-04-28-context-threading.md
+++ b/docs/superpowers/plans/2026-04-28-context-threading.md
@@ -1,0 +1,1197 @@
+# Context Threading Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Thread `context.Context` as the first parameter through every DB-touching method across the store, repository interface, service, and cmd layers so queries can be cancelled and time-bounded.
+
+**Architecture:** Bottom-up mechanical sweep: DBTX interface → repository interfaces → store implementations → service test mocks → service methods → cmd interfaces → cmd call sites. Tasks 1 compiles cleanly in isolation; Tasks 2–10 are interdependent and must all complete before the build passes again. Commit after Task 1 (safe checkpoint), then commit again after the full sweep.
+
+**Tech Stack:** Go standard library `context.Context`, `database/sql` `*Context` variants (`ExecContext`, `QueryContext`, `QueryRowContext`, `PrepareContext`), Cobra (`cmd.Context()`).
+
+---
+
+## File Map
+
+Modified files and what changes in each:
+
+| File | Change |
+|------|--------|
+| `internal/store/sqlite.go` | `DBTX` interface → `*Context` methods |
+| `internal/repository/interfaces.go` | Add `ctx context.Context` first param to all 32 methods (13 AccountRepository + 19 TransactionRepository) |
+| `internal/store/sqlite_account.go` | Add ctx to 13 method signatures + use `*Context` DB calls |
+| `internal/store/sqlite_transaction.go` | Add ctx to ~15 method signatures + use `*Context` DB calls |
+| `internal/store/sqlite_reconcile.go` | Add ctx to 5 method signatures + use `*Context` DB calls |
+| `internal/service/testhelper_test.go` | Add `_ context.Context` first param to all mock methods |
+| `internal/service/account_service.go` | Add ctx to 8 methods; pass ctx to repo calls |
+| `internal/service/account_ops.go` | Add ctx to 5 methods; `ExecTx(ctx,` replaces `ExecTx(context.Background(),` |
+| `internal/service/transaction_service.go` | Add ctx to 5 methods |
+| `internal/service/transaction_ops.go` | Add ctx to 6 methods; replace hardcoded `context.Background()` |
+| `internal/service/transaction_validation.go` | Add ctx to `ValidateTransactionEdit` (calls accRepo) |
+| `internal/service/reconcile_ops.go` | Add ctx to 2 methods; replace hardcoded `context.Background()` |
+| `internal/service/report_service.go` | Add ctx to 5 methods (incl. private `buildReportMaps`) |
+| `cmd/add_types.go` | Add ctx to `AddProvider` + `TransactionProvider` methods |
+| `cmd/report_types.go` | Add ctx to `ReportProvider` methods |
+| `cmd/reconcile.go` | Add ctx to `reconcileAccountProvider` + `reconcileTxProvider` methods |
+| `cmd/transaction/list.go` | Add ctx to `ListProvider` methods |
+| `cmd/transaction/edit_types.go` | Add ctx to `EditProvider` + `AccountProvider` DB-touching methods |
+| `cmd/transaction/clear.go` | Add ctx to `ClearProvider` |
+| `cmd/transaction/show.go` | Add ctx to `ShowProvider` |
+| `cmd/transaction/delete.go` | Add ctx to `TxDeleteProvider` |
+| `cmd/account/list.go` | Add ctx to `AccountListProvider` methods |
+| `cmd/account/delete.go` | Add ctx to `AccountDeleteProvider` |
+| `cmd/account/edit_types.go` | Add ctx to `EditProvider` DB-touching methods |
+| `cmd/account/create_types.go` | Add ctx to `CreateProvider` DB-touching methods |
+| `cmd/add.go` | Pass ctx in `Run` |
+| `cmd/add_actions.go` | Pass ctx down through action helpers |
+| `cmd/add_test.go` | Add `_ context.Context` to mock method signatures |
+| `cmd/report.go` | Pass `cmd.Context()` to `runner.run()` |
+| `cmd/report_actions.go` | Accept + thread ctx through report runners |
+| `cmd/reconcile_actions.go` | Thread ctx through reconcile runners |
+| `cmd/account/create.go` | Pass ctx to RunE call sites |
+| `cmd/account/create_actions.go` | Thread ctx |
+| `cmd/account/edit.go` | Thread ctx |
+| `cmd/account/edit_actions.go` | Thread ctx |
+| `cmd/account/list.go` | Thread ctx |
+| `cmd/account/delete.go` | Thread ctx |
+| `cmd/transaction/show.go` | Thread ctx |
+| `cmd/transaction/list.go` | Thread ctx |
+| `cmd/transaction/clear.go` | Thread ctx |
+| `cmd/transaction/delete.go` | Thread ctx |
+| `cmd/transaction/edit.go` | Thread ctx |
+| `cmd/transaction/edit_actions.go` | Thread ctx |
+| `cmd/root.go` | `initSysAcc` / `migrateLegacySysAcc` use `context.Background()` |
+
+**Not changed** (no DB calls, no ctx needed):
+- `internal/service/account_validation.go` — pure string validation
+- `internal/service/transaction_validation.go` line 12 `ValidateSplitsBalance` — pure math (only `ValidateTransactionEdit` changes)
+- Service methods: `GetTransactionRule`, `IsEditable`, `GetAllowedAccounts`, `GetDisplayAccount`, `GetDisplayOffsetAccount`, `GetDisplayAmount`, `ValidateSplitsMatchType`, `ValidateAccountName`, `ValidateFullAccountName`, `ValidateCurrency`, `FormatAccountName`, `GetRootNameByType`
+
+---
+
+## Task 1: Update DBTX Interface and Internal Store DB Calls
+
+> This task is compile-safe — it changes only internal store details, not any public method signatures.
+
+**Files:**
+- Modify: `internal/store/sqlite.go`
+- Modify: `internal/store/sqlite_account.go`
+- Modify: `internal/store/sqlite_transaction.go`
+- Modify: `internal/store/sqlite_reconcile.go`
+
+- [ ] **Step 1: Update `DBTX` interface in `internal/store/sqlite.go`**
+
+Replace lines 19–24 (the `DBTX` interface):
+
+```go
+type DBTX interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+```
+
+Both `*sql.DB` and `*sql.Tx` already satisfy this interface, so `ExecTx` keeps working unchanged.
+
+- [ ] **Step 2: Update internal DB calls in `internal/store/sqlite_account.go`**
+
+The public method signatures do NOT change yet. Only the internal `s.db.Xxx` call sites change. Problem: the methods don't have a `ctx` parameter yet, so use `context.Background()` as a temporary placeholder to keep things compiling. (In Task 3, the real ctx will be threaded.)
+
+Apply this pattern to every method:
+- `s.db.Prepare(q)` → `s.db.PrepareContext(context.Background(), q)`
+- After prepare: `stmt.QueryRow(args...)` → `stmt.QueryRowContext(context.Background(), args...)`
+- After prepare: `stmt.Exec(args...)` → `stmt.ExecContext(context.Background(), args...)`
+- `s.db.Query(q, args...)` → `s.db.QueryContext(context.Background(), q, args...)`
+- `s.db.QueryRow(q, args...)` → `s.db.QueryRowContext(context.Background(), q, args...)`
+- `s.db.Exec(q, args...)` → `s.db.ExecContext(context.Background(), q, args...)`
+
+Add `"context"` to the import block.
+
+Affected methods (13 total):
+`CreateAccount`, `GetAllAccounts`, `GetAccountByName`, `GetAccountByID`, `AccountExists`, `GetAllAccountBalances`, `HasChildAccounts`, `GetAccountsByType`, `GetAccountBalance`, `AccountHasTransactions`, `RenameAccount`, `DeleteAccount`, `UpdateAccountMetadata`
+
+- [ ] **Step 3: Update internal DB calls in `internal/store/sqlite_transaction.go`**
+
+Apply the same `context.Background()` placeholder pattern. Add `"context"` to imports.
+
+Affected methods (14 in this file):
+`CreateTransactionWithSplits`, `GetTransactionByID`, `GetTransactionsByAccount`, `GetTransactionsByDateRange`, `GetAllTransactions`, `UpdateTransactionStatus`, `DeleteTransaction`, `UpdateTransactionBasic`, `UpdateSplit`, `DeleteSplit`, `CreateSplit`, `GetSplitsByTransaction`, `GetSplitsWithAccountsByDateRange`, `GetSplitsWithAccountsByTransaction`
+
+(`GetUnreconciledTransactionsByAccount` lives in `sqlite_reconcile.go` — handled in Step 4.)
+
+Exact call replacement example for `CreateTransactionWithSplits`:
+```go
+stmtTx, err := s.db.PrepareContext(context.Background(), `
+    INSERT INTO transactions (timestamp, description, status, external_id, type)
+    VALUES (?, ?, ?, ?, ?)
+    RETURNING id;
+`)
+// ...
+err = stmtTx.QueryRowContext(context.Background(), tx.Timestamp, tx.Description, tx.Status, tx.ExternalID, tx.Type).Scan(&newTxID)
+// ...
+stmtSplit, err := s.db.PrepareContext(context.Background(), `
+    INSERT INTO splits (transaction_id, account_id, amount, currency, memo)
+    VALUES (?, ?, ?, ?, ?);
+`)
+// ...
+_, err := stmtSplit.ExecContext(context.Background(), newTxID, split.AccountID, split.Amount, split.Currency, split.Memo)
+```
+
+- [ ] **Step 4: Update internal DB calls in `internal/store/sqlite_reconcile.go`**
+
+Apply the same `context.Background()` placeholder pattern. Add `"context"` to imports.
+
+Affected methods (5 total):
+`GetUnreconciledTransactionsByAccount`, `MarkSplitsReconciledByAccount`, `BulkUpdateTransactionStatus`, `GetLastReconciledBalance`, `SetLastReconciledBalance`
+
+- [ ] **Step 5: Verify Task 1 compiles and tests pass**
+
+```bash
+go build ./...
+go test ./...
+```
+
+Expected: all pass. If any method in store has a mismatched signature (e.g., used wrong method name), fix it now.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add internal/store/sqlite.go internal/store/sqlite_account.go internal/store/sqlite_transaction.go internal/store/sqlite_reconcile.go
+git commit -m "refactor: switch DBTX interface to *Context methods (internal only)"
+```
+
+---
+
+## Task 2: Update Repository Interfaces
+
+> After this task the build breaks. It will not pass until Task 10 is complete.
+
+**Files:**
+- Modify: `internal/repository/interfaces.go`
+
+- [ ] **Step 1: Add `ctx context.Context` as first parameter to all interface methods**
+
+Replace the entire file content:
+
+```go
+package repository
+
+import (
+	"context"
+
+	"github.com/hance08/kea/internal/model"
+)
+
+type AccountRepository interface {
+	CreateAccount(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64) (int64, error)
+	GetAllAccounts(ctx context.Context) ([]*model.Account, error)
+	GetAccountByName(ctx context.Context, name string) (*model.Account, error)
+	GetAccountByID(ctx context.Context, id int64) (*model.Account, error)
+	AccountExists(ctx context.Context, name string) (bool, error)
+	GetAccountsByType(ctx context.Context, accType model.AccountType) ([]*model.Account, error)
+	GetAccountBalance(ctx context.Context, accountID int64) (int64, error)
+	GetAllAccountBalances(ctx context.Context, asOf int64) (map[int64]int64, error)
+	HasChildAccounts(ctx context.Context, accountID int64) (bool, error)
+	AccountHasTransactions(ctx context.Context, accountID int64) (bool, error)
+	DeleteAccount(ctx context.Context, accountID int64) error
+	RenameAccount(ctx context.Context, oldName, newName string) error
+	UpdateAccountMetadata(ctx context.Context, accountID int64, description string, isHidden bool) error
+}
+
+type TransactionRepository interface {
+	CreateTransactionWithSplits(ctx context.Context, tx model.Transaction, splits []model.Split) (int64, error)
+	GetTransactionByID(ctx context.Context, txID int64) (*model.Transaction, error)
+	GetTransactionsByAccount(ctx context.Context, accountID int64, limit int) ([]*model.Transaction, error)
+	GetTransactionsByDateRange(ctx context.Context, startTime, endTime int64) ([]*model.Transaction, error)
+	GetAllTransactions(ctx context.Context, limit int) ([]*model.Transaction, error)
+
+	UpdateTransactionStatus(ctx context.Context, txID int64, status model.TransactionStatus) error
+	DeleteTransaction(ctx context.Context, txID int64) error
+	UpdateTransactionBasic(ctx context.Context, txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error
+
+	CreateSplit(ctx context.Context, txID int64, split *model.Split) (int64, error)
+	UpdateSplit(ctx context.Context, splitID int64, accountID int64, amount int64, currency string, memo string) error
+	DeleteSplit(ctx context.Context, splitID int64) error
+	GetSplitsByTransaction(ctx context.Context, txID int64) ([]*model.Split, error)
+
+	GetSplitsWithAccountsByDateRange(ctx context.Context, startTime, endTime int64) (map[int64][]model.SplitDetail, error)
+	GetSplitsWithAccountsByTransaction(ctx context.Context, txID int64) ([]model.SplitDetail, error)
+	GetUnreconciledTransactionsByAccount(ctx context.Context, accountID int64) ([]*model.ReconcileEntry, error)
+	BulkUpdateTransactionStatus(ctx context.Context, txIDs []int64, status model.TransactionStatus) error
+	MarkSplitsReconciledByAccount(ctx context.Context, accountID int64, txIDs []int64) (int64, error)
+	GetLastReconciledBalance(ctx context.Context, accountID int64) (int64, error)
+	SetLastReconciledBalance(ctx context.Context, accountID int64, balance int64) error
+}
+
+type Repository interface {
+	AccountRepository
+	TransactionRepository
+}
+
+type TransactionManager interface {
+	ExecTx(ctx context.Context, fn func(Repository) error) error
+}
+```
+
+---
+
+## Task 3: Update Store Account Method Signatures
+
+**Files:**
+- Modify: `internal/store/sqlite_account.go`
+
+- [ ] **Step 1: Add `ctx context.Context` as first parameter to each Store method and replace placeholder `context.Background()` with `ctx`**
+
+Apply this to all 13 methods. Example showing full before/after for `CreateAccount`:
+
+Before:
+```go
+func (s *Store) CreateAccount(name string, accType model.AccountType, currency string, description string, parentID *int64) (int64, error) {
+	stmt, err := s.db.PrepareContext(context.Background(), `...`)
+	// ...
+	err = stmt.QueryRowContext(context.Background(), name, ...).Scan(&newID)
+```
+
+After:
+```go
+func (s *Store) CreateAccount(ctx context.Context, name string, accType model.AccountType, currency string, description string, parentID *int64) (int64, error) {
+	stmt, err := s.db.PrepareContext(ctx, `...`)
+	// ...
+	err = stmt.QueryRowContext(ctx, name, ...).Scan(&newID)
+```
+
+Apply the same pattern — add `ctx context.Context` as first param, replace all `context.Background()` with `ctx` — to every method:
+
+- `GetAllAccounts(ctx context.Context) ([]*model.Account, error)`
+- `GetAccountByName(ctx context.Context, name string) (*model.Account, error)`
+- `GetAccountByID(ctx context.Context, id int64) (*model.Account, error)`
+- `AccountExists(ctx context.Context, name string) (bool, error)`
+- `GetAllAccountBalances(ctx context.Context, asOf int64) (map[int64]int64, error)`
+- `HasChildAccounts(ctx context.Context, accountID int64) (bool, error)`
+- `GetAccountsByType(ctx context.Context, accType model.AccountType) ([]*model.Account, error)`
+- `GetAccountBalance(ctx context.Context, accountID int64) (int64, error)`
+- `AccountHasTransactions(ctx context.Context, accountID int64) (bool, error)`
+- `RenameAccount(ctx context.Context, oldName, newName string) error`
+- `DeleteAccount(ctx context.Context, accountID int64) error`
+- `UpdateAccountMetadata(ctx context.Context, accountID int64, description string, isHidden bool) error`
+
+The `scanAccounts` private helper method does NOT change (it operates on `*sql.Rows`, no DB calls).
+
+---
+
+## Task 4: Update Store Transaction and Reconcile Method Signatures
+
+**Files:**
+- Modify: `internal/store/sqlite_transaction.go`
+- Modify: `internal/store/sqlite_reconcile.go`
+
+- [ ] **Step 1: Update `internal/store/sqlite_transaction.go`**
+
+Add `ctx context.Context` as first param and replace all `context.Background()` with `ctx`:
+
+- `CreateTransactionWithSplits(ctx context.Context, tx model.Transaction, splits []model.Split) (int64, error)`
+- `GetTransactionByID(ctx context.Context, txID int64) (*model.Transaction, error)`
+- `GetTransactionsByAccount(ctx context.Context, accountID int64, limit int) ([]*model.Transaction, error)`
+- `GetTransactionsByDateRange(ctx context.Context, startTime, endTime int64) ([]*model.Transaction, error)`
+- `GetAllTransactions(ctx context.Context, limit int) ([]*model.Transaction, error)`
+- `UpdateTransactionStatus(ctx context.Context, txID int64, status model.TransactionStatus) error`
+- `DeleteTransaction(ctx context.Context, txID int64) error`
+- `UpdateTransactionBasic(ctx context.Context, txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error`
+- `UpdateSplit(ctx context.Context, splitID int64, accountID int64, amount int64, currency string, memo string) error`
+- `DeleteSplit(ctx context.Context, splitID int64) error`
+- `CreateSplit(ctx context.Context, txID int64, split *model.Split) (int64, error)`
+- `GetSplitsByTransaction(ctx context.Context, txID int64) ([]*model.Split, error)`
+- `GetSplitsWithAccountsByDateRange(ctx context.Context, startTime, endTime int64) (map[int64][]model.SplitDetail, error)`
+- `GetSplitsWithAccountsByTransaction(ctx context.Context, txID int64) ([]model.SplitDetail, error)`
+
+The `scanTransactions` private helper does NOT change.
+
+- [ ] **Step 2: Update `internal/store/sqlite_reconcile.go`**
+
+Add `ctx context.Context` as first param and replace all `context.Background()` with `ctx`:
+
+- `GetUnreconciledTransactionsByAccount(ctx context.Context, accountID int64) ([]*model.ReconcileEntry, error)`
+- `MarkSplitsReconciledByAccount(ctx context.Context, accountID int64, txIDs []int64) (int64, error)`
+- `BulkUpdateTransactionStatus(ctx context.Context, txIDs []int64, status model.TransactionStatus) error`
+- `GetLastReconciledBalance(ctx context.Context, accountID int64) (int64, error)`
+- `SetLastReconciledBalance(ctx context.Context, accountID int64, balance int64) error`
+
+Note: `MarkSplitsReconciledByAccount` at line 104 calls `s.BulkUpdateTransactionStatus(txIDs, model.StatusReconciled)` — this internal call must also pass ctx: `s.BulkUpdateTransactionStatus(ctx, txIDs, model.StatusReconciled)`.
+
+---
+
+## Task 5: Update Service Test Mocks
+
+**Files:**
+- Modify: `internal/service/testhelper_test.go`
+
+- [ ] **Step 1: Add `_ context.Context` as first parameter to every mock method on `mockAccountRepo`**
+
+The mock ignores ctx (it operates on in-memory maps), so use blank identifier. Apply to all 13 methods:
+
+```go
+func (m *mockAccountRepo) CreateAccount(_ context.Context, name string, accType model.AccountType, currency, description string, parentID *int64) (int64, error) {
+func (m *mockAccountRepo) GetAllAccounts(_ context.Context) ([]*model.Account, error) {
+func (m *mockAccountRepo) GetAccountByName(_ context.Context, name string) (*model.Account, error) {
+func (m *mockAccountRepo) GetAccountByID(_ context.Context, id int64) (*model.Account, error) {
+func (m *mockAccountRepo) AccountExists(_ context.Context, name string) (bool, error) {
+func (m *mockAccountRepo) GetAccountsByType(_ context.Context, accType model.AccountType) ([]*model.Account, error) {
+func (m *mockAccountRepo) GetAccountBalance(_ context.Context, accountID int64) (int64, error) {
+func (m *mockAccountRepo) GetAllAccountBalances(_ context.Context, asOf int64) (map[int64]int64, error) {
+func (m *mockAccountRepo) HasChildAccounts(_ context.Context, accountID int64) (bool, error) {
+func (m *mockAccountRepo) AccountHasTransactions(_ context.Context, accountID int64) (bool, error) {
+func (m *mockAccountRepo) DeleteAccount(_ context.Context, accountID int64) error {
+func (m *mockAccountRepo) RenameAccount(_ context.Context, oldName, newName string) error {
+func (m *mockAccountRepo) UpdateAccountMetadata(_ context.Context, accountID int64, description string, isHidden bool) error {
+```
+
+- [ ] **Step 2: Add `_ context.Context` to every mock method on `mockTransactionRepo`**
+
+Apply to all 14 methods:
+
+```go
+func (m *mockTransactionRepo) CreateTransactionWithSplits(_ context.Context, tx model.Transaction, splits []model.Split) (int64, error) {
+func (m *mockTransactionRepo) GetTransactionByID(_ context.Context, txID int64) (*model.Transaction, error) {
+func (m *mockTransactionRepo) GetTransactionsByAccount(_ context.Context, accountID int64, limit int) ([]*model.Transaction, error) {
+func (m *mockTransactionRepo) GetTransactionsByDateRange(_ context.Context, startTime, endTime int64) ([]*model.Transaction, error) {
+func (m *mockTransactionRepo) GetAllTransactions(_ context.Context, limit int) ([]*model.Transaction, error) {
+func (m *mockTransactionRepo) UpdateTransactionStatus(_ context.Context, txID int64, status model.TransactionStatus) error {
+func (m *mockTransactionRepo) DeleteTransaction(_ context.Context, txID int64) error {
+func (m *mockTransactionRepo) UpdateTransactionBasic(_ context.Context, txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error {
+func (m *mockTransactionRepo) CreateSplit(_ context.Context, txID int64, split *model.Split) (int64, error) {
+func (m *mockTransactionRepo) UpdateSplit(_ context.Context, splitID int64, accountID int64, amount int64, currency string, memo string) error {
+func (m *mockTransactionRepo) DeleteSplit(_ context.Context, splitID int64) error {
+func (m *mockTransactionRepo) GetSplitsByTransaction(_ context.Context, txID int64) ([]*model.Split, error) {
+func (m *mockTransactionRepo) GetSplitsWithAccountsByDateRange(_ context.Context, startTime, endTime int64) (map[int64][]model.SplitDetail, error) {
+func (m *mockTransactionRepo) GetSplitsWithAccountsByTransaction(_ context.Context, txID int64) ([]model.SplitDetail, error) {
+func (m *mockTransactionRepo) GetUnreconciledTransactionsByAccount(_ context.Context, accountID int64) ([]*model.ReconcileEntry, error) {
+func (m *mockTransactionRepo) BulkUpdateTransactionStatus(_ context.Context, txIDs []int64, status model.TransactionStatus) error {
+func (m *mockTransactionRepo) MarkSplitsReconciledByAccount(_ context.Context, accountID int64, txIDs []int64) (int64, error) {
+func (m *mockTransactionRepo) GetLastReconciledBalance(_ context.Context, accountID int64) (int64, error) {
+func (m *mockTransactionRepo) SetLastReconciledBalance(_ context.Context, accountID int64, balance int64) error {
+```
+
+---
+
+## Task 6: Update Service Account Layer
+
+**Files:**
+- Modify: `internal/service/account_service.go`
+- Modify: `internal/service/account_ops.go`
+
+- [ ] **Step 1: Update `internal/service/account_service.go`**
+
+Add `ctx context.Context` to every method that calls accRepo. Thread ctx to repo calls.
+
+```go
+func (as *AccountService) GetAllAccounts(ctx context.Context) ([]*model.Account, error) {
+    return as.repo.GetAllAccounts(ctx)
+}
+
+func (as *AccountService) GetAccountByName(ctx context.Context, name string) (*model.Account, error) {
+    acc, err := as.repo.GetAccountByName(ctx, name)
+    // ... rest unchanged
+}
+
+func (as *AccountService) GetAccountsByType(ctx context.Context, accType model.AccountType) ([]*model.Account, error) {
+    return as.repo.GetAccountsByType(ctx, accType)
+}
+
+func (as *AccountService) GetAccountBalance(ctx context.Context, accountID int64) (int64, error) {
+    return as.repo.GetAccountBalance(ctx, accountID)
+}
+
+func (as *AccountService) GetAccountBalanceFormatted(ctx context.Context, accountID int64) (string, error) {
+    balance, err := as.GetAccountBalance(ctx, accountID)
+    // ... rest unchanged
+}
+
+func (as *AccountService) GetRootNameByType(accType string) (string, error) { // NO ctx — pure lookup table, no DB
+    // ... unchanged
+}
+
+func (as *AccountService) CheckAccountExists(ctx context.Context, name string) (bool, error) {
+    return as.repo.AccountExists(ctx, name)
+}
+
+func (as *AccountService) ValidateSelectableAccount(ctx context.Context, name string, allowedTypes []string) error {
+    acc, err := as.GetAccountByName(ctx, name)
+    // ... rest unchanged
+}
+
+func (as *AccountService) UpdateAccountMetadata(ctx context.Context, accountID int64, description string, isHidden bool) error {
+    return as.repo.UpdateAccountMetadata(ctx, accountID, description, isHidden)
+}
+```
+
+Add `"context"` to imports.
+
+- [ ] **Step 2: Update `internal/service/account_ops.go`**
+
+> **Scope note:** This PR threads `ctx` through the existing structure. It does NOT change atomicity boundaries. The known atomicity bug in `CreateAccountWithBalance` (issue #29 — `CreateAccount` and `createOpeningBalance` are not in the same transaction) stays unchanged here and will be fixed in a separate PR. Keep the existing two-step structure; just plumb `ctx` through it.
+
+Add ctx to every method and thread it through. Replace `context.Background()` with `ctx`:
+
+```go
+func (as *AccountService) CreateAccount(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64) (*model.Account, error) {
+    // ...validation unchanged...
+    _, err := as.repo.CreateAccount(ctx, name, accType, currency, description, parentID)
+    // ...
+}
+
+func (as *AccountService) CreateAccountWithBalance(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64, balance int64) (*model.Account, error) {
+    account, err := as.CreateAccount(ctx, name, accType, currency, description, parentID)
+    if err != nil {
+        return nil, err
+    }
+    if balance != 0 {
+        if err := as.createOpeningBalance(ctx, account, balance); err != nil {
+            return account, fmt.Errorf("account created but failed to set opening balance: %w", err)
+        }
+    }
+    return account, nil
+}
+
+func (as *AccountService) createOpeningBalance(ctx context.Context, account *model.Account, amountInCents int64) error {
+    // ...existing setup unchanged (currency, equityAccountName, balanceAmount, equityAmount, tx)...
+    return as.tm.ExecTx(ctx, func(repo repository.Repository) error {
+        // existing closure body unchanged — keeps using the closure-bound `repo`,
+        // just add ctx to every repo.X(...) call:
+        equityAcc, err := repo.GetAccountByName(ctx, equityAccountName)
+        if err != nil {
+            if !errors.Is(err, store.ErrRecordNotFound) {
+                return fmt.Errorf("failed to look up %q: %w", equityAccountName, err)
+            }
+            newID, createErr := repo.CreateAccount(ctx, equityAccountName, model.AccountTypeEquity, currency, "Opening Balances (System Account)", nil)
+            if createErr != nil {
+                return fmt.Errorf("failed to create %q: %w", equityAccountName, createErr)
+            }
+            equityAcc = &model.Account{ID: newID}
+        }
+        splits := []model.Split{
+            {AccountID: account.ID, Amount: balanceAmount, Currency: currency, Memo: model.OpeningAccountMemo},
+            {AccountID: equityAcc.ID, Amount: equityAmount, Currency: currency, Memo: model.OpeningAccountMemo},
+        }
+        _, err = repo.CreateTransactionWithSplits(ctx, tx, splits)
+        return err
+    })
+}
+
+func (as *AccountService) DeleteAccountByName(ctx context.Context, name string) error {
+    acc, err := as.repo.GetAccountByName(ctx, name)
+    // ...
+    hasChildren, err := as.repo.HasChildAccounts(ctx, acc.ID)
+    // ...
+    hasTx, err := as.repo.AccountHasTransactions(ctx, acc.ID)
+    // ...
+    return as.repo.DeleteAccount(ctx, acc.ID)
+}
+
+func (as *AccountService) RenameAccount(ctx context.Context, oldName, newSegment string) error {
+    oldAcc, err := as.repo.GetAccountByName(ctx, oldName)
+    // ...
+    _, err = as.repo.GetAccountByName(ctx, newFullName)
+    // ...
+    return as.repo.RenameAccount(ctx, oldName, newFullName)
+}
+```
+
+`FormatAccountName(prefix, name string) string` — pure string method, NO ctx.
+
+Note on `createOpeningBalance`: it currently opens its own `ExecTx` and uses the closure-bound `repo` (verified in the current code). Keep that structure; only swap `context.Background()` for the new `ctx` parameter and add `ctx` to every `repo.X(...)` call inside the closure. Do NOT lift the `ExecTx` up into `CreateAccountWithBalance` in this PR — that's the #29 fix and belongs in its own change.
+
+---
+
+## Task 7: Update Service Transaction Layer
+
+**Files:**
+- Modify: `internal/service/transaction_service.go`
+- Modify: `internal/service/transaction_ops.go`
+- Modify: `internal/service/transaction_validation.go`
+
+- [ ] **Step 1: Update `internal/service/transaction_service.go`**
+
+```go
+func (ts *TransactionService) GetTransactionRule(txType model.TransactionType) (model.TransactionRule, error) { // NO ctx — pure table lookup
+func (ts *TransactionService) GetTransactionByID(ctx context.Context, txID int64) (*model.TransactionDetail, error) {
+    tx, err := ts.txRepo.GetTransactionByID(ctx, txID)
+    // ...
+    splits, err := ts.txRepo.GetSplitsWithAccountsByTransaction(ctx, txID)
+    // ...
+}
+func (ts *TransactionService) GetRecentTransactions(ctx context.Context, limit int) ([]*model.Transaction, error) {
+    return ts.txRepo.GetAllTransactions(ctx, limit)
+}
+func (ts *TransactionService) GetTransactionHistory(ctx context.Context, accountName string, limit int) ([]*model.Transaction, error) {
+    acc, err := ts.accRepo.GetAccountByName(ctx, accountName)
+    // ...
+    return ts.txRepo.GetTransactionsByAccount(ctx, acc.ID, limit)
+}
+```
+
+- [ ] **Step 2: Update `internal/service/transaction_ops.go`**
+
+Replace all `context.Background()` occurrences with the incoming `ctx`. Key methods:
+
+```go
+func (ts *TransactionService) CreateTransaction(ctx context.Context, input model.TransactionDetail) (int64, error) {
+    err := ts.tm.ExecTx(ctx, func(repo repository.Repository) error {
+        txID, err := repo.CreateTransactionWithSplits(ctx, tx, splits)
+        // ...
+    })
+}
+
+func (ts *TransactionService) CreateSimpleTransaction(ctx context.Context, fromAccount, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error) {
+    fromAcc, err := ts.accRepo.GetAccountByName(ctx, fromAccount)
+    toAcc, err := ts.accRepo.GetAccountByName(ctx, toAccount)
+    // ...
+    txID, err := ts.CreateTransaction(ctx, input)
+    // ...
+}
+
+func (ts *TransactionService) CreateTransactionFromSplits(ctx context.Context, splits []model.SplitDetail, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error) {
+    // ...
+    txID, err := ts.CreateTransaction(ctx, input)
+    // ...
+}
+
+func (ts *TransactionService) DeleteTransaction(ctx context.Context, txID int64) error {
+    tx, err := ts.txRepo.GetTransactionByID(ctx, txID)
+    // ...
+    return ts.txRepo.DeleteTransaction(ctx, txID)
+}
+
+func (ts *TransactionService) UpdateTransactionStatus(ctx context.Context, txID int64, status model.TransactionStatus) error {
+    tx, err := ts.txRepo.GetTransactionByID(ctx, txID)
+    // ...
+    return ts.txRepo.UpdateTransactionStatus(ctx, txID, status)
+}
+
+func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType, splits []model.SplitDetail) error {
+    return ts.tm.ExecTx(ctx, func(repo repository.Repository) error {
+        // All repo calls pass ctx
+        tx, err := repo.GetTransactionByID(ctx, txID)
+        // ...
+        err = repo.UpdateTransactionBasic(ctx, txID, ...)
+        // ...
+        for _, s := range toDelete {
+            err := repo.DeleteSplit(ctx, s.ID)
+        }
+        // ...
+    })
+}
+```
+
+`IsEditable(detail *model.TransactionDetail) (bool, NotEditableReason)` — NO ctx (pure domain logic).
+
+- [ ] **Step 3: Update `ValidateTransactionEdit` in `internal/service/transaction_validation.go`**
+
+```go
+func (ts *TransactionService) ValidateTransactionEdit(ctx context.Context, splits []model.SplitDetail) error {
+    // ...
+    for i, split := range splits {
+        _, err := ts.accRepo.GetAccountByID(ctx, split.AccountID)
+        // ...
+    }
+}
+```
+
+`ValidateSplitsBalance` — NO ctx (pure math).
+
+---
+
+## Task 8: Update Service Reconcile and Report Layers
+
+**Files:**
+- Modify: `internal/service/reconcile_ops.go`
+- Modify: `internal/service/report_service.go`
+
+- [ ] **Step 1: Update `internal/service/reconcile_ops.go`**
+
+```go
+func (ts *TransactionService) GetUnreconciledByAccount(ctx context.Context, accountID int64) ([]*model.ReconcileEntry, int64, error) {
+    entries, err := ts.txRepo.GetUnreconciledTransactionsByAccount(ctx, accountID)
+    // ...
+    lastBalance, err := ts.txRepo.GetLastReconciledBalance(ctx, accountID)
+    // ...
+}
+
+func (ts *TransactionService) ReconcileTransactions(ctx context.Context, accountID int64, statementBalance int64, txIDs []int64) (int64, error) {
+    if err := ts.tm.ExecTx(ctx, func(repo repository.Repository) error {
+        rowsAffected, err := repo.MarkSplitsReconciledByAccount(ctx, accountID, txIDs)
+        // ...
+        return repo.SetLastReconciledBalance(ctx, accountID, statementBalance)
+    }); err != nil {
+        // ...
+    }
+}
+```
+
+- [ ] **Step 2: Update `internal/service/report_service.go`**
+
+```go
+func (ts *TransactionService) GetNetWorthAt(ctx context.Context, endTime int64) (int64, error) {
+    balances, err := ts.accRepo.GetAllAccountBalances(ctx, endTime)
+    // ...
+}
+
+func (ts *TransactionService) buildReportMaps(ctx context.Context, startTime, endTime int64, includeIncome, includeExpense bool) (incomeByAccount, expenseByAccount map[string]*model.ReportRow, err error) {
+    splitsMap, err := ts.txRepo.GetSplitsWithAccountsByDateRange(ctx, startTime, endTime)
+    // ...
+}
+
+func (ts *TransactionService) GenerateIncomeStatement(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error) {
+    income, expense, err := ts.buildReportMaps(ctx, startTime, endTime, true, true)
+    // ...
+}
+
+func (ts *TransactionService) GenerateIncomeBreakdown(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error) {
+    income, _, err := ts.buildReportMaps(ctx, startTime, endTime, true, false)
+    // ...
+}
+
+func (ts *TransactionService) GenerateExpenseBreakdown(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error) {
+    _, expense, err := ts.buildReportMaps(ctx, startTime, endTime, false, true)
+    // ...
+}
+
+func (ts *TransactionService) GenerateBalanceSheet(ctx context.Context, asOf int64) (*model.BalanceSheetResult, error) {
+    balances, err := ts.accRepo.GetAllAccountBalances(ctx, asOf)
+    // ...
+    accounts, err := ts.accRepo.GetAllAccounts(ctx)
+    // ...
+}
+```
+
+Private helpers `offsetAccountName`, `getOrCreateRowWithOffset`, `rowsFromMap` — NO ctx (pure logic).
+
+---
+
+## Task 9: Update cmd Interfaces
+
+> Every cmd-level interface that mirrors a DB-touching service method must add `ctx context.Context`.
+
+**Files:**
+- Modify: `cmd/add_types.go`
+- Modify: `cmd/report_types.go`
+- Modify: `cmd/reconcile.go`
+- Modify: `cmd/transaction/list.go`
+- Modify: `cmd/transaction/edit_types.go`
+- Modify: `cmd/transaction/clear.go`
+- Modify: `cmd/transaction/show.go`
+- Modify: `cmd/transaction/delete.go`
+- Modify: `cmd/account/list.go`
+- Modify: `cmd/account/delete.go`
+- Modify: `cmd/account/edit_types.go`
+- Modify: `cmd/account/create_types.go`
+
+- [ ] **Step 1: Update `cmd/add_types.go`**
+
+```go
+type AddProvider interface {
+    GetAllAccounts(ctx context.Context) ([]*model.Account, error)
+    GetAccountBalanceFormatted(ctx context.Context, accountID int64) (string, error)
+    GetAccountByName(ctx context.Context, name string) (*model.Account, error)
+    ValidateSelectableAccount(ctx context.Context, name string, allowedTypes []string) error
+}
+
+type TransactionProvider interface {
+    GetTransactionRule(mode model.TransactionType) (model.TransactionRule, error)  // no ctx — pure lookup
+    CreateSimpleTransaction(ctx context.Context, fromAccount string, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error)
+    CreateTransactionFromSplits(ctx context.Context, splits []model.SplitDetail, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error)
+}
+```
+
+Add `"context"` to imports.
+
+- [ ] **Step 2: Update `cmd/report_types.go`**
+
+```go
+type ReportProvider interface {
+    GenerateIncomeStatement(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error)
+    GenerateIncomeBreakdown(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error)
+    GenerateExpenseBreakdown(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error)
+    GenerateBalanceSheet(ctx context.Context, asOf int64) (*model.BalanceSheetResult, error)
+    GetNetWorthAt(ctx context.Context, endTime int64) (int64, error)
+}
+```
+
+Add `"context"` to imports.
+
+- [ ] **Step 3: Update `cmd/reconcile.go`**
+
+```go
+type reconcileAccountProvider interface {
+    GetAccountByName(ctx context.Context, name string) (*model.Account, error)
+}
+
+type reconcileTxProvider interface {
+    GetUnreconciledByAccount(ctx context.Context, accountID int64) ([]*model.ReconcileEntry, int64, error)
+    ReconcileTransactions(ctx context.Context, accountID int64, statementBalance int64, txIDs []int64) (int64, error)
+}
+```
+
+Add `"context"` to imports.
+
+- [ ] **Step 4: Update `cmd/transaction/list.go`**
+
+```go
+type ListProvider interface {
+    GetTransactionHistory(ctx context.Context, accountName string, limit int) ([]*model.Transaction, error)
+    GetRecentTransactions(ctx context.Context, limit int) ([]*model.Transaction, error)
+    GetTransactionByID(ctx context.Context, txID int64) (*model.TransactionDetail, error)
+    GetDisplayAccount(splits []model.SplitDetail, txType string) (string, error)         // no ctx — pure logic
+    GetDisplayOffsetAccount(splits []model.SplitDetail, txType string, primaryAccount string) (string, error)  // no ctx
+    GetDisplayAmount(splits []model.SplitDetail) (int64, string)                         // no ctx
+}
+```
+
+Add `"context"` to imports.
+
+- [ ] **Step 5: Update `cmd/transaction/edit_types.go`**
+
+```go
+type EditProvider interface {
+    GetTransactionByID(ctx context.Context, txID int64) (*model.TransactionDetail, error)
+    IsEditable(detail *model.TransactionDetail) (bool, service.NotEditableReason)                       // no ctx
+    GetAllowedAccounts(txType model.TransactionType, currentAccountType model.AccountType, allAccounts []*model.Account) []*model.Account // no ctx
+    ValidateTransactionEdit(ctx context.Context, splits []model.SplitDetail) error
+    ValidateSplitsMatchType(txType model.TransactionType, splits []model.SplitDetail) error             // no ctx
+    UpdateTransactionComplete(ctx context.Context, txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType, splits []model.SplitDetail) error
+}
+
+type AccountProvider interface {
+    GetAccountByName(ctx context.Context, name string) (*model.Account, error)
+    GetAllAccounts(ctx context.Context) ([]*model.Account, error)
+}
+```
+
+Add `"context"` to imports.
+
+- [ ] **Step 6: Update `cmd/transaction/clear.go`**
+
+```go
+type ClearProvider interface {
+    UpdateTransactionStatus(ctx context.Context, txID int64, status model.TransactionStatus) error
+}
+```
+
+Add `"context"` to imports.
+
+- [ ] **Step 7: Update `cmd/transaction/show.go`**
+
+```go
+type ShowProvider interface {
+    GetTransactionByID(ctx context.Context, txID int64) (*model.TransactionDetail, error)
+}
+```
+
+Add `"context"` to imports.
+
+- [ ] **Step 8: Update `cmd/transaction/delete.go`**
+
+```go
+type TxDeleteProvider interface {
+    GetTransactionByID(ctx context.Context, txID int64) (*model.TransactionDetail, error)
+    DeleteTransaction(ctx context.Context, txID int64) error
+}
+```
+
+Add `"context"` to imports.
+
+- [ ] **Step 9: Update `cmd/account/list.go`**
+
+```go
+type AccountListProvider interface {
+    GetAccountsByType(ctx context.Context, accType model.AccountType) ([]*model.Account, error)
+    GetAllAccounts(ctx context.Context) ([]*model.Account, error)
+    GetAccountBalance(ctx context.Context, id int64) (int64, error)
+    GetAccountBalanceFormatted(ctx context.Context, id int64) (string, error)
+}
+```
+
+Add `"context"` to imports.
+
+- [ ] **Step 10: Update `cmd/account/delete.go`**
+
+```go
+type AccountDeleteProvider interface {
+    GetAccountByName(ctx context.Context, name string) (*model.Account, error)
+    DeleteAccountByName(ctx context.Context, name string) error
+}
+```
+
+Add `"context"` to imports.
+
+- [ ] **Step 11: Update `cmd/account/edit_types.go`**
+
+```go
+type EditProvider interface {
+    GetAccountByName(ctx context.Context, name string) (*model.Account, error)
+    GetAccountBalance(ctx context.Context, id int64) (int64, error)
+    RenameAccount(ctx context.Context, oldName, newSegment string) error
+    UpdateAccountMetadata(ctx context.Context, id int64, description string, isHidden bool) error
+    ValidateAccountName(name string) error          // no ctx — pure validation
+    CheckAccountExists(ctx context.Context, name string) (bool, error)
+}
+```
+
+Add `"context"` to imports.
+
+- [ ] **Step 12: Update `cmd/account/create_types.go`**
+
+```go
+type CreateProvider interface {
+    GetAllAccounts(ctx context.Context) ([]*model.Account, error)
+    GetAccountByName(ctx context.Context, name string) (*model.Account, error)
+    GetRootNameByType(accType string) (string, error)       // no ctx — pure lookup
+    CheckAccountExists(ctx context.Context, name string) (bool, error)
+    FormatAccountName(prefix string, name string) string   // no ctx — pure string
+    CreateAccountWithBalance(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64, balance int64) (*model.Account, error)
+    ValidateAccountName(name string) error                 // no ctx — pure validation
+    ValidateFullAccountName(name string) error             // no ctx — pure validation
+    ValidateCurrency(currency string) error                // no ctx — pure validation
+    GetAccountBalance(ctx context.Context, id int64) (int64, error)
+}
+```
+
+Add `"context"` to imports.
+
+---
+
+## Task 10: Update cmd Call Sites and root.go
+
+**Files:**
+- Modify: `cmd/add.go`, `cmd/add_actions.go`, `cmd/add_test.go`
+- Modify: `cmd/report.go`, `cmd/report_actions.go`
+- Modify: `cmd/reconcile_actions.go`
+- Modify: `cmd/root.go`
+- Modify: `cmd/account/create.go`, `cmd/account/create_actions.go`
+- Modify: `cmd/account/edit.go`, `cmd/account/edit_actions.go`
+- Modify: `cmd/account/list.go`
+- Modify: `cmd/account/delete.go`
+- Modify: `cmd/transaction/show.go`
+- Modify: `cmd/transaction/list.go`
+- Modify: `cmd/transaction/clear.go`
+- Modify: `cmd/transaction/delete.go`
+- Modify: `cmd/transaction/edit.go`, `cmd/transaction/edit_actions.go`
+
+The pattern for RunE-backed commands:
+```go
+RunE: func(cmd *cobra.Command, args []string) error {
+    ctx := cmd.Context()
+    return runner.run(ctx)
+    // or: runner.Run(ctx, flags, cmd)
+}
+```
+
+The pattern for runner methods: add `ctx context.Context` as first parameter and thread to every DB-touching call.
+
+- [ ] **Step 1: Update `cmd/add.go` and `cmd/add_actions.go`**
+
+`addRunner.Run` already receives `cmd *cobra.Command`. Extract ctx there:
+
+```go
+func (r *addRunner) Run(flags *addFlags, cmd *cobra.Command) error {
+    ctx := cmd.Context()
+    // ...
+    input, err = r.runFromFlags(ctx, flags)
+    // OR:
+    input, err = r.runInteractive(ctx)
+    // ...
+    result, err = r.txSvc.CreateTransactionFromSplits(ctx, ...)
+    result, err = r.txSvc.CreateSimpleTransaction(ctx, ...)
+}
+
+func (r *addRunner) runFromFlags(ctx context.Context, flags *addFlags) (addTransactionInput, error) { ... }
+func (r *addRunner) runInteractive(ctx context.Context) (addTransactionInput, error) { ... }
+func (r *addRunner) selectAccount(ctx context.Context, accounts []*model.Account, ...) (string, error) { ... }
+func (r *addRunner) validateAccountSelectable(ctx context.Context, accountName string, allowedTypes []string, flagName string) error { ... }
+```
+
+Inside `runInteractive`: `accounts, err := r.accSvc.GetAllAccounts(ctx)` and `r.accSvc.GetAccountByName(ctx, ...)`.
+
+`determineMode`, `parseDate`, `runFromSplitFlags` — check each method's body; only add ctx if they call DB methods.
+
+- [ ] **Step 2: Update `cmd/add_test.go`**
+
+Add `_ context.Context` to the mock:
+
+```go
+func (m *mockTransactionProvider) CreateSimpleTransaction(_ context.Context, fromAccount, toAccount string, ...) (model.TransactionDetail, error) {
+func (m *mockTransactionProvider) CreateTransactionFromSplits(_ context.Context, splits []model.SplitDetail, ...) (model.TransactionDetail, error) {
+```
+
+`GetTransactionRule` — no ctx, no change.
+
+Add `"context"` to imports if not already present.
+
+- [ ] **Step 3: Update `cmd/report.go` and `cmd/report_actions.go`**
+
+In `report.go` RunE:
+```go
+RunE: func(cmd *cobra.Command, args []string) error {
+    runner := &reportRunner{...}
+    return runner.run(cmd.Context())
+},
+```
+
+In `report_actions.go`:
+```go
+func (r *reportRunner) run(ctx context.Context) error { ... }
+func (r *reportRunner) runIncomeStatement(ctx context.Context) error {
+    result, err := r.provider.GenerateIncomeStatement(ctx, start, end)
+    currentNetWorth, err := r.provider.GetNetWorthAt(ctx, end)
+    previousNetWorth, err := r.provider.GetNetWorthAt(ctx, prevEnd)
+    // ...
+}
+func (r *reportRunner) runExpenseBreakdown(ctx context.Context) error {
+    result, err := r.provider.GenerateExpenseBreakdown(ctx, start, end)
+    // ...
+}
+func (r *reportRunner) runIncomeBreakdown(ctx context.Context) error {
+    result, err := r.provider.GenerateIncomeBreakdown(ctx, start, end)
+    // ...
+}
+func (r *reportRunner) runBalanceSheet(ctx context.Context) error {
+    result, err := r.provider.GenerateBalanceSheet(ctx, end)
+    // ...
+}
+// resolveDateRange — NO ctx (pure date math)
+```
+
+- [ ] **Step 4: Update `cmd/reconcile_actions.go`**
+
+`reconcileRunner.Run` already receives `cmd *cobra.Command`:
+
+```go
+func (r *reconcileRunner) Run(cmd *cobra.Command, args []string) error {
+    ctx := cmd.Context()
+    acc, err := r.accSvc.GetAccountByName(ctx, accountName)
+    // ...
+    return r.runNonInteractive(ctx, acc)
+    // or:
+    return r.runInteractive(ctx, acc)
+}
+
+func (r *reconcileRunner) runNonInteractive(ctx context.Context, acc *model.Account) error {
+    diff, err := r.txSvc.ReconcileTransactions(ctx, acc.ID, statementBalance, txIDs)
+    // ...
+}
+
+func (r *reconcileRunner) runInteractive(ctx context.Context, acc *model.Account) error {
+    entries, lastReconciledBalance, err := r.txSvc.GetUnreconciledByAccount(ctx, acc.ID)
+    // ...
+    diff, err := r.txSvc.ReconcileTransactions(ctx, acc.ID, statementBalance, selectedIDs)
+    // ...
+}
+```
+
+- [ ] **Step 5: Update `cmd/root.go`**
+
+`initSysAcc` and `migrateLegacySysAcc` run before `rootCmd.Execute()`, so no Cobra context is available. Use `context.Background()`:
+
+```go
+func initSysAcc(svc *service.Service, cfg *config.Config) error {
+    ctx := context.Background()
+    if err := migrateLegacySysAcc(ctx, svc, cfg); err != nil { ... }
+    _, err := svc.Account().GetAccountByName(ctx, targetName)
+    // ...
+    _, err = svc.Account().CreateAccount(ctx, targetName, ...)
+}
+
+func migrateLegacySysAcc(ctx context.Context, svc *service.Service, cfg *config.Config) error {
+    _, err := svc.Account().GetAccountByName(ctx, legacyName)
+    // ...
+    _, err = svc.Account().GetAccountByName(ctx, targetName)
+    // ...
+    return svc.Account().RenameAccount(ctx, legacyName, targetName)
+}
+```
+
+Add `"context"` to imports.
+
+- [ ] **Step 6: Update `cmd/account/create.go` and `cmd/account/create_actions.go`**
+
+In `create.go` RunE, extract `ctx := cmd.Context()` and pass to runner methods. In `create_actions.go`:
+
+```go
+func (r *createRunner) createAccount(ctx context.Context, input createInput) (*model.Account, error) {
+    return r.accSvc.CreateAccountWithBalance(ctx, ...)
+}
+func (r *createRunner) buildFromParentName(ctx context.Context, parentName, currency string, input *createInput) error {
+    parentAccount, err := r.accSvc.GetAccountByName(ctx, parentName)
+    // ...
+}
+func (r *createRunner) buildFromTypeFlag(ctx context.Context, accType, currency string, input *createInput) error {
+    allAccounts, err := r.accSvc.GetAllAccounts(ctx)
+    // ...
+}
+```
+
+Methods that only do string/logic work (`applyTypeSettings`, `applyParentSettings`) — check their bodies; add ctx only if they call DB methods.
+
+- [ ] **Step 7: Update `cmd/account/edit.go` and `cmd/account/edit_actions.go`**
+
+Extract `ctx := cmd.Context()` in RunE. In `edit_actions.go`:
+
+```go
+func (r *editRunner) runFromFlags(ctx context.Context, acc *model.Account, flags *editFlags, cmd *cobra.Command) (editInput, error) { ... }
+func (r *editRunner) runInteractive(ctx context.Context, acc *model.Account) (editInput, error) {
+    // Any call to r.svc.CheckAccountExists, r.svc.GetAccountByName etc. gets ctx
+}
+func (r *editRunner) applyChanges(ctx context.Context, acc *model.Account, input editInput) (string, error) {
+    return r.svc.RenameAccount(ctx, ...) / r.svc.UpdateAccountMetadata(ctx, ...)
+}
+```
+
+In `edit.go` RunE:
+```go
+ctx := cmd.Context()
+acc, err := r.svc.GetAccountByName(ctx, accName)
+updatedAcc, err := r.svc.GetAccountByName(ctx, finalName)
+bal, err := r.svc.GetAccountBalance(ctx, updatedAcc.ID)
+```
+
+- [ ] **Step 8: Update `cmd/account/list.go`**
+
+In RunE or runner method:
+```go
+ctx := cmd.Context()
+accounts, err = r.svc.GetAccountsByType(ctx, model.AccountType(r.flags.Type))
+accounts, err = r.svc.GetAllAccounts(ctx)
+bal, err := r.svc.GetAccountBalance(ctx, acc.ID)
+// GetAccountBalanceFormatted is passed as a callback — update to ctx-aware closure:
+return views.NewAccountListView().Render(accounts, func(id int64) (string, error) {
+    return r.svc.GetAccountBalanceFormatted(ctx, id)
+})
+```
+
+Note: `GetAccountBalanceFormatted` is passed as a function value to `Render`. Since its signature now requires ctx, wrap it in a closure that captures ctx from the RunE scope.
+
+- [ ] **Step 9: Update `cmd/account/delete.go`**
+
+```go
+ctx := cmd.Context()
+acc, err := r.svc.GetAccountByName(ctx, name)
+if err := r.svc.DeleteAccountByName(ctx, acc.Name); err != nil {
+```
+
+- [ ] **Step 10: Update `cmd/transaction/show.go`**
+
+```go
+ctx := cmd.Context()
+detail, err := r.svc.GetTransactionByID(ctx, txID)
+```
+
+- [ ] **Step 11: Update `cmd/transaction/list.go`**
+
+```go
+ctx := cmd.Context()
+return r.svc.GetTransactionHistory(ctx, r.flags.Account, r.flags.Limit)
+return r.svc.GetRecentTransactions(ctx, r.flags.Limit)
+detail, err := r.svc.GetTransactionByID(ctx, tx.ID)
+```
+
+`GetDisplayAccount`, `GetDisplayOffsetAccount`, `GetDisplayAmount` — no ctx, no change.
+
+- [ ] **Step 12: Update `cmd/transaction/clear.go`**
+
+```go
+ctx := cmd.Context()
+if err := r.svc.UpdateTransactionStatus(ctx, txID, model.StatusCleared); err != nil {
+```
+
+- [ ] **Step 13: Update `cmd/transaction/delete.go`**
+
+```go
+ctx := cmd.Context()
+detail, err := r.svc.GetTransactionByID(ctx, txID)
+if err := r.svc.DeleteTransaction(ctx, txID); err != nil {
+```
+
+- [ ] **Step 14: Update `cmd/transaction/edit.go` and `cmd/transaction/edit_actions.go`**
+
+In `edit.go` RunE or runner entry point:
+```go
+ctx := cmd.Context()
+detail, err := r.txSvc.GetTransactionByID(ctx, r.txID)
+```
+
+In `edit_actions.go`:
+```go
+func (r *editRunner) actionEditBasicInfo(ctx context.Context, detail *model.TransactionDetail) error { ... }
+func (r *editRunner) actionQuickChangeAccount(ctx context.Context, detail *model.TransactionDetail) error {
+    allAccounts, err := r.accSvc.GetAllAccounts(ctx)
+    currentAcc, err := r.accSvc.GetAccountByName(ctx, targetSplit.AccountName)
+    newAcc, _ := r.accSvc.GetAccountByName(ctx, newAccName)
+}
+func (r *editRunner) actionQuickChangeAmount(ctx context.Context, detail *model.TransactionDetail) error { ... }
+func (r *editRunner) actionAddSplit(ctx context.Context, detail *model.TransactionDetail) error {
+    accounts, err := r.accSvc.GetAllAccounts(ctx)
+    acc, _ := r.accSvc.GetAccountByName(ctx, accName)
+}
+func (r *editRunner) actionEditSplit(ctx context.Context, detail *model.TransactionDetail) error {
+    accounts, err := r.accSvc.GetAllAccounts(ctx)
+    acc, _ := r.accSvc.GetAccountByName(ctx, newAccName)
+}
+func (r *editRunner) actionSave(ctx context.Context, detail *model.TransactionDetail) error {
+    if err := r.txSvc.ValidateTransactionEdit(ctx, splits); err != nil {
+    if err := r.txSvc.UpdateTransactionComplete(ctx, txID, ...); err != nil {
+}
+```
+
+`actionDeleteSplit`, `actionEditType` — check their bodies; add ctx only if they call DB methods.
+`determineMode` — no ctx (pure logic).
+
+The main edit loop (likely in `edit.go` or a top-level runner method) passes ctx down to all action methods.
+
+---
+
+## Task 11: Verify and Commit
+
+- [ ] **Step 1: Verify build**
+
+```bash
+go build ./...
+```
+
+Expected: exits 0 with no errors. If there are errors, they will point to remaining call sites that still use the old signature — fix each one.
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: all tests pass. If any service-layer test fails with "too many arguments", check `testhelper_test.go` for any missed mock methods.
+
+- [ ] **Step 3: Commit the full context-threading sweep**
+
+```bash
+git add -A
+git commit -m "refactor: thread context.Context through all DB-touching methods
+
+- DBTX interface uses *Context variants (ExecContext, QueryContext, etc.)
+- All AccountRepository and TransactionRepository methods accept ctx
+- Store implementations pass ctx to database/sql *Context calls
+- Service methods accept and propagate ctx; ExecTx calls no longer use context.Background()
+- cmd layer passes cmd.Context() from RunE; initSysAcc uses context.Background()
+- Enables per-request cancellation, timeouts, and graceful shutdown
+
+Closes #37"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] **Spec coverage**: All 4 steps from the issue are covered: DBTX (Task 1), AccountRepository (Task 2–3, 6), TransactionRepository (Task 2, 4, 7–8), service methods (Tasks 6–9), call sites (Task 10).
+- [x] **No placeholders**: Every task shows exact method signatures. Task 10 step 14 ("check their bodies") is an instruction to read before writing — the signatures shown are complete for the methods that definitely change.
+- [x] **Type consistency**: `ctx context.Context` is the first parameter everywhere. `_ context.Context` in mocks. ExecTx fn captures ctx from outer method — no changes needed to TransactionManager interface.
+- [x] **Field names verified**: `AccountService` field is `repo` (not `accRepo`); `TransactionService` fields are `txRepo` and `accRepo`. Plan code blocks reflect this.
+- [x] **Scope is bounded**: Pure mechanical ctx threading. Atomicity bug in `CreateAccountWithBalance` (issue #29) is explicitly NOT fixed here — `createOpeningBalance` keeps its own `ExecTx`. #29 is a separate PR.
+- [x] **root.go edge case**: `initSysAcc`/`migrateLegacySysAcc` run pre-Execute; explicitly documented to use `context.Background()`.
+- [x] **GetAccountBalanceFormatted as callback**: Documented in Task 10 Step 8 that it must be wrapped in a ctx-capturing closure when passed to views.
+- [x] **Private store helpers**: `scanAccounts`, `scanTransactions` explicitly noted as NOT changing.
+- [x] **Non-DB service methods**: Explicitly documented which methods skip ctx across all tasks.

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -7,69 +7,69 @@ import (
 )
 
 type AccountRepository interface {
-	CreateAccount(name string, accType model.AccountType, currency, description string, parentID *int64) (int64, error)
-	GetAllAccounts() ([]*model.Account, error)
-	GetAccountByName(name string) (*model.Account, error)
-	GetAccountByID(id int64) (*model.Account, error)
-	AccountExists(name string) (bool, error)
-	GetAccountsByType(accType model.AccountType) ([]*model.Account, error)
-	GetAccountBalance(accountID int64) (int64, error)
-	GetAllAccountBalances(asOf int64) (map[int64]int64, error)
-	HasChildAccounts(accountID int64) (bool, error)
-	AccountHasTransactions(accountID int64) (bool, error)
-	DeleteAccount(accountID int64) error
-	RenameAccount(oldName, newName string) error
-	UpdateAccountMetadata(accountID int64, description string, isHidden bool) error
+	CreateAccount(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64) (int64, error)
+	GetAllAccounts(ctx context.Context) ([]*model.Account, error)
+	GetAccountByName(ctx context.Context, name string) (*model.Account, error)
+	GetAccountByID(ctx context.Context, id int64) (*model.Account, error)
+	AccountExists(ctx context.Context, name string) (bool, error)
+	GetAccountsByType(ctx context.Context, accType model.AccountType) ([]*model.Account, error)
+	GetAccountBalance(ctx context.Context, accountID int64) (int64, error)
+	GetAllAccountBalances(ctx context.Context, asOf int64) (map[int64]int64, error)
+	HasChildAccounts(ctx context.Context, accountID int64) (bool, error)
+	AccountHasTransactions(ctx context.Context, accountID int64) (bool, error)
+	DeleteAccount(ctx context.Context, accountID int64) error
+	RenameAccount(ctx context.Context, oldName, newName string) error
+	UpdateAccountMetadata(ctx context.Context, accountID int64, description string, isHidden bool) error
 }
 
 type TransactionRepository interface {
-	CreateTransactionWithSplits(tx model.Transaction, splits []model.Split) (int64, error)
-	GetTransactionByID(txID int64) (*model.Transaction, error)
-	GetTransactionsByAccount(accountID int64, limit int) ([]*model.Transaction, error)
-	GetTransactionsByDateRange(startTime, endTime int64) ([]*model.Transaction, error)
-	GetAllTransactions(limit int) ([]*model.Transaction, error)
+	CreateTransactionWithSplits(ctx context.Context, tx model.Transaction, splits []model.Split) (int64, error)
+	GetTransactionByID(ctx context.Context, txID int64) (*model.Transaction, error)
+	GetTransactionsByAccount(ctx context.Context, accountID int64, limit int) ([]*model.Transaction, error)
+	GetTransactionsByDateRange(ctx context.Context, startTime, endTime int64) ([]*model.Transaction, error)
+	GetAllTransactions(ctx context.Context, limit int) ([]*model.Transaction, error)
 
-	UpdateTransactionStatus(txID int64, status model.TransactionStatus) error
-	DeleteTransaction(txID int64) error
-	UpdateTransactionBasic(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error
+	UpdateTransactionStatus(ctx context.Context, txID int64, status model.TransactionStatus) error
+	DeleteTransaction(ctx context.Context, txID int64) error
+	UpdateTransactionBasic(ctx context.Context, txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error
 
-	CreateSplit(txID int64, split *model.Split) (int64, error)
-	UpdateSplit(splitID int64, accountID int64, amount int64, currency string, memo string) error
-	DeleteSplit(splitID int64) error
-	GetSplitsByTransaction(txID int64) ([]*model.Split, error)
+	CreateSplit(ctx context.Context, txID int64, split *model.Split) (int64, error)
+	UpdateSplit(ctx context.Context, splitID int64, accountID int64, amount int64, currency string, memo string) error
+	DeleteSplit(ctx context.Context, splitID int64) error
+	GetSplitsByTransaction(ctx context.Context, txID int64) ([]*model.Split, error)
 
 	// GetSplitsWithAccountsByDateRange returns all splits (with account info) for
 	// transactions in the given Unix time range, keyed by transaction ID.
 	// Designed for bulk report queries to avoid N+1 patterns.
-	GetSplitsWithAccountsByDateRange(startTime, endTime int64) (map[int64][]model.SplitDetail, error)
+	GetSplitsWithAccountsByDateRange(ctx context.Context, startTime, endTime int64) (map[int64][]model.SplitDetail, error)
 
 	// GetSplitsWithAccountsByTransaction returns all splits (with account info) for
 	// a single transaction in one JOIN query.
-	GetSplitsWithAccountsByTransaction(txID int64) ([]model.SplitDetail, error)
+	GetSplitsWithAccountsByTransaction(ctx context.Context, txID int64) ([]model.SplitDetail, error)
 
 	// GetUnreconciledTransactionsByAccount returns all Pending and Cleared
 	// transactions that have a split touching accountID, together with the
 	// net split amount for that account. Ordered by timestamp ASC.
-	GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.ReconcileEntry, error)
+	GetUnreconciledTransactionsByAccount(ctx context.Context, accountID int64) ([]*model.ReconcileEntry, error)
 
 	// BulkUpdateTransactionStatus sets status on all listed transaction IDs
 	// in a single atomic UPDATE. Returns an error if the affected row count
 	// does not match len(txIDs).
-	BulkUpdateTransactionStatus(txIDs []int64, status model.TransactionStatus) error
+	BulkUpdateTransactionStatus(ctx context.Context, txIDs []int64, status model.TransactionStatus) error
 
 	// MarkSplitsReconciledByAccount marks the splits for accountID in each of
 	// the listed transactions as reconciled. If all splits in a transaction are
 	// now reconciled the transaction's status is upgraded to StatusReconciled.
-	MarkSplitsReconciledByAccount(accountID int64, txIDs []int64) (int64, error)
+	MarkSplitsReconciledByAccount(ctx context.Context, accountID int64, txIDs []int64) (int64, error)
 
 	// GetLastReconciledBalance returns the running reconciled balance for
 	// accountID as persisted after the most recent successful reconcile.
 	// Returns 0 if the account has never been reconciled.
-	GetLastReconciledBalance(accountID int64) (int64, error)
+	GetLastReconciledBalance(ctx context.Context, accountID int64) (int64, error)
 
 	// SetLastReconciledBalance persists the new running reconciled balance for
 	// accountID. Uses an upsert so the first call creates the row.
-	SetLastReconciledBalance(accountID int64, balance int64) error
+	SetLastReconciledBalance(ctx context.Context, accountID int64, balance int64) error
 }
 
 type Repository interface {

--- a/internal/service/account_ops.go
+++ b/internal/service/account_ops.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hance08/kea/internal/store"
 )
 
-func (as *AccountService) CreateAccount(name string, accType model.AccountType, currency, description string, parentID *int64) (*model.Account, error) {
+func (as *AccountService) CreateAccount(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64) (*model.Account, error) {
 	if err := as.ValidateFullAccountName(name); err != nil {
 		return nil, fmt.Errorf("invalid account name: %w", err)
 	}
@@ -23,7 +23,7 @@ func (as *AccountService) CreateAccount(name string, accType model.AccountType, 
 		return nil, fmt.Errorf("invalid account type: %s", accType)
 	}
 
-	newID, err := as.repo.CreateAccount(name, accType, currency, description, parentID)
+	newID, err := as.repo.CreateAccount(ctx, name, accType, currency, description, parentID)
 	if err != nil {
 		if errors.Is(err, store.ErrAccountExists) {
 			return nil, fmt.Errorf("account %q: %w", name, ErrAlreadyExists)
@@ -42,14 +42,14 @@ func (as *AccountService) CreateAccount(name string, accType model.AccountType, 
 	}, nil
 }
 
-func (as *AccountService) CreateAccountWithBalance(name string, accType model.AccountType, currency, description string, parentID *int64, balance int64) (*model.Account, error) {
-	account, err := as.CreateAccount(name, accType, currency, description, parentID)
+func (as *AccountService) CreateAccountWithBalance(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64, balance int64) (*model.Account, error) {
+	account, err := as.CreateAccount(ctx, name, accType, currency, description, parentID)
 	if err != nil {
 		return nil, err
 	}
 
 	if balance != 0 {
-		if err := as.createOpeningBalance(account, balance); err != nil {
+		if err := as.createOpeningBalance(ctx, account, balance); err != nil {
 			return account, fmt.Errorf("account created but failed to set opening balance: %w", err)
 		}
 	}
@@ -57,7 +57,7 @@ func (as *AccountService) CreateAccountWithBalance(name string, accType model.Ac
 	return account, nil
 }
 
-func (as *AccountService) createOpeningBalance(account *model.Account, amountInCents int64) error {
+func (as *AccountService) createOpeningBalance(ctx context.Context, account *model.Account, amountInCents int64) error {
 	currency := account.Currency
 	if currency == "" {
 		currency = as.config.Defaults.Currency
@@ -84,16 +84,17 @@ func (as *AccountService) createOpeningBalance(account *model.Account, amountInC
 		Type:        model.TxTypeOpening,
 	}
 
-	return as.tm.ExecTx(context.Background(), func(repo repository.Repository) error {
+	return as.tm.ExecTx(ctx, func(repo repository.Repository) error {
 		// repo is the raw repository.Repository passed by ExecTx, not AccountService,
 		// so GetAccountByName here returns store.ErrRecordNotFound directly (no service translation).
-		equityAcc, err := repo.GetAccountByName(equityAccountName)
+		equityAcc, err := repo.GetAccountByName(ctx, equityAccountName)
 		if err != nil {
 			if !errors.Is(err, store.ErrRecordNotFound) {
 				return fmt.Errorf("failed to look up %q: %w", equityAccountName, err)
 			}
 			// not found — create it
 			newID, createErr := repo.CreateAccount(
+				ctx,
 				equityAccountName,
 				model.AccountTypeEquity,
 				currency,
@@ -110,13 +111,13 @@ func (as *AccountService) createOpeningBalance(account *model.Account, amountInC
 			{AccountID: account.ID, Amount: balanceAmount, Currency: currency, Memo: model.OpeningAccountMemo},
 			{AccountID: equityAcc.ID, Amount: equityAmount, Currency: currency, Memo: model.OpeningAccountMemo},
 		}
-		_, err = repo.CreateTransactionWithSplits(tx, splits)
+		_, err = repo.CreateTransactionWithSplits(ctx, tx, splits)
 		return err
 	})
 }
 
-func (as *AccountService) DeleteAccountByName(name string) error {
-	acc, err := as.repo.GetAccountByName(name)
+func (as *AccountService) DeleteAccountByName(ctx context.Context, name string) error {
+	acc, err := as.repo.GetAccountByName(ctx, name)
 	if err != nil {
 		return err
 	}
@@ -125,7 +126,7 @@ func (as *AccountService) DeleteAccountByName(name string) error {
 		return fmt.Errorf("account %q is a system account and cannot be deleted: %w", acc.Name, ErrNotEditable)
 	}
 
-	hasChildren, err := as.repo.HasChildAccounts(acc.ID)
+	hasChildren, err := as.repo.HasChildAccounts(ctx, acc.ID)
 	if err != nil {
 		return err
 	}
@@ -133,7 +134,7 @@ func (as *AccountService) DeleteAccountByName(name string) error {
 		return fmt.Errorf("account %q has child accounts; delete or move them first", acc.Name)
 	}
 
-	hasTransactions, err := as.repo.AccountHasTransactions(acc.ID)
+	hasTransactions, err := as.repo.AccountHasTransactions(ctx, acc.ID)
 	if err != nil {
 		return err
 	}
@@ -141,7 +142,7 @@ func (as *AccountService) DeleteAccountByName(name string) error {
 		return fmt.Errorf("account %q has transactions and cannot be deleted", acc.Name)
 	}
 
-	return as.repo.DeleteAccount(acc.ID)
+	return as.repo.DeleteAccount(ctx, acc.ID)
 }
 
 func (as *AccountService) FormatAccountName(prefix, name string) string {
@@ -151,8 +152,8 @@ func (as *AccountService) FormatAccountName(prefix, name string) string {
 	return prefix + ":" + name
 }
 
-func (as *AccountService) RenameAccount(oldName, newSegment string) error {
-	acc, err := as.repo.GetAccountByName(oldName)
+func (as *AccountService) RenameAccount(ctx context.Context, oldName, newSegment string) error {
+	acc, err := as.repo.GetAccountByName(ctx, oldName)
 	if err != nil {
 		return err
 	}
@@ -172,7 +173,7 @@ func (as *AccountService) RenameAccount(oldName, newSegment string) error {
 		newFullName = newSegment
 	}
 
-	exists, err := as.repo.AccountExists(newFullName)
+	exists, err := as.repo.AccountExists(ctx, newFullName)
 	if err != nil {
 		return err
 	}
@@ -180,5 +181,5 @@ func (as *AccountService) RenameAccount(oldName, newSegment string) error {
 		return fmt.Errorf("account %q already exists", newFullName)
 	}
 
-	return as.repo.RenameAccount(acc.Name, newFullName)
+	return as.repo.RenameAccount(ctx, acc.Name, newFullName)
 }

--- a/internal/service/account_ops_test.go
+++ b/internal/service/account_ops_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -167,7 +168,7 @@ func TestCreateAccount(t *testing.T) {
 		accRepo := newMockAccountRepo()
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		acc, err := svc.CreateAccount("Assets:Bank", model.AccountTypeAsset, "USD", "My bank", nil)
+		acc, err := svc.CreateAccount(context.Background(), "Assets:Bank", model.AccountTypeAsset, "USD", "My bank", nil)
 		require.NoError(t, err)
 		require.NotNil(t, acc)
 		assert.Greater(t, acc.ID, int64(0))
@@ -180,21 +181,21 @@ func TestCreateAccount(t *testing.T) {
 
 	t.Run("invalid account name (non-reserved root) rejected", func(t *testing.T) {
 		svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
-		_, err := svc.CreateAccount("Money:Bank", model.AccountTypeAsset, "USD", "", nil)
+		_, err := svc.CreateAccount(context.Background(), "Money:Bank", model.AccountTypeAsset, "USD", "", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid account name")
 	})
 
 	t.Run("invalid currency code rejected", func(t *testing.T) {
 		svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
-		_, err := svc.CreateAccount("Assets:Bank", model.AccountTypeAsset, "US", "", nil)
+		_, err := svc.CreateAccount(context.Background(), "Assets:Bank", model.AccountTypeAsset, "US", "", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid currency")
 	})
 
 	t.Run("invalid account type rejected", func(t *testing.T) {
 		svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
-		_, err := svc.CreateAccount("Assets:Bank", model.AccountType("X"), "USD", "", nil)
+		_, err := svc.CreateAccount(context.Background(), "Assets:Bank", model.AccountType("X"), "USD", "", nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid account type")
 	})
@@ -204,7 +205,7 @@ func TestCreateAccount(t *testing.T) {
 		accRepo.createErr = errors.New("db error")
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		_, err := svc.CreateAccount("Assets:Bank", model.AccountTypeAsset, "USD", "", nil)
+		_, err := svc.CreateAccount(context.Background(), "Assets:Bank", model.AccountTypeAsset, "USD", "", nil)
 		require.Error(t, err)
 	})
 
@@ -213,7 +214,7 @@ func TestCreateAccount(t *testing.T) {
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD"})
 
-		_, err := svc.CreateAccount("Assets:Bank", model.AccountTypeAsset, "USD", "", nil)
+		_, err := svc.CreateAccount(context.Background(), "Assets:Bank", model.AccountTypeAsset, "USD", "", nil)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrAlreadyExists), "expected ErrAlreadyExists, got: %v", err)
 	})
@@ -231,7 +232,7 @@ func TestCreateAccountWithBalance_SplitDirection(t *testing.T) {
 		addOpeningBalanceAccount(accRepo)
 		svc := newTestAccountService(accRepo, txRepo)
 
-		acc, err := svc.CreateAccountWithBalance("Assets:Bank", model.AccountTypeAsset, "USD", "", nil, 5000)
+		acc, err := svc.CreateAccountWithBalance(context.Background(), "Assets:Bank", model.AccountTypeAsset, "USD", "", nil, 5000)
 		require.NoError(t, err)
 
 		splits := txRepo.splits[1] // first transaction ID=1
@@ -260,7 +261,7 @@ func TestCreateAccountWithBalance_SplitDirection(t *testing.T) {
 		addOpeningBalanceAccount(accRepo)
 		svc := newTestAccountService(accRepo, txRepo)
 
-		acc, err := svc.CreateAccountWithBalance("Assets:Loan", model.AccountTypeAsset, "USD", "", nil, -3000)
+		acc, err := svc.CreateAccountWithBalance(context.Background(), "Assets:Loan", model.AccountTypeAsset, "USD", "", nil, -3000)
 		require.NoError(t, err)
 
 		splits := txRepo.splits[1]
@@ -284,7 +285,7 @@ func TestCreateAccountWithBalance_SplitDirection(t *testing.T) {
 		addOpeningBalanceAccount(accRepo)
 		svc := newTestAccountService(accRepo, txRepo)
 
-		acc, err := svc.CreateAccountWithBalance("Liabilities:CreditCard", model.AccountTypeLiability, "USD", "", nil, 2000)
+		acc, err := svc.CreateAccountWithBalance(context.Background(), "Liabilities:CreditCard", model.AccountTypeLiability, "USD", "", nil, 2000)
 		require.NoError(t, err)
 
 		splits := txRepo.splits[1]
@@ -308,7 +309,7 @@ func TestCreateAccountWithBalance_SplitDirection(t *testing.T) {
 		addOpeningBalanceAccount(accRepo)
 		svc := newTestAccountService(accRepo, txRepo)
 
-		_, err := svc.CreateAccountWithBalance("Assets:Bank", model.AccountTypeAsset, "USD", "", nil, 0)
+		_, err := svc.CreateAccountWithBalance(context.Background(), "Assets:Bank", model.AccountTypeAsset, "USD", "", nil, 0)
 		require.NoError(t, err)
 		assert.Empty(t, txRepo.transactions, "no transaction should be created for zero balance")
 	})
@@ -319,7 +320,7 @@ func TestCreateAccountWithBalance_SplitDirection(t *testing.T) {
 		addOpeningBalanceAccount(accRepo)
 		svc := newTestAccountService(accRepo, txRepo)
 
-		_, err := svc.CreateAccountWithBalance("Expenses:Food", model.AccountTypeExpense, "USD", "", nil, 500)
+		_, err := svc.CreateAccountWithBalance(context.Background(), "Expenses:Food", model.AccountTypeExpense, "USD", "", nil, 500)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "opening balance")
 	})
@@ -329,11 +330,11 @@ func TestCreateAccountWithBalance_SplitDirection(t *testing.T) {
 		// intentionally omit the opening balance account
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		_, err := svc.CreateAccountWithBalance("Assets:Bank", model.AccountTypeAsset, "USD", "", nil, 1000)
+		_, err := svc.CreateAccountWithBalance(context.Background(), "Assets:Bank", model.AccountTypeAsset, "USD", "", nil, 1000)
 		require.NoError(t, err)
 
 		equityName := model.OpeningBalancesAccountName("USD")
-		equityAcc, err := accRepo.GetAccountByName(equityName)
+		equityAcc, err := accRepo.GetAccountByName(context.Background(), equityName)
 		require.NoError(t, err)
 		assert.Equal(t, model.AccountTypeEquity, equityAcc.Type)
 		assert.Equal(t, "USD", equityAcc.Currency)
@@ -347,7 +348,7 @@ func TestCreateAccountWithBalance_CurrencyRouting(t *testing.T) {
 		addOpeningBalancesForCurrency(accRepo, "TWD")
 		svc := newTestAccountService(accRepo, txRepo)
 
-		acc, err := svc.CreateAccountWithBalance("Assets:TWDBank", model.AccountTypeAsset, "TWD", "", nil, 30000)
+		acc, err := svc.CreateAccountWithBalance(context.Background(), "Assets:TWDBank", model.AccountTypeAsset, "TWD", "", nil, 30000)
 		require.NoError(t, err)
 
 		splits := txRepo.splits[1]
@@ -373,7 +374,7 @@ func TestCreateAccountWithBalance_CurrencyRouting(t *testing.T) {
 		addOpeningBalancesForCurrency(accRepo, "USD")
 		svc := newTestAccountService(accRepo, txRepo)
 
-		_, err := svc.CreateAccountWithBalance("Assets:Bank", model.AccountTypeAsset, "", "", nil, 5000)
+		_, err := svc.CreateAccountWithBalance(context.Background(), "Assets:Bank", model.AccountTypeAsset, "", "", nil, 5000)
 		require.NoError(t, err)
 
 		splits := txRepo.splits[1]
@@ -389,12 +390,12 @@ func TestCreateAccountWithBalance_CurrencyRouting(t *testing.T) {
 		// no TWD equity account pre-seeded
 		svc := newTestAccountService(accRepo, txRepo)
 
-		_, err := svc.CreateAccountWithBalance("Assets:TWDBank", model.AccountTypeAsset, "TWD", "", nil, 30000)
+		_, err := svc.CreateAccountWithBalance(context.Background(), "Assets:TWDBank", model.AccountTypeAsset, "TWD", "", nil, 30000)
 		require.NoError(t, err)
 
 		// equity account should now exist
 		equityName := model.OpeningBalancesAccountName("TWD")
-		equityAcc, err := accRepo.GetAccountByName(equityName)
+		equityAcc, err := accRepo.GetAccountByName(context.Background(), equityName)
 		require.NoError(t, err)
 		assert.Equal(t, model.AccountTypeEquity, equityAcc.Type)
 		assert.Equal(t, "TWD", equityAcc.Currency)
@@ -410,7 +411,7 @@ func TestGetAccountByName(t *testing.T) {
 		repo := newMockAccountRepo()
 		svc := newTestAccountService(repo, newMockTransactionRepo())
 
-		_, err := svc.GetAccountByName("Assets:Nonexistent")
+		_, err := svc.GetAccountByName(context.Background(), "Assets:Nonexistent")
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrNotFound), "expected ErrNotFound, got: %v", err)
 	})
@@ -426,9 +427,9 @@ func TestDeleteAccountByName(t *testing.T) {
 		accRepo.addAccount(&model.Account{ID: 5, Name: "Assets:OldAccount"})
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		err := svc.DeleteAccountByName("Assets:OldAccount")
+		err := svc.DeleteAccountByName(context.Background(), "Assets:OldAccount")
 		require.NoError(t, err)
-		_, err = accRepo.GetAccountByName("Assets:OldAccount")
+		_, err = accRepo.GetAccountByName(context.Background(), "Assets:OldAccount")
 		assert.Error(t, err, "account should not exist after deletion")
 	})
 
@@ -437,7 +438,7 @@ func TestDeleteAccountByName(t *testing.T) {
 		addOpeningBalanceAccount(accRepo)
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		err := svc.DeleteAccountByName(model.OpeningBalancesAccountName("USD"))
+		err := svc.DeleteAccountByName(context.Background(), model.OpeningBalancesAccountName("USD"))
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrNotEditable))
 	})
@@ -447,7 +448,7 @@ func TestDeleteAccountByName(t *testing.T) {
 		accRepo.addAccount(&model.Account{ID: 10, Name: "Equity:OpeningBalances_TWD", Type: model.AccountTypeEquity})
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		err := svc.DeleteAccountByName("Equity:OpeningBalances_TWD")
+		err := svc.DeleteAccountByName(context.Background(), "Equity:OpeningBalances_TWD")
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrNotEditable))
 	})
@@ -458,7 +459,7 @@ func TestDeleteAccountByName(t *testing.T) {
 		accRepo.childMap[5] = true
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		err := svc.DeleteAccountByName("Assets:Bank")
+		err := svc.DeleteAccountByName(context.Background(), "Assets:Bank")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "child")
 	})
@@ -469,14 +470,14 @@ func TestDeleteAccountByName(t *testing.T) {
 		accRepo.txExistsMap[5] = true
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		err := svc.DeleteAccountByName("Assets:Bank")
+		err := svc.DeleteAccountByName(context.Background(), "Assets:Bank")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "transactions")
 	})
 
 	t.Run("non-existent account returns error", func(t *testing.T) {
 		svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
-		err := svc.DeleteAccountByName("Assets:NonExistent")
+		err := svc.DeleteAccountByName(context.Background(), "Assets:NonExistent")
 		require.Error(t, err)
 	})
 }
@@ -514,14 +515,14 @@ func TestGetAccountBalance(t *testing.T) {
 	repo.balances[1] = 5000 // 50.00 in cents
 
 	t.Run("returns raw cents", func(t *testing.T) {
-		got, err := svc.GetAccountBalance(1)
+		got, err := svc.GetAccountBalance(context.Background(), 1)
 		require.NoError(t, err)
 		assert.Equal(t, int64(5000), got)
 	})
 
 	t.Run("propagates repo error", func(t *testing.T) {
 		repo.getBalanceErr[99] = errors.New("not found")
-		_, err := svc.GetAccountBalance(99)
+		_, err := svc.GetAccountBalance(context.Background(), 99)
 		assert.Error(t, err)
 	})
 }
@@ -536,7 +537,7 @@ func TestRenameAccount(t *testing.T) {
 		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank", Type: model.AccountTypeAsset})
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		err := svc.RenameAccount("Assets:Bank", "Savings")
+		err := svc.RenameAccount(context.Background(), "Assets:Bank", "Savings")
 		require.NoError(t, err)
 
 		require.Len(t, accRepo.renameCalls, 1)
@@ -549,7 +550,7 @@ func TestRenameAccount(t *testing.T) {
 		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank:Checking", Type: model.AccountTypeAsset})
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		err := svc.RenameAccount("Assets:Bank:Checking", "Current")
+		err := svc.RenameAccount(context.Background(), "Assets:Bank:Checking", "Current")
 		require.NoError(t, err)
 
 		require.Len(t, accRepo.renameCalls, 1)
@@ -562,7 +563,7 @@ func TestRenameAccount(t *testing.T) {
 		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank", Type: model.AccountTypeAsset})
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		err := svc.RenameAccount("Assets:Bank", "Bad:Name")
+		err := svc.RenameAccount(context.Background(), "Assets:Bank", "Bad:Name")
 		require.Error(t, err)
 		assert.Empty(t, accRepo.renameCalls)
 	})
@@ -572,7 +573,7 @@ func TestRenameAccount(t *testing.T) {
 		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank", Type: model.AccountTypeAsset})
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		err := svc.RenameAccount("Assets:Bank", "")
+		err := svc.RenameAccount(context.Background(), "Assets:Bank", "")
 		require.Error(t, err)
 		assert.Empty(t, accRepo.renameCalls)
 	})
@@ -583,7 +584,7 @@ func TestRenameAccount(t *testing.T) {
 		accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Savings", Type: model.AccountTypeAsset})
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		err := svc.RenameAccount("Assets:Bank", "Savings")
+		err := svc.RenameAccount(context.Background(), "Assets:Bank", "Savings")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "already exists")
 		assert.Empty(t, accRepo.renameCalls)
@@ -594,7 +595,7 @@ func TestRenameAccount(t *testing.T) {
 		addOpeningBalanceAccount(accRepo)
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		err := svc.RenameAccount(model.OpeningBalancesAccountName("USD"), "Other")
+		err := svc.RenameAccount(context.Background(), model.OpeningBalancesAccountName("USD"), "Other")
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrNotEditable))
 		assert.Empty(t, accRepo.renameCalls)
@@ -602,7 +603,7 @@ func TestRenameAccount(t *testing.T) {
 
 	t.Run("account not found returns error", func(t *testing.T) {
 		svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
-		err := svc.RenameAccount("Assets:Ghost", "NewName")
+		err := svc.RenameAccount(context.Background(), "Assets:Ghost", "NewName")
 		require.Error(t, err)
 	})
 }
@@ -617,7 +618,7 @@ func TestUpdateAccountMetadata(t *testing.T) {
 		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank", Description: "old desc", IsHidden: false})
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		err := svc.UpdateAccountMetadata(1, "new desc", true)
+		err := svc.UpdateAccountMetadata(context.Background(), 1, "new desc", true)
 		require.NoError(t, err)
 
 		require.Len(t, accRepo.updateMetadataCalls, 1)
@@ -632,7 +633,7 @@ func TestUpdateAccountMetadata(t *testing.T) {
 		accRepo.addAccount(&model.Account{ID: 99, Name: model.OpeningBalancesAccountName("USD"), Type: model.AccountTypeEquity})
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		err := svc.UpdateAccountMetadata(99, "desc", false)
+		err := svc.UpdateAccountMetadata(context.Background(), 99, "desc", false)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrNotEditable))
 		assert.Empty(t, accRepo.updateMetadataCalls)
@@ -640,7 +641,7 @@ func TestUpdateAccountMetadata(t *testing.T) {
 
 	t.Run("account not found returns error", func(t *testing.T) {
 		svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
-		err := svc.UpdateAccountMetadata(999, "desc", false)
+		err := svc.UpdateAccountMetadata(context.Background(), 999, "desc", false)
 		require.Error(t, err)
 	})
 
@@ -650,7 +651,7 @@ func TestUpdateAccountMetadata(t *testing.T) {
 		accRepo.updateMetadataErr = errors.New("db error")
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		err := svc.UpdateAccountMetadata(1, "desc", false)
+		err := svc.UpdateAccountMetadata(context.Background(), 1, "desc", false)
 		require.Error(t, err)
 	})
 }

--- a/internal/service/account_service.go
+++ b/internal/service/account_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -22,12 +23,12 @@ func NewAccountService(repo repository.AccountRepository, cfg *config.Config, tm
 	return &AccountService{repo: repo, config: cfg, tm: tm}
 }
 
-func (as *AccountService) GetAllAccounts() ([]*model.Account, error) {
-	return as.repo.GetAllAccounts()
+func (as *AccountService) GetAllAccounts(ctx context.Context) ([]*model.Account, error) {
+	return as.repo.GetAllAccounts(ctx)
 }
 
-func (as *AccountService) GetAccountByName(name string) (*model.Account, error) {
-	acc, err := as.repo.GetAccountByName(name)
+func (as *AccountService) GetAccountByName(ctx context.Context, name string) (*model.Account, error) {
+	acc, err := as.repo.GetAccountByName(ctx, name)
 	if err != nil {
 		if errors.Is(err, store.ErrRecordNotFound) {
 			return nil, fmt.Errorf("account %q: %w", name, ErrNotFound)
@@ -37,16 +38,16 @@ func (as *AccountService) GetAccountByName(name string) (*model.Account, error) 
 	return acc, nil
 }
 
-func (as *AccountService) GetAccountsByType(accType model.AccountType) ([]*model.Account, error) {
-	return as.repo.GetAccountsByType(accType)
+func (as *AccountService) GetAccountsByType(ctx context.Context, accType model.AccountType) ([]*model.Account, error) {
+	return as.repo.GetAccountsByType(ctx, accType)
 }
 
-func (as *AccountService) GetAccountBalance(accountID int64) (int64, error) {
-	return as.repo.GetAccountBalance(accountID)
+func (as *AccountService) GetAccountBalance(ctx context.Context, accountID int64) (int64, error) {
+	return as.repo.GetAccountBalance(ctx, accountID)
 }
 
-func (as *AccountService) GetAccountBalanceFormatted(accountID int64) (string, error) {
-	balance, err := as.repo.GetAccountBalance(accountID)
+func (as *AccountService) GetAccountBalanceFormatted(ctx context.Context, accountID int64) (string, error) {
+	balance, err := as.repo.GetAccountBalance(ctx, accountID)
 	if err != nil {
 		return "", err
 	}
@@ -62,12 +63,12 @@ func (as *AccountService) GetRootNameByType(accType string) (string, error) {
 	return name, nil
 }
 
-func (as *AccountService) CheckAccountExists(name string) (bool, error) {
-	return as.repo.AccountExists(name)
+func (as *AccountService) CheckAccountExists(ctx context.Context, name string) (bool, error) {
+	return as.repo.AccountExists(ctx, name)
 }
 
-func (as *AccountService) ValidateSelectableAccount(name string, allowedTypes []string) error {
-	acc, err := as.repo.GetAccountByName(name)
+func (as *AccountService) ValidateSelectableAccount(ctx context.Context, name string, allowedTypes []string) error {
+	acc, err := as.repo.GetAccountByName(ctx, name)
 	if err != nil {
 		return err
 	}
@@ -89,7 +90,7 @@ func (as *AccountService) ValidateSelectableAccount(name string, allowedTypes []
 		return fmt.Errorf("account %q is hidden", name)
 	}
 
-	hasChildren, err := as.repo.HasChildAccounts(acc.ID)
+	hasChildren, err := as.repo.HasChildAccounts(ctx, acc.ID)
 	if err != nil {
 		return err
 	}
@@ -100,8 +101,8 @@ func (as *AccountService) ValidateSelectableAccount(name string, allowedTypes []
 	return nil
 }
 
-func (as *AccountService) UpdateAccountMetadata(accountID int64, description string, isHidden bool) error {
-	acc, err := as.repo.GetAccountByID(accountID)
+func (as *AccountService) UpdateAccountMetadata(ctx context.Context, accountID int64, description string, isHidden bool) error {
+	acc, err := as.repo.GetAccountByID(ctx, accountID)
 	if err != nil {
 		return err
 	}
@@ -110,5 +111,5 @@ func (as *AccountService) UpdateAccountMetadata(accountID int64, description str
 		return fmt.Errorf("account %q is a system account and cannot be edited: %w", acc.Name, ErrNotEditable)
 	}
 
-	return as.repo.UpdateAccountMetadata(accountID, description, isHidden)
+	return as.repo.UpdateAccountMetadata(ctx, accountID, description, isHidden)
 }

--- a/internal/service/reconcile_ops.go
+++ b/internal/service/reconcile_ops.go
@@ -13,12 +13,12 @@ import (
 // reconciled balance. Used to populate the reconciliation TUI.
 //
 // The last reconciled balance is 0 if the account has never been reconciled.
-func (ts *TransactionService) GetUnreconciledByAccount(accountID int64) ([]*model.ReconcileEntry, int64, error) {
-	entries, err := ts.txRepo.GetUnreconciledTransactionsByAccount(accountID)
+func (ts *TransactionService) GetUnreconciledByAccount(ctx context.Context, accountID int64) ([]*model.ReconcileEntry, int64, error) {
+	entries, err := ts.txRepo.GetUnreconciledTransactionsByAccount(ctx, accountID)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to load unreconciled transactions: %w", err)
 	}
-	lastBalance, err := ts.txRepo.GetLastReconciledBalance(accountID)
+	lastBalance, err := ts.txRepo.GetLastReconciledBalance(ctx, accountID)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to load last reconciled balance: %w", err)
 	}
@@ -40,24 +40,24 @@ func (ts *TransactionService) GetUnreconciledByAccount(accountID int64) ([]*mode
 // The new running reconciled balance (lastReconciledBalance + clearedBalance)
 // is always persisted after a successful reconcile — regardless of whether the
 // difference is zero. The caller decides whether to warn on a non-zero diff.
-func (ts *TransactionService) ReconcileTransactions(accountID int64, statementBalance int64, txIDs []int64) (int64, error) {
+func (ts *TransactionService) ReconcileTransactions(ctx context.Context, accountID int64, statementBalance int64, txIDs []int64) (int64, error) {
 	if len(txIDs) == 0 {
 		return 0, fmt.Errorf("no transactions selected for reconciliation")
 	}
 
 	// 1. Verify account exists.
-	if _, err := ts.accRepo.GetAccountByID(accountID); err != nil {
+	if _, err := ts.accRepo.GetAccountByID(ctx, accountID); err != nil {
 		return 0, fmt.Errorf("account not found: %w", err)
 	}
 
 	// 2. Fetch last reconciled balance.
-	lastBalance, err := ts.txRepo.GetLastReconciledBalance(accountID)
+	lastBalance, err := ts.txRepo.GetLastReconciledBalance(ctx, accountID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to load last reconciled balance: %w", err)
 	}
 
 	// 3. Fetch unreconciled transactions and build a valid-ID → amount map.
-	entries, err := ts.txRepo.GetUnreconciledTransactionsByAccount(accountID)
+	entries, err := ts.txRepo.GetUnreconciledTransactionsByAccount(ctx, accountID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to load unreconciled transactions: %w", err)
 	}
@@ -81,8 +81,8 @@ func (ts *TransactionService) ReconcileTransactions(accountID int64, statementBa
 	// Both writes run in the same DB transaction so a rows guard or a balance
 	// persistence error rolls back the splits UPDATE too.
 	newBalance := lastBalance + clearedBalance
-	if err := ts.tm.ExecTx(context.Background(), func(repo repository.Repository) error {
-		rowsAffected, err := repo.MarkSplitsReconciledByAccount(accountID, txIDs)
+	if err := ts.tm.ExecTx(ctx, func(repo repository.Repository) error {
+		rowsAffected, err := repo.MarkSplitsReconciledByAccount(ctx, accountID, txIDs)
 		if err != nil {
 			return fmt.Errorf("failed to reconcile transactions: %w", err)
 		}
@@ -92,7 +92,7 @@ func (ts *TransactionService) ReconcileTransactions(accountID int64, statementBa
 				len(txIDs), rowsAffected,
 			)
 		}
-		if err := repo.SetLastReconciledBalance(accountID, newBalance); err != nil {
+		if err := repo.SetLastReconciledBalance(ctx, accountID, newBalance); err != nil {
 			return fmt.Errorf("failed to persist reconciled balance: %w", err)
 		}
 		return nil

--- a/internal/service/reconcile_ops_test.go
+++ b/internal/service/reconcile_ops_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -25,7 +26,7 @@ func TestGetUnreconciledByAccount_ReturnsEntriesAndBalance(t *testing.T) {
 	})
 	txRepo.lastReconciledBalances[1] = 50000
 
-	entries, lastBal, err := svc.GetUnreconciledByAccount(1)
+	entries, lastBal, err := svc.GetUnreconciledByAccount(context.Background(), 1)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -46,7 +47,7 @@ func TestGetUnreconciledByAccount_FirstTime_ReturnsZeroBalance(t *testing.T) {
 	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
 	// no entry in lastReconciledBalances → mock returns 0
 
-	_, lastBal, err := svc.GetUnreconciledByAccount(1)
+	_, lastBal, err := svc.GetUnreconciledByAccount(context.Background(), 1)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -71,7 +72,7 @@ func TestReconcileTransactions_FirstReconcile_ZeroDifference(t *testing.T) {
 	// No prior balance (first reconcile) → lastReconciledBalance = 0.
 	// Cleared = 100000 + (-50000) = 50000; statementBalance = 50000 → diff = 0.
 
-	diff, err := svc.ReconcileTransactions(1, 50000, []int64{10, 11})
+	diff, err := svc.ReconcileTransactions(context.Background(), 1, 50000, []int64{10, 11})
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -101,7 +102,7 @@ func TestReconcileTransactions_SubsequentReconcile_CarriedBalance(t *testing.T) 
 	txRepo.lastReconciledBalances[1] = 20000
 	// Bank now shows $50: diff = 5000 − (20000 + (−15000)) = 5000 − 5000 = 0.
 
-	diff, err := svc.ReconcileTransactions(1, 5000, []int64{20})
+	diff, err := svc.ReconcileTransactions(context.Background(), 1, 5000, []int64{20})
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -128,7 +129,7 @@ func TestReconcileTransactions_ForcedReconcile_PersistsActualCleared(t *testing.
 	// diff = 15000 − (0 + 20000) = −5000 (OVER $50).
 	// Regardless of force, the service always reconciles and persists lastBal+cleared = 20000.
 
-	diff, err := svc.ReconcileTransactions(1, 15000, []int64{30})
+	diff, err := svc.ReconcileTransactions(context.Background(), 1, 15000, []int64{30})
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -153,7 +154,7 @@ func TestReconcileTransactions_NonZeroDifference(t *testing.T) {
 	})
 	// lastBal = 0; cleared = 100000; statementBalance = 120000 → diff = 20000 (SHORT).
 
-	diff, err := svc.ReconcileTransactions(1, 120000, []int64{10})
+	diff, err := svc.ReconcileTransactions(context.Background(), 1, 120000, []int64{10})
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -176,7 +177,7 @@ func TestReconcileTransactions_UnknownTxID(t *testing.T) {
 		{ID: 10, Amount: 100000},
 	})
 
-	_, err := svc.ReconcileTransactions(1, 100000, []int64{10, 99})
+	_, err := svc.ReconcileTransactions(context.Background(), 1, 100000, []int64{10, 99})
 
 	if err == nil {
 		t.Fatal("expected error for unknown transaction ID, got nil")
@@ -199,7 +200,7 @@ func TestReconcileTransactions_AlreadyReconciledID(t *testing.T) {
 		{ID: 10, Amount: 100000},
 	})
 
-	_, err := svc.ReconcileTransactions(1, 100000, []int64{10, 20})
+	_, err := svc.ReconcileTransactions(context.Background(), 1, 100000, []int64{10, 20})
 
 	if err == nil {
 		t.Fatal("expected error for already-reconciled ID, got nil")
@@ -216,7 +217,7 @@ func TestReconcileTransactions_EmptyIDs(t *testing.T) {
 
 	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
 
-	_, err := svc.ReconcileTransactions(1, 100000, []int64{})
+	_, err := svc.ReconcileTransactions(context.Background(), 1, 100000, []int64{})
 
 	if err == nil {
 		t.Fatal("expected error for empty IDs, got nil")
@@ -228,7 +229,7 @@ func TestReconcileTransactions_AccountNotFound(t *testing.T) {
 	txRepo := newMockTransactionRepo()
 	svc := newTestTransactionService(accRepo, txRepo)
 
-	_, err := svc.ReconcileTransactions(99, 100000, []int64{10})
+	_, err := svc.ReconcileTransactions(context.Background(), 99, 100000, []int64{10})
 
 	if err == nil {
 		t.Fatal("expected error for unknown account, got nil")
@@ -246,7 +247,7 @@ func TestReconcileTransactions_GetLastReconciledBalance_Error(t *testing.T) {
 	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
 	txRepo.getLastReconciledBalErr[1] = fmt.Errorf("db error")
 
-	_, err := svc.ReconcileTransactions(1, 50000, []int64{10})
+	_, err := svc.ReconcileTransactions(context.Background(), 1, 50000, []int64{10})
 
 	if err == nil {
 		t.Fatal("expected error when GetLastReconciledBalance fails")
@@ -272,7 +273,7 @@ func TestReconcileTransactions_SetLastReconciledBalance_Error(t *testing.T) {
 
 	// Note: under ExecTx the marks are rolled back atomically when SetLastReconciledBalance
 	// fails. The mock does not simulate rollback, so we do not assert on markSplitsReconciledCalls.
-	_, err := svc.ReconcileTransactions(1, 50000, []int64{10})
+	_, err := svc.ReconcileTransactions(context.Background(), 1, 50000, []int64{10})
 
 	if err == nil {
 		t.Fatal("expected error when SetLastReconciledBalance fails")
@@ -287,7 +288,7 @@ func TestGetUnreconciledByAccount_GetLastReconciledBalance_Error(t *testing.T) {
 	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
 	txRepo.getLastReconciledBalErr[1] = fmt.Errorf("db error")
 
-	_, _, err := svc.GetUnreconciledByAccount(1)
+	_, _, err := svc.GetUnreconciledByAccount(context.Background(), 1)
 
 	if err == nil {
 		t.Fatal("expected error when GetLastReconciledBalance fails in GetUnreconciledByAccount")
@@ -309,7 +310,7 @@ func TestReconcileTransactions_MarkSplitsAffectsFewerRowsThanTxIDs_ReturnsError(
 	one := int64(1)
 	txRepo.markSplitsRowsOverride = &one
 
-	_, err := svc.ReconcileTransactions(1, 50000, []int64{10, 11})
+	_, err := svc.ReconcileTransactions(context.Background(), 1, 50000, []int64{10, 11})
 
 	if err == nil {
 		t.Fatal("expected error when fewer rows were affected than txIDs, got nil")
@@ -328,7 +329,7 @@ func TestReconcileTransactions_ExecTxFailure_ReturnsError(t *testing.T) {
 	tm := &mockTransactionManager{accRepo: accRepo, txRepo: txRepo, failTx: true}
 	svc := NewTransactionService(txRepo, accRepo, tm, defaultConfig())
 
-	_, err := svc.ReconcileTransactions(1, 50000, []int64{10})
+	_, err := svc.ReconcileTransactions(context.Background(), 1, 50000, []int64{10})
 
 	if err == nil {
 		t.Fatal("expected error when ExecTx fails, got nil")

--- a/internal/service/report_service.go
+++ b/internal/service/report_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"sort"
 
 	"github.com/hance08/kea/internal/model"
@@ -8,8 +9,8 @@ import (
 )
 
 // GetNetWorthAt returns net worth (assets - liabilities) using all posted splits up to endTime.
-func (ts *TransactionService) GetNetWorthAt(endTime int64) (int64, error) {
-	txSplitsMap, err := ts.txRepo.GetSplitsWithAccountsByDateRange(0, endTime)
+func (ts *TransactionService) GetNetWorthAt(ctx context.Context, endTime int64) (int64, error) {
+	txSplitsMap, err := ts.txRepo.GetSplitsWithAccountsByDateRange(ctx, 0, endTime)
 	if err != nil {
 		return 0, err
 	}
@@ -54,13 +55,13 @@ func offsetAccountName(details []model.SplitDetail, primaryType model.AccountTyp
 // buildReportMaps fetches all splits in the date range and aggregates them into
 // income/expense row maps. Pass includeIncome=false to skip income classification
 // (and vice versa) to avoid unnecessary work for breakdown-only queries.
-func (ts *TransactionService) buildReportMaps(startTime, endTime int64, includeIncome, includeExpense bool) (incomeByAccount, expenseByAccount map[string]*model.ReportRow, err error) {
-	txSplitsMap, err := ts.txRepo.GetSplitsWithAccountsByDateRange(startTime, endTime)
+func (ts *TransactionService) buildReportMaps(ctx context.Context, startTime, endTime int64, includeIncome, includeExpense bool) (incomeByAccount, expenseByAccount map[string]*model.ReportRow, err error) {
+	txSplitsMap, err := ts.txRepo.GetSplitsWithAccountsByDateRange(ctx, startTime, endTime)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	txs, err := ts.txRepo.GetTransactionsByDateRange(startTime, endTime)
+	txs, err := ts.txRepo.GetTransactionsByDateRange(ctx, startTime, endTime)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -104,8 +105,8 @@ func (ts *TransactionService) buildReportMaps(startTime, endTime int64, includeI
 }
 
 // GenerateIncomeStatement produces an income/expense summary for the given Unix time range.
-func (ts *TransactionService) GenerateIncomeStatement(startTime, endTime int64) (*model.ReportResult, error) {
-	incomeByAccount, expenseByAccount, err := ts.buildReportMaps(startTime, endTime, true, true)
+func (ts *TransactionService) GenerateIncomeStatement(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error) {
+	incomeByAccount, expenseByAccount, err := ts.buildReportMaps(ctx, startTime, endTime, true, true)
 	if err != nil {
 		return nil, err
 	}
@@ -127,8 +128,8 @@ func (ts *TransactionService) GenerateIncomeStatement(startTime, endTime int64) 
 }
 
 // GenerateIncomeBreakdown produces a detailed income-only report for the given Unix time range.
-func (ts *TransactionService) GenerateIncomeBreakdown(startTime, endTime int64) (*model.ReportResult, error) {
-	incomeByAccount, _, err := ts.buildReportMaps(startTime, endTime, true, false)
+func (ts *TransactionService) GenerateIncomeBreakdown(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error) {
+	incomeByAccount, _, err := ts.buildReportMaps(ctx, startTime, endTime, true, false)
 	if err != nil {
 		return nil, err
 	}
@@ -149,8 +150,8 @@ func (ts *TransactionService) GenerateIncomeBreakdown(startTime, endTime int64) 
 }
 
 // GenerateExpenseBreakdown produces a detailed expense-only report for the given Unix time range.
-func (ts *TransactionService) GenerateExpenseBreakdown(startTime, endTime int64) (*model.ReportResult, error) {
-	_, expenseByAccount, err := ts.buildReportMaps(startTime, endTime, false, true)
+func (ts *TransactionService) GenerateExpenseBreakdown(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error) {
+	_, expenseByAccount, err := ts.buildReportMaps(ctx, startTime, endTime, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -172,13 +173,13 @@ func (ts *TransactionService) GenerateExpenseBreakdown(startTime, endTime int64)
 
 // GenerateBalanceSheet produces a snapshot of all asset, liability, and equity account balances
 // as of the given Unix timestamp.
-func (ts *TransactionService) GenerateBalanceSheet(asOf int64) (*model.BalanceSheetResult, error) {
-	allAccounts, err := ts.accRepo.GetAllAccounts()
+func (ts *TransactionService) GenerateBalanceSheet(ctx context.Context, asOf int64) (*model.BalanceSheetResult, error) {
+	allAccounts, err := ts.accRepo.GetAllAccounts(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	balances, err := ts.accRepo.GetAllAccountBalances(asOf)
+	balances, err := ts.accRepo.GetAllAccountBalances(ctx, asOf)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/report_service_test.go
+++ b/internal/service/report_service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hance08/kea/internal/model"
@@ -85,7 +86,7 @@ func TestGetNetWorthAt(t *testing.T) {
 		)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		worth, err := svc.GetNetWorthAt(0)
+		worth, err := svc.GetNetWorthAt(context.Background(), 0)
 		require.NoError(t, err)
 		assert.Equal(t, int64(10000), worth)
 	})
@@ -105,14 +106,14 @@ func TestGetNetWorthAt(t *testing.T) {
 		// totalAssets = 15000 + (-5000) = 10000
 		// totalLiabilities = 5000
 		// netWorth = 10000 - 5000 = 5000
-		worth, err := svc.GetNetWorthAt(0)
+		worth, err := svc.GetNetWorthAt(context.Background(), 0)
 		require.NoError(t, err)
 		assert.Equal(t, int64(5000), worth)
 	})
 
 	t.Run("no transactions returns zero net worth", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		worth, err := svc.GetNetWorthAt(0)
+		worth, err := svc.GetNetWorthAt(context.Background(), 0)
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), worth)
 	})
@@ -125,7 +126,7 @@ func TestGetNetWorthAt(t *testing.T) {
 		)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		worth, err := svc.GetNetWorthAt(0)
+		worth, err := svc.GetNetWorthAt(context.Background(), 0)
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), worth)
 	})
@@ -135,7 +136,7 @@ func TestGetNetWorthAt(t *testing.T) {
 		txRepo.splitsRangeErr = assert.AnError
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		_, err := svc.GetNetWorthAt(0)
+		_, err := svc.GetNetWorthAt(context.Background(), 0)
 		assert.Error(t, err)
 	})
 }
@@ -154,7 +155,7 @@ func TestGenerateIncomeStatement(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 1, Type: model.TxTypeIncome}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		result, err := svc.GenerateIncomeStatement(0, 0)
+		result, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
 		require.NoError(t, err)
 		assert.Equal(t, int64(2000), result.TotalIncome)
 		assert.Equal(t, int64(0), result.TotalExpense)
@@ -172,7 +173,7 @@ func TestGenerateIncomeStatement(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 1, Type: model.TxTypeExpense}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		result, err := svc.GenerateIncomeStatement(0, 0)
+		result, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), result.TotalIncome)
 		assert.Equal(t, int64(500), result.TotalExpense)
@@ -195,7 +196,7 @@ func TestGenerateIncomeStatement(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 2, Type: model.TxTypeExpense}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		result, err := svc.GenerateIncomeStatement(0, 0)
+		result, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
 		require.NoError(t, err)
 		assert.Equal(t, int64(3000), result.TotalIncome)
 		assert.Equal(t, int64(800), result.TotalExpense)
@@ -211,7 +212,7 @@ func TestGenerateIncomeStatement(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 1, Type: model.TxTypeTransfer}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		result, err := svc.GenerateIncomeStatement(0, 0)
+		result, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), result.TotalIncome)
 		assert.Equal(t, int64(0), result.TotalExpense)
@@ -221,7 +222,7 @@ func TestGenerateIncomeStatement(t *testing.T) {
 
 	t.Run("empty data returns all-zero result", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		result, err := svc.GenerateIncomeStatement(0, 0)
+		result, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), result.TotalIncome)
 		assert.Equal(t, int64(0), result.TotalExpense)
@@ -242,7 +243,7 @@ func TestGenerateIncomeStatement(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 2, Type: model.TxTypeIncome}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		result, err := svc.GenerateIncomeStatement(0, 0)
+		result, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
 		require.NoError(t, err)
 		require.Len(t, result.IncomeRows, 2)
 		assert.GreaterOrEqual(t, result.IncomeRows[0].Amount, result.IncomeRows[1].Amount)
@@ -262,7 +263,7 @@ func TestGenerateIncomeStatement(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 2, Type: model.TxTypeExpense}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		result, err := svc.GenerateIncomeStatement(0, 0)
+		result, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
 		require.NoError(t, err)
 		assert.Equal(t, int64(500), result.TotalExpense)
 		// two transactions for the same account should be merged into one row
@@ -276,7 +277,7 @@ func TestGenerateIncomeStatement(t *testing.T) {
 		txRepo.splitsRangeErr = assert.AnError
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		_, err := svc.GenerateIncomeStatement(0, 0)
+		_, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
 		assert.Error(t, err)
 	})
 
@@ -285,7 +286,7 @@ func TestGenerateIncomeStatement(t *testing.T) {
 		txRepo.txsByDateRangeErr = assert.AnError
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		_, err := svc.GenerateIncomeStatement(0, 0)
+		_, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
 		assert.Error(t, err)
 	})
 }
@@ -309,7 +310,7 @@ func TestGenerateIncomeBreakdown(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 2, Type: model.TxTypeExpense}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		result, err := svc.GenerateIncomeBreakdown(0, 0)
+		result, err := svc.GenerateIncomeBreakdown(context.Background(), 0, 0)
 		require.NoError(t, err)
 		assert.Equal(t, int64(2000), result.TotalIncome)
 		assert.NotEmpty(t, result.IncomeRows)
@@ -330,7 +331,7 @@ func TestGenerateIncomeBreakdown(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 2, Type: model.TxTypeIncome}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		result, err := svc.GenerateIncomeBreakdown(0, 0)
+		result, err := svc.GenerateIncomeBreakdown(context.Background(), 0, 0)
 		require.NoError(t, err)
 		require.Len(t, result.IncomeRows, 2)
 		assert.GreaterOrEqual(t, result.IncomeRows[0].Amount, result.IncomeRows[1].Amount)
@@ -356,7 +357,7 @@ func TestGenerateExpenseBreakdown(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 2, Type: model.TxTypeExpense}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		result, err := svc.GenerateExpenseBreakdown(0, 0)
+		result, err := svc.GenerateExpenseBreakdown(context.Background(), 0, 0)
 		require.NoError(t, err)
 		assert.Equal(t, int64(500), result.TotalExpense)
 		assert.NotEmpty(t, result.ExpenseRows)
@@ -377,7 +378,7 @@ func TestGenerateBalanceSheet(t *testing.T) {
 		accRepo.balances[2] = 3000
 		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
 
-		result, err := svc.GenerateBalanceSheet(9999999999)
+		result, err := svc.GenerateBalanceSheet(context.Background(), 9999999999)
 		require.NoError(t, err)
 		assert.Equal(t, int64(10000), result.TotalAssets)
 		assert.Equal(t, int64(3000), result.TotalLiabilities)
@@ -394,7 +395,7 @@ func TestGenerateBalanceSheet(t *testing.T) {
 		accRepo.balances[2] = 0 // zero balance
 		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
 
-		result, err := svc.GenerateBalanceSheet(9999999999)
+		result, err := svc.GenerateBalanceSheet(context.Background(), 9999999999)
 		require.NoError(t, err)
 		assert.Len(t, result.Assets, 1)
 		assert.Equal(t, "Assets:Bank", result.Assets[0].AccountName)
@@ -406,7 +407,7 @@ func TestGenerateBalanceSheet(t *testing.T) {
 		accRepo.balances[1] = 5000
 		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
 
-		result, err := svc.GenerateBalanceSheet(9999999999)
+		result, err := svc.GenerateBalanceSheet(context.Background(), 9999999999)
 		require.NoError(t, err)
 		assert.Equal(t, int64(5000), result.TotalEquity)
 		require.Len(t, result.Equity, 1)
@@ -418,7 +419,7 @@ func TestGenerateBalanceSheet(t *testing.T) {
 		accRepo.balances[1] = 10000
 		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
 
-		result, err := svc.GenerateBalanceSheet(9999999999)
+		result, err := svc.GenerateBalanceSheet(context.Background(), 9999999999)
 		require.NoError(t, err)
 		require.Len(t, result.Assets, 1)
 		assert.Equal(t, "TWD", result.Assets[0].Currency)
@@ -430,7 +431,7 @@ func TestGenerateBalanceSheet(t *testing.T) {
 		accRepo.balances[1] = 10000
 		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
 
-		result, err := svc.GenerateBalanceSheet(9999999999)
+		result, err := svc.GenerateBalanceSheet(context.Background(), 9999999999)
 		require.NoError(t, err)
 		require.Len(t, result.Assets, 1)
 		assert.Equal(t, "USD", result.Assets[0].Currency)
@@ -444,7 +445,7 @@ func TestGenerateBalanceSheet(t *testing.T) {
 		accRepo.balances[2] = 9000
 		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
 
-		result, err := svc.GenerateBalanceSheet(9999999999)
+		result, err := svc.GenerateBalanceSheet(context.Background(), 9999999999)
 		require.NoError(t, err)
 		require.Len(t, result.Assets, 2)
 		assert.GreaterOrEqual(t, result.Assets[0].Amount, result.Assets[1].Amount)
@@ -456,7 +457,7 @@ func TestGenerateBalanceSheet(t *testing.T) {
 		accRepo.getAllBalancesErr = assert.AnError
 		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
 
-		_, err := svc.GenerateBalanceSheet(9999999999)
+		_, err := svc.GenerateBalanceSheet(context.Background(), 9999999999)
 		assert.Error(t, err)
 	})
 }

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -35,8 +35,8 @@ type mockAccountRepo struct {
 	getAllBalancesErr error
 
 	// call recorders
-	renameCalls          []struct{ old, new string }
-	updateMetadataCalls  []struct {
+	renameCalls         []struct{ old, new string }
+	updateMetadataCalls []struct {
 		id          int64
 		description string
 		isHidden    bool
@@ -64,7 +64,7 @@ func (m *mockAccountRepo) addAccount(acc *model.Account) {
 	m.accountsByID[acc.ID] = acc
 }
 
-func (m *mockAccountRepo) CreateAccount(name string, accType model.AccountType, currency, description string, parentID *int64) (int64, error) {
+func (m *mockAccountRepo) CreateAccount(_ context.Context, name string, accType model.AccountType, currency, description string, parentID *int64) (int64, error) {
 	if m.createErr != nil {
 		return 0, m.createErr
 	}
@@ -86,7 +86,7 @@ func (m *mockAccountRepo) CreateAccount(name string, accType model.AccountType, 
 	return id, nil
 }
 
-func (m *mockAccountRepo) GetAllAccounts() ([]*model.Account, error) {
+func (m *mockAccountRepo) GetAllAccounts(_ context.Context) ([]*model.Account, error) {
 	result := make([]*model.Account, 0, len(m.accountsByID))
 	for _, acc := range m.accountsByID {
 		result = append(result, acc)
@@ -94,7 +94,7 @@ func (m *mockAccountRepo) GetAllAccounts() ([]*model.Account, error) {
 	return result, nil
 }
 
-func (m *mockAccountRepo) GetAccountByName(name string) (*model.Account, error) {
+func (m *mockAccountRepo) GetAccountByName(_ context.Context, name string) (*model.Account, error) {
 	if err, ok := m.getByNameErr[name]; ok {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (m *mockAccountRepo) GetAccountByName(name string) (*model.Account, error) 
 	return acc, nil
 }
 
-func (m *mockAccountRepo) GetAccountByID(id int64) (*model.Account, error) {
+func (m *mockAccountRepo) GetAccountByID(_ context.Context, id int64) (*model.Account, error) {
 	if err, ok := m.getByIDErr[id]; ok {
 		return nil, err
 	}
@@ -116,12 +116,12 @@ func (m *mockAccountRepo) GetAccountByID(id int64) (*model.Account, error) {
 	return acc, nil
 }
 
-func (m *mockAccountRepo) AccountExists(name string) (bool, error) {
+func (m *mockAccountRepo) AccountExists(_ context.Context, name string) (bool, error) {
 	_, ok := m.accountsByName[name]
 	return ok, nil
 }
 
-func (m *mockAccountRepo) GetAccountsByType(accType model.AccountType) ([]*model.Account, error) {
+func (m *mockAccountRepo) GetAccountsByType(_ context.Context, accType model.AccountType) ([]*model.Account, error) {
 	var result []*model.Account
 	for _, acc := range m.accountsByID {
 		if acc.Type == accType {
@@ -131,14 +131,14 @@ func (m *mockAccountRepo) GetAccountsByType(accType model.AccountType) ([]*model
 	return result, nil
 }
 
-func (m *mockAccountRepo) GetAccountBalance(accountID int64) (int64, error) {
+func (m *mockAccountRepo) GetAccountBalance(_ context.Context, accountID int64) (int64, error) {
 	if err, ok := m.getBalanceErr[accountID]; ok {
 		return 0, err
 	}
 	return m.balances[accountID], nil
 }
 
-func (m *mockAccountRepo) GetAllAccountBalances(_ int64) (map[int64]int64, error) {
+func (m *mockAccountRepo) GetAllAccountBalances(_ context.Context, _ int64) (map[int64]int64, error) {
 	if m.getAllBalancesErr != nil {
 		return nil, m.getAllBalancesErr
 	}
@@ -149,15 +149,15 @@ func (m *mockAccountRepo) GetAllAccountBalances(_ int64) (map[int64]int64, error
 	return result, nil
 }
 
-func (m *mockAccountRepo) HasChildAccounts(accountID int64) (bool, error) {
+func (m *mockAccountRepo) HasChildAccounts(_ context.Context, accountID int64) (bool, error) {
 	return m.childMap[accountID], nil
 }
 
-func (m *mockAccountRepo) AccountHasTransactions(accountID int64) (bool, error) {
+func (m *mockAccountRepo) AccountHasTransactions(_ context.Context, accountID int64) (bool, error) {
 	return m.txExistsMap[accountID], nil
 }
 
-func (m *mockAccountRepo) DeleteAccount(accountID int64) error {
+func (m *mockAccountRepo) DeleteAccount(_ context.Context, accountID int64) error {
 	if m.deleteErr != nil {
 		return m.deleteErr
 	}
@@ -170,7 +170,7 @@ func (m *mockAccountRepo) DeleteAccount(accountID int64) error {
 	return nil
 }
 
-func (m *mockAccountRepo) RenameAccount(oldName, newName string) error {
+func (m *mockAccountRepo) RenameAccount(_ context.Context, oldName, newName string) error {
 	m.renameCalls = append(m.renameCalls, struct{ old, new string }{oldName, newName})
 	acc, ok := m.accountsByName[oldName]
 	if !ok {
@@ -182,7 +182,7 @@ func (m *mockAccountRepo) RenameAccount(oldName, newName string) error {
 	return nil
 }
 
-func (m *mockAccountRepo) UpdateAccountMetadata(accountID int64, description string, isHidden bool) error {
+func (m *mockAccountRepo) UpdateAccountMetadata(_ context.Context, accountID int64, description string, isHidden bool) error {
 	if m.updateMetadataErr != nil {
 		return m.updateMetadataErr
 	}
@@ -229,11 +229,11 @@ type mockTransactionRepo struct {
 	updateSplitCalls []int64
 
 	// reconciliation support
-	unreconciledByAccount    map[int64][]*model.ReconcileEntry
-	unreconciledByAccountErr map[int64]error
-	bulkUpdateErr            error
-	bulkUpdateCalls          [][]int64
-	markSplitsReconciledErr  error
+	unreconciledByAccount     map[int64][]*model.ReconcileEntry
+	unreconciledByAccountErr  map[int64]error
+	bulkUpdateErr             error
+	bulkUpdateCalls           [][]int64
+	markSplitsReconciledErr   error
 	markSplitsReconciledCalls []struct {
 		accountID int64
 		txIDs     []int64
@@ -271,7 +271,7 @@ func (m *mockTransactionRepo) addTransaction(tx *model.Transaction, splits []*mo
 	m.splits[tx.ID] = splits
 }
 
-func (m *mockTransactionRepo) CreateTransactionWithSplits(tx model.Transaction, splits []model.Split) (int64, error) {
+func (m *mockTransactionRepo) CreateTransactionWithSplits(_ context.Context, tx model.Transaction, splits []model.Split) (int64, error) {
 	if m.createErr != nil {
 		return 0, m.createErr
 	}
@@ -293,7 +293,7 @@ func (m *mockTransactionRepo) CreateTransactionWithSplits(tx model.Transaction, 
 	return id, nil
 }
 
-func (m *mockTransactionRepo) GetTransactionByID(txID int64) (*model.Transaction, error) {
+func (m *mockTransactionRepo) GetTransactionByID(_ context.Context, txID int64) (*model.Transaction, error) {
 	if err, ok := m.getByIDErr[txID]; ok {
 		return nil, err
 	}
@@ -304,11 +304,11 @@ func (m *mockTransactionRepo) GetTransactionByID(txID int64) (*model.Transaction
 	return tx, nil
 }
 
-func (m *mockTransactionRepo) GetTransactionsByAccount(accountID int64, limit int) ([]*model.Transaction, error) {
+func (m *mockTransactionRepo) GetTransactionsByAccount(_ context.Context, accountID int64, limit int) ([]*model.Transaction, error) {
 	return nil, nil
 }
 
-func (m *mockTransactionRepo) GetTransactionsByDateRange(startTime, endTime int64) ([]*model.Transaction, error) {
+func (m *mockTransactionRepo) GetTransactionsByDateRange(_ context.Context, startTime, endTime int64) ([]*model.Transaction, error) {
 	if m.txsByDateRangeErr != nil {
 		return nil, m.txsByDateRangeErr
 	}
@@ -319,7 +319,7 @@ func (m *mockTransactionRepo) GetTransactionsByDateRange(startTime, endTime int6
 	return result, nil
 }
 
-func (m *mockTransactionRepo) GetAllTransactions(limit int) ([]*model.Transaction, error) {
+func (m *mockTransactionRepo) GetAllTransactions(_ context.Context, limit int) ([]*model.Transaction, error) {
 	result := make([]*model.Transaction, 0, len(m.transactions))
 	for _, tx := range m.transactions {
 		result = append(result, tx)
@@ -327,7 +327,7 @@ func (m *mockTransactionRepo) GetAllTransactions(limit int) ([]*model.Transactio
 	return result, nil
 }
 
-func (m *mockTransactionRepo) UpdateTransactionStatus(txID int64, status model.TransactionStatus) error {
+func (m *mockTransactionRepo) UpdateTransactionStatus(_ context.Context, txID int64, status model.TransactionStatus) error {
 	if m.updateErr != nil {
 		return m.updateErr
 	}
@@ -339,7 +339,7 @@ func (m *mockTransactionRepo) UpdateTransactionStatus(txID int64, status model.T
 	return nil
 }
 
-func (m *mockTransactionRepo) DeleteTransaction(txID int64) error {
+func (m *mockTransactionRepo) DeleteTransaction(_ context.Context, txID int64) error {
 	if m.deleteErr != nil {
 		return m.deleteErr
 	}
@@ -351,7 +351,7 @@ func (m *mockTransactionRepo) DeleteTransaction(txID int64) error {
 	return nil
 }
 
-func (m *mockTransactionRepo) UpdateTransactionBasic(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error {
+func (m *mockTransactionRepo) UpdateTransactionBasic(_ context.Context, txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error {
 	if m.updateErr != nil {
 		return m.updateErr
 	}
@@ -366,7 +366,7 @@ func (m *mockTransactionRepo) UpdateTransactionBasic(txID int64, description str
 	return nil
 }
 
-func (m *mockTransactionRepo) CreateSplit(txID int64, split *model.Split) (int64, error) {
+func (m *mockTransactionRepo) CreateSplit(_ context.Context, txID int64, split *model.Split) (int64, error) {
 	id := m.nextSplitID
 	m.nextSplitID++
 	sc := *split
@@ -377,28 +377,28 @@ func (m *mockTransactionRepo) CreateSplit(txID int64, split *model.Split) (int64
 	return id, nil
 }
 
-func (m *mockTransactionRepo) UpdateSplit(splitID int64, accountID int64, amount int64, currency string, memo string) error {
+func (m *mockTransactionRepo) UpdateSplit(_ context.Context, splitID int64, accountID int64, amount int64, currency string, memo string) error {
 	m.updateSplitCalls = append(m.updateSplitCalls, splitID)
 	return nil
 }
 
-func (m *mockTransactionRepo) DeleteSplit(splitID int64) error {
+func (m *mockTransactionRepo) DeleteSplit(_ context.Context, splitID int64) error {
 	m.deleteSplitCalls = append(m.deleteSplitCalls, splitID)
 	return nil
 }
 
-func (m *mockTransactionRepo) GetSplitsByTransaction(txID int64) ([]*model.Split, error) {
+func (m *mockTransactionRepo) GetSplitsByTransaction(_ context.Context, txID int64) ([]*model.Split, error) {
 	return m.splits[txID], nil
 }
 
-func (m *mockTransactionRepo) GetSplitsWithAccountsByDateRange(startTime, endTime int64) (map[int64][]model.SplitDetail, error) {
+func (m *mockTransactionRepo) GetSplitsWithAccountsByDateRange(_ context.Context, startTime, endTime int64) (map[int64][]model.SplitDetail, error) {
 	if m.splitsRangeErr != nil {
 		return nil, m.splitsRangeErr
 	}
 	return m.splitsWithAccts, nil
 }
 
-func (m *mockTransactionRepo) GetSplitsWithAccountsByTransaction(txID int64) ([]model.SplitDetail, error) {
+func (m *mockTransactionRepo) GetSplitsWithAccountsByTransaction(_ context.Context, txID int64) ([]model.SplitDetail, error) {
 	splits := m.splits[txID]
 	result := make([]model.SplitDetail, 0, len(splits))
 	for _, s := range splits {
@@ -413,14 +413,14 @@ func (m *mockTransactionRepo) GetSplitsWithAccountsByTransaction(txID int64) ([]
 	return result, nil
 }
 
-func (m *mockTransactionRepo) GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.ReconcileEntry, error) {
+func (m *mockTransactionRepo) GetUnreconciledTransactionsByAccount(_ context.Context, accountID int64) ([]*model.ReconcileEntry, error) {
 	if err, ok := m.unreconciledByAccountErr[accountID]; ok {
 		return nil, err
 	}
 	return m.unreconciledByAccount[accountID], nil
 }
 
-func (m *mockTransactionRepo) BulkUpdateTransactionStatus(txIDs []int64, status model.TransactionStatus) error {
+func (m *mockTransactionRepo) BulkUpdateTransactionStatus(_ context.Context, txIDs []int64, status model.TransactionStatus) error {
 	if m.bulkUpdateErr != nil {
 		return m.bulkUpdateErr
 	}
@@ -435,7 +435,7 @@ func (m *mockTransactionRepo) BulkUpdateTransactionStatus(txIDs []int64, status 
 	return nil
 }
 
-func (m *mockTransactionRepo) MarkSplitsReconciledByAccount(accountID int64, txIDs []int64) (int64, error) {
+func (m *mockTransactionRepo) MarkSplitsReconciledByAccount(_ context.Context, accountID int64, txIDs []int64) (int64, error) {
 	if m.markSplitsReconciledErr != nil {
 		return 0, m.markSplitsReconciledErr
 	}
@@ -451,14 +451,14 @@ func (m *mockTransactionRepo) MarkSplitsReconciledByAccount(accountID int64, txI
 	return int64(len(txIDs)), nil
 }
 
-func (m *mockTransactionRepo) GetLastReconciledBalance(accountID int64) (int64, error) {
+func (m *mockTransactionRepo) GetLastReconciledBalance(_ context.Context, accountID int64) (int64, error) {
 	if err, ok := m.getLastReconciledBalErr[accountID]; ok {
 		return 0, err
 	}
 	return m.lastReconciledBalances[accountID], nil
 }
 
-func (m *mockTransactionRepo) SetLastReconciledBalance(accountID int64, balance int64) error {
+func (m *mockTransactionRepo) SetLastReconciledBalance(_ context.Context, accountID int64, balance int64) error {
 	if err, ok := m.setLastReconciledBalErr[accountID]; ok {
 		return err
 	}

--- a/internal/service/transaction_classifier.go
+++ b/internal/service/transaction_classifier.go
@@ -1,13 +1,14 @@
 package service
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/utils"
 )
 
-func (ts *TransactionService) DetermineType(splits []model.SplitDetail) (model.TransactionType, error) {
+func (ts *TransactionService) DetermineType(ctx context.Context, splits []model.SplitDetail) (model.TransactionType, error) {
 	// Fallback for empty splits
 	if len(splits) == 0 {
 		return model.TxTypeOther, nil
@@ -29,7 +30,7 @@ func (ts *TransactionService) DetermineType(splits []model.SplitDetail) (model.T
 	for _, split := range splits {
 		accType := split.AccountType
 		if accType == "" {
-			acc, err := ts.accRepo.GetAccountByID(split.AccountID)
+			acc, err := ts.accRepo.GetAccountByID(ctx, split.AccountID)
 			if err != nil {
 				return model.TxTypeOther, err
 			}
@@ -102,7 +103,7 @@ func (ts *TransactionService) DetermineType(splits []model.SplitDetail) (model.T
 	return model.TxTypeOther, nil
 }
 
-func (ts *TransactionService) GetDisplayAccount(splits []model.SplitDetail, txType string) (string, error) {
+func (ts *TransactionService) GetDisplayAccount(ctx context.Context, splits []model.SplitDetail, txType string) (string, error) {
 	if len(splits) == 0 {
 		return "-", nil
 	}
@@ -111,7 +112,7 @@ func (ts *TransactionService) GetDisplayAccount(splits []model.SplitDetail, txTy
 		if split.AccountType != "" {
 			return split.AccountType, nil
 		}
-		account, err := ts.accRepo.GetAccountByName(split.AccountName)
+		account, err := ts.accRepo.GetAccountByName(ctx, split.AccountName)
 		if err != nil {
 			return "", err
 		}
@@ -195,7 +196,7 @@ func (ts *TransactionService) GetDisplayAmount(splits []model.SplitDetail) (int6
 	return maxAmount, currency
 }
 
-func (ts *TransactionService) GetDisplayOffsetAccount(splits []model.SplitDetail, txType string, primaryAccount string) (string, error) {
+func (ts *TransactionService) GetDisplayOffsetAccount(ctx context.Context, splits []model.SplitDetail, txType string, primaryAccount string) (string, error) {
 	if len(splits) == 0 {
 		return "-", nil
 	}
@@ -204,7 +205,7 @@ func (ts *TransactionService) GetDisplayOffsetAccount(splits []model.SplitDetail
 		if split.AccountType != "" {
 			return split.AccountType, nil
 		}
-		account, err := ts.accRepo.GetAccountByName(split.AccountName)
+		account, err := ts.accRepo.GetAccountByName(ctx, split.AccountName)
 		if err != nil {
 			return "", err
 		}
@@ -273,12 +274,12 @@ func (ts *TransactionService) GetAllowedAccounts(txType model.TransactionType, c
 	}
 }
 
-func (ts *TransactionService) ValidateSplitsMatchType(txType model.TransactionType, splits []model.SplitDetail) error {
+func (ts *TransactionService) ValidateSplitsMatchType(ctx context.Context, txType model.TransactionType, splits []model.SplitDetail) error {
 	resolveType := func(s model.SplitDetail) (model.AccountType, error) {
 		if s.AccountType != "" {
 			return s.AccountType, nil
 		}
-		acc, err := ts.accRepo.GetAccountByName(s.AccountName)
+		acc, err := ts.accRepo.GetAccountByName(ctx, s.AccountName)
 		if err != nil {
 			return "", err
 		}

--- a/internal/service/transaction_classifier_test.go
+++ b/internal/service/transaction_classifier_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hance08/kea/internal/model"
@@ -165,7 +166,7 @@ func TestDetermineType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := svc.DetermineType(tt.splits)
+			got, err := svc.DetermineType(context.Background(), tt.splits)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -184,7 +185,7 @@ func TestDetermineType_FallbackToRepo(t *testing.T) {
 			{AccountID: 1, AccountName: "Expenses:Food", Amount: 500},
 			{AccountID: 2, AccountName: "Assets:Bank", Amount: -500},
 		}
-		got, err := svc.DetermineType(splits)
+		got, err := svc.DetermineType(context.Background(), splits)
 		require.NoError(t, err)
 		assert.Equal(t, model.TxTypeExpense, got)
 	})
@@ -197,7 +198,7 @@ func TestDetermineType_FallbackToRepo(t *testing.T) {
 		splits := []model.SplitDetail{
 			{AccountID: 99, AccountName: "Unknown", Amount: 100},
 		}
-		_, err := svc.DetermineType(splits)
+		_, err := svc.DetermineType(context.Background(), splits)
 		assert.Error(t, err)
 	})
 }
@@ -260,7 +261,7 @@ func TestGetDisplayAccount(t *testing.T) {
 			{AccountName: "Expenses:Food", Amount: 500},
 			{AccountName: "Assets:Cash", Amount: -500},
 		}
-		got, err := svc.GetDisplayAccount(splits, "Expense")
+		got, err := svc.GetDisplayAccount(context.Background(), splits, "Expense")
 		require.NoError(t, err)
 		assert.Equal(t, "Expenses:Food", got)
 	})
@@ -275,7 +276,7 @@ func TestGetDisplayAccount(t *testing.T) {
 			{AccountName: "Revenue:Salary", Amount: -3000},
 			{AccountName: "Assets:Bank", Amount: 3000},
 		}
-		got, err := svc.GetDisplayAccount(splits, "Income")
+		got, err := svc.GetDisplayAccount(context.Background(), splits, "Income")
 		require.NoError(t, err)
 		assert.Equal(t, "Revenue:Salary", got)
 	})
@@ -290,7 +291,7 @@ func TestGetDisplayAccount(t *testing.T) {
 			{AccountName: "Assets:Savings", Amount: 1000},
 			{AccountName: "Assets:Checking", Amount: -1000},
 		}
-		got, err := svc.GetDisplayAccount(splits, "Transfer")
+		got, err := svc.GetDisplayAccount(context.Background(), splits, "Transfer")
 		require.NoError(t, err)
 		assert.Equal(t, "Assets:Savings", got)
 	})
@@ -305,14 +306,14 @@ func TestGetDisplayAccount(t *testing.T) {
 			{AccountName: "Assets:Cash", Amount: 5000},
 			{AccountName: model.OpeningBalancesAccountName("USD"), Amount: -5000},
 		}
-		got, err := svc.GetDisplayAccount(splits, "Opening")
+		got, err := svc.GetDisplayAccount(context.Background(), splits, "Opening")
 		require.NoError(t, err)
 		assert.Equal(t, "Assets:Cash", got)
 	})
 
 	t.Run("empty splits returns -", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		got, err := svc.GetDisplayAccount(nil, "Expense")
+		got, err := svc.GetDisplayAccount(context.Background(), nil, "Expense")
 		require.NoError(t, err)
 		assert.Equal(t, "-", got)
 	})
@@ -329,7 +330,7 @@ func TestGetDisplayOffsetAccount(t *testing.T) {
 			{AccountName: "Expenses:Food", AccountType: model.AccountTypeExpense, Amount: 500},
 			{AccountName: "Assets:Cash", AccountType: model.AccountTypeAsset, Amount: -500},
 		}
-		got, err := svc.GetDisplayOffsetAccount(splits, "Expense", "Expenses:Food")
+		got, err := svc.GetDisplayOffsetAccount(context.Background(), splits, "Expense", "Expenses:Food")
 		require.NoError(t, err)
 		assert.Equal(t, "Assets:Cash", got)
 	})
@@ -341,7 +342,7 @@ func TestGetDisplayOffsetAccount(t *testing.T) {
 			{AccountName: "Assets:Cash", AccountType: model.AccountTypeAsset, Amount: -300},
 			{AccountName: "Assets:Card", AccountType: model.AccountTypeAsset, Amount: -200},
 		}
-		got, err := svc.GetDisplayOffsetAccount(splits, "Expense", "Expenses:Food")
+		got, err := svc.GetDisplayOffsetAccount(context.Background(), splits, "Expense", "Expenses:Food")
 		require.NoError(t, err)
 		assert.Equal(t, "(multiple)", got)
 	})
@@ -352,7 +353,7 @@ func TestGetDisplayOffsetAccount(t *testing.T) {
 			{AccountName: "Assets:Savings", AccountType: model.AccountTypeAsset, Amount: 1000},
 			{AccountName: "Assets:Checking", AccountType: model.AccountTypeAsset, Amount: -1000},
 		}
-		got, err := svc.GetDisplayOffsetAccount(splits, "Transfer", "Assets:Savings")
+		got, err := svc.GetDisplayOffsetAccount(context.Background(), splits, "Transfer", "Assets:Savings")
 		require.NoError(t, err)
 		assert.Equal(t, "Assets:Checking", got)
 	})
@@ -362,14 +363,14 @@ func TestGetDisplayOffsetAccount(t *testing.T) {
 		splits := []model.SplitDetail{
 			{AccountName: "Expenses:Food", AccountType: model.AccountTypeExpense, Amount: 500},
 		}
-		got, err := svc.GetDisplayOffsetAccount(splits, "Expense", "Expenses:Food")
+		got, err := svc.GetDisplayOffsetAccount(context.Background(), splits, "Expense", "Expenses:Food")
 		require.NoError(t, err)
 		assert.Equal(t, "-", got)
 	})
 
 	t.Run("empty splits returns -", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		got, err := svc.GetDisplayOffsetAccount(nil, "Expense", "")
+		got, err := svc.GetDisplayOffsetAccount(context.Background(), nil, "Expense", "")
 		require.NoError(t, err)
 		assert.Equal(t, "-", got)
 	})
@@ -549,7 +550,7 @@ func TestValidateSplitsMatchType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := svc.ValidateSplitsMatchType(tt.txType, tt.splits)
+			err := svc.ValidateSplitsMatchType(context.Background(), tt.txType, tt.splits)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -17,7 +17,7 @@ import (
 // 3. Resolving account names to IDs and determining the appropriate currency.
 // 4. Verifying that the total amount of all splits balances to zero.
 // 5. executing the write operation within an atomic database transaction.
-func (ts *TransactionService) CreateTransaction(input model.TransactionDetail) (int64, error) {
+func (ts *TransactionService) CreateTransaction(ctx context.Context, input model.TransactionDetail) (int64, error) {
 	defaultCurrency := ts.config.Defaults.Currency
 
 	// Validate: According to double-entry bookkeeping principles,
@@ -41,7 +41,7 @@ func (ts *TransactionService) CreateTransaction(input model.TransactionDetail) (
 
 	for i, splitInput := range input.Splits {
 		// Step 1: Validate account existence and retrieve account details.
-		account, err := ts.accRepo.GetAccountByName(splitInput.AccountName)
+		account, err := ts.accRepo.GetAccountByName(ctx, splitInput.AccountName)
 		if err != nil {
 			return 0, fmt.Errorf("split #%d: %w", i+1, err)
 		}
@@ -61,7 +61,7 @@ func (ts *TransactionService) CreateTransaction(input model.TransactionDetail) (
 		})
 	}
 
-	if err := ts.ValidateSplitsMatchType(input.Type, input.Splits); err != nil {
+	if err := ts.ValidateSplitsMatchType(ctx, input.Type, input.Splits); err != nil {
 		return 0, fmt.Errorf("splits do not match transaction type %q: %w", input.Type, err)
 	}
 
@@ -82,10 +82,10 @@ func (ts *TransactionService) CreateTransaction(input model.TransactionDetail) (
 
 	// Execute Database Transaction:
 	// Ensure atomicity when writing the transaction and its splits.
-	err := ts.tm.ExecTx(context.Background(), func(repo repository.Repository) error {
+	err := ts.tm.ExecTx(ctx, func(repo repository.Repository) error {
 		var err error
 
-		newTxID, err = repo.CreateTransactionWithSplits(tx, splits)
+		newTxID, err = repo.CreateTransactionWithSplits(ctx, tx, splits)
 		if err != nil {
 			return fmt.Errorf("failed to create transaction: %w", err)
 		}
@@ -108,7 +108,7 @@ func (ts *TransactionService) CreateTransaction(input model.TransactionDetail) (
 //
 // If txType is empty, it is inferred from the account types via DetermineType.
 // Returns the constructed TransactionDetail (useful for UI rendering).
-func (ts *TransactionService) CreateSimpleTransaction(fromAccount, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error) {
+func (ts *TransactionService) CreateSimpleTransaction(ctx context.Context, fromAccount, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error) {
 	if fromAccount == toAccount {
 		return model.TransactionDetail{}, fmt.Errorf("source and destination accounts cannot be the same")
 	}
@@ -118,15 +118,15 @@ func (ts *TransactionService) CreateSimpleTransaction(fromAccount, toAccount str
 
 	// If no type provided, infer from account types.
 	if txType == "" {
-		fromAcc, err := ts.accRepo.GetAccountByName(fromAccount)
+		fromAcc, err := ts.accRepo.GetAccountByName(ctx, fromAccount)
 		if err != nil {
 			return model.TransactionDetail{}, fmt.Errorf("failed to resolve from account: %w", err)
 		}
-		toAcc, err := ts.accRepo.GetAccountByName(toAccount)
+		toAcc, err := ts.accRepo.GetAccountByName(ctx, toAccount)
 		if err != nil {
 			return model.TransactionDetail{}, fmt.Errorf("failed to resolve to account: %w", err)
 		}
-		inferred, err := ts.DetermineType([]model.SplitDetail{
+		inferred, err := ts.DetermineType(ctx, []model.SplitDetail{
 			{AccountType: toAcc.Type, Amount: amount},
 			{AccountType: fromAcc.Type, Amount: -amount},
 		})
@@ -147,7 +147,7 @@ func (ts *TransactionService) CreateSimpleTransaction(fromAccount, toAccount str
 		Type:        txType,
 		Splits:      splits,
 	}
-	id, err := ts.CreateTransaction(input)
+	id, err := ts.CreateTransaction(ctx, input)
 	if err != nil {
 		return model.TransactionDetail{}, err
 	}
@@ -159,6 +159,7 @@ func (ts *TransactionService) CreateSimpleTransaction(fromAccount, toAccount str
 // All validation (balance, type match, ≥2 splits, account resolution) is handled
 // by CreateTransaction.
 func (ts *TransactionService) CreateTransactionFromSplits(
+	ctx context.Context,
 	splits []model.SplitDetail,
 	desc string,
 	timestamp int64,
@@ -172,7 +173,7 @@ func (ts *TransactionService) CreateTransactionFromSplits(
 		Type:        txType,
 		Splits:      splits,
 	}
-	id, err := ts.CreateTransaction(input)
+	id, err := ts.CreateTransaction(ctx, input)
 	if err != nil {
 		return model.TransactionDetail{}, err
 	}
@@ -181,12 +182,12 @@ func (ts *TransactionService) CreateTransactionFromSplits(
 }
 
 // DeleteTransaction deletes a transaction
-func (ts *TransactionService) DeleteTransaction(txID int64) error {
+func (ts *TransactionService) DeleteTransaction(ctx context.Context, txID int64) error {
 	if txID == model.SystemTransactionID {
 		return fmt.Errorf("cannot delete the initial opening transaction: %w", ErrNotEditable)
 	}
 
-	tx, err := ts.txRepo.GetTransactionByID(txID)
+	tx, err := ts.txRepo.GetTransactionByID(ctx, txID)
 	if err != nil {
 		return fmt.Errorf("failed to get transaction: %w", err)
 	}
@@ -194,12 +195,12 @@ func (ts *TransactionService) DeleteTransaction(txID int64) error {
 	if tx.Status == model.StatusReconciled {
 		return fmt.Errorf("transaction #%d cannot be deleted: %w", tx.ID, ErrReconciled)
 	}
-	return ts.txRepo.DeleteTransaction(txID)
+	return ts.txRepo.DeleteTransaction(ctx, txID)
 }
 
 // UpdateTransactionStatus updates the lifecycle state of a transaction identified by its ID.
 // It validates that the provided status is a legal value (Pending or Cleared) before persisting.
-func (ts *TransactionService) UpdateTransactionStatus(txID int64, status model.TransactionStatus) error {
+func (ts *TransactionService) UpdateTransactionStatus(ctx context.Context, txID int64, status model.TransactionStatus) error {
 
 	// Business Rule: Restrict status updates to valid enum constant to ensure data integrity.
 	if status != model.StatusPending && status != model.StatusCleared {
@@ -210,7 +211,7 @@ func (ts *TransactionService) UpdateTransactionStatus(txID int64, status model.T
 		return fmt.Errorf("transaction #%d cannot be modified: %w", txID, ErrNotEditable)
 	}
 
-	oldTx, err := ts.txRepo.GetTransactionByID(txID)
+	oldTx, err := ts.txRepo.GetTransactionByID(ctx, txID)
 	if err != nil {
 		return fmt.Errorf("transaction not found: %w", err)
 	}
@@ -219,12 +220,12 @@ func (ts *TransactionService) UpdateTransactionStatus(txID int64, status model.T
 		return fmt.Errorf("transaction #%d cannot be modified: %w", txID, ErrReconciled)
 	}
 
-	return ts.txRepo.UpdateTransactionStatus(txID, status)
+	return ts.txRepo.UpdateTransactionStatus(ctx, txID, status)
 }
 
 // UpdateTransactionComplete performs a complete update of a transaction including splits
 // This operation is atomic - either all changes succeed or all fail
-func (ts *TransactionService) UpdateTransactionComplete(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType, splits []model.SplitDetail) error {
+func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType, splits []model.SplitDetail) error {
 	// Validate status
 	if status != model.StatusPending && status != model.StatusCleared && status != model.StatusReconciled {
 		return fmt.Errorf("invalid status: must be 0 (Pending), 1 (Cleared) or 2 (Reconciled)")
@@ -234,7 +235,7 @@ func (ts *TransactionService) UpdateTransactionComplete(txID int64, description 
 		return fmt.Errorf("cannot modify the initial opening transaction: %w", ErrNotEditable)
 	}
 
-	oldTx, err := ts.txRepo.GetTransactionByID(txID)
+	oldTx, err := ts.txRepo.GetTransactionByID(ctx, txID)
 	if err != nil {
 		return fmt.Errorf("transaction not found: %w", err)
 	}
@@ -257,24 +258,24 @@ func (ts *TransactionService) UpdateTransactionComplete(txID int64, description 
 		return fmt.Errorf("splits must balance to zero (current sum: %d)", total)
 	}
 
-	if err := ts.ValidateSplitsMatchType(txType, splits); err != nil {
+	if err := ts.ValidateSplitsMatchType(ctx, txType, splits); err != nil {
 		return fmt.Errorf("splits do not match transaction type %q: %w", txType, err)
 	}
 
 	// Validate all accounts exist
 	for _, split := range splits {
-		_, err := ts.accRepo.GetAccountByID(split.AccountID)
+		_, err := ts.accRepo.GetAccountByID(ctx, split.AccountID)
 		if err != nil {
 			return fmt.Errorf("account ID %d not found", split.AccountID)
 		}
 	}
 
-	return ts.tm.ExecTx(context.Background(), func(repo repository.Repository) error {
-		if err := repo.UpdateTransactionBasic(txID, description, timestamp, status, txType); err != nil {
+	return ts.tm.ExecTx(ctx, func(repo repository.Repository) error {
+		if err := repo.UpdateTransactionBasic(ctx, txID, description, timestamp, status, txType); err != nil {
 			return err
 		}
 
-		existingSplits, err := repo.GetSplitsByTransaction(txID)
+		existingSplits, err := repo.GetSplitsByTransaction(ctx, txID)
 		if err != nil {
 			return err
 		}
@@ -294,7 +295,7 @@ func (ts *TransactionService) UpdateTransactionComplete(txID int64, description 
 		// Delete splits that are no longer present
 		for id := range existingSplitMap {
 			if !newSplitMap[id] {
-				if err := repo.DeleteSplit(id); err != nil {
+				if err := repo.DeleteSplit(ctx, id); err != nil {
 					return fmt.Errorf("failed to delete split: %w", err)
 				}
 			}
@@ -311,13 +312,13 @@ func (ts *TransactionService) UpdateTransactionComplete(txID int64, description 
 					Currency:      split.Currency,
 					Memo:          split.Memo,
 				}
-				_, err := repo.CreateSplit(txID, newSplit)
+				_, err := repo.CreateSplit(ctx, txID, newSplit)
 				if err != nil {
 					return err
 				}
 			} else {
 				// Update existing split
-				if err := repo.UpdateSplit(split.ID, split.AccountID, split.Amount, split.Currency, split.Memo); err != nil {
+				if err := repo.UpdateSplit(ctx, split.ID, split.AccountID, split.Amount, split.Currency, split.Memo); err != nil {
 					return err
 				}
 			}
@@ -330,9 +331,9 @@ func (ts *TransactionService) UpdateTransactionComplete(txID int64, description 
 type NotEditableReason int
 
 const (
-	EditableOK              NotEditableReason = 0 // transaction may be edited
-	NotEditableSystemTx     NotEditableReason = 1 // opening-balance system transaction
-	NotEditableReconciled   NotEditableReason = 2 // already reconciled
+	EditableOK            NotEditableReason = 0 // transaction may be edited
+	NotEditableSystemTx   NotEditableReason = 1 // opening-balance system transaction
+	NotEditableReconciled NotEditableReason = 2 // already reconciled
 )
 
 func (ts *TransactionService) IsEditable(detail *model.TransactionDetail) (bool, NotEditableReason) {

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -40,7 +41,7 @@ func TestCreateTransaction(t *testing.T) {
 				{AccountName: "Assets:Bank", Amount: -500},
 			},
 		}
-		id, err := svc.CreateTransaction(input)
+		id, err := svc.CreateTransaction(context.Background(), input)
 		require.NoError(t, err)
 		assert.Greater(t, id, int64(0))
 	})
@@ -56,14 +57,14 @@ func TestCreateTransaction(t *testing.T) {
 				{AccountName: "Assets:Bank", Amount: 1000},
 			},
 		}
-		_, err := svc.CreateTransaction(input)
+		_, err := svc.CreateTransaction(context.Background(), input)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "at least 2")
 	})
 
 	t.Run("empty splits rejected", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		_, err := svc.CreateTransaction(model.TransactionDetail{Type: model.TxTypeExpense})
+		_, err := svc.CreateTransaction(context.Background(), model.TransactionDetail{Type: model.TxTypeExpense})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "at least 2")
 	})
@@ -79,7 +80,7 @@ func TestCreateTransaction(t *testing.T) {
 				{AccountName: "Assets:Bank", Amount: -500},
 			},
 		}
-		_, err := svc.CreateTransaction(input)
+		_, err := svc.CreateTransaction(context.Background(), input)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "type is required")
 	})
@@ -96,7 +97,7 @@ func TestCreateTransaction(t *testing.T) {
 				{AccountName: "Assets:Bank", Amount: -400}, // off by 100
 			},
 		}
-		_, err := svc.CreateTransaction(input)
+		_, err := svc.CreateTransaction(context.Background(), input)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "balance")
 	})
@@ -113,7 +114,7 @@ func TestCreateTransaction(t *testing.T) {
 				{AccountName: "NonExistent:Account", Amount: 500},
 			},
 		}
-		_, err := svc.CreateTransaction(input)
+		_, err := svc.CreateTransaction(context.Background(), input)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "#2")
 	})
@@ -133,7 +134,7 @@ func TestCreateTransaction(t *testing.T) {
 				{AccountName: "Assets:Bank", Amount: -500},
 			},
 		}
-		id, err := svc.CreateTransaction(input)
+		id, err := svc.CreateTransaction(context.Background(), input)
 		require.NoError(t, err)
 
 		tx := txRepo.transactions[id]
@@ -155,7 +156,7 @@ func TestCreateTransaction(t *testing.T) {
 				{AccountName: "Assets:TWDBank", Amount: -500},
 			},
 		}
-		id, err := svc.CreateTransaction(input)
+		id, err := svc.CreateTransaction(context.Background(), input)
 		require.NoError(t, err)
 
 		splits := txRepo.splits[id]
@@ -179,7 +180,7 @@ func TestCreateTransaction(t *testing.T) {
 				{AccountName: "Assets:Cash", Amount: -500},
 			},
 		}
-		_, err := svc.CreateTransaction(input)
+		_, err := svc.CreateTransaction(context.Background(), input)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "currency")
 	})
@@ -197,7 +198,7 @@ func TestCreateTransaction(t *testing.T) {
 				{AccountName: "Assets:Bank", Amount: -500},
 			},
 		}
-		id, err := svc.CreateTransaction(input)
+		id, err := svc.CreateTransaction(context.Background(), input)
 		require.NoError(t, err)
 
 		for _, s := range txRepo.splits[id] {
@@ -219,7 +220,7 @@ func TestCreateTransaction(t *testing.T) {
 				{AccountName: "Assets:Bank", Amount: -500},
 			},
 		}
-		_, err := svc.CreateTransaction(input)
+		_, err := svc.CreateTransaction(context.Background(), input)
 		assert.Error(t, err)
 	})
 }
@@ -236,7 +237,7 @@ func TestCreateSimpleTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		detail, err := svc.CreateSimpleTransaction(
-			"Assets:Bank", "Expenses:Food", 1000, "Dinner", 0, model.StatusPending, model.TxTypeExpense,
+			context.Background(), "Assets:Bank", "Expenses:Food", 1000, "Dinner", 0, model.StatusPending, model.TxTypeExpense,
 		)
 		require.NoError(t, err)
 		assert.Greater(t, detail.ID, int64(0))
@@ -258,7 +259,7 @@ func TestCreateSimpleTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		detail, err := svc.CreateSimpleTransaction(
-			"Assets:Bank", "Expenses:Food", 750, "Coffee", 0, model.StatusPending, model.TxTypeExpense,
+			context.Background(), "Assets:Bank", "Expenses:Food", 750, "Coffee", 0, model.StatusPending, model.TxTypeExpense,
 		)
 		require.NoError(t, err)
 
@@ -272,7 +273,7 @@ func TestCreateSimpleTransaction(t *testing.T) {
 	t.Run("same account rejected", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
 		_, err := svc.CreateSimpleTransaction(
-			"Assets:Bank", "Assets:Bank", 1000, "Self", 0, model.StatusPending, model.TxTypeExpense,
+			context.Background(), "Assets:Bank", "Assets:Bank", 1000, "Self", 0, model.StatusPending, model.TxTypeExpense,
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "same")
@@ -281,7 +282,7 @@ func TestCreateSimpleTransaction(t *testing.T) {
 	t.Run("zero amount rejected", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
 		_, err := svc.CreateSimpleTransaction(
-			"Assets:Bank", "Expenses:Food", 0, "Zero", 0, model.StatusPending, model.TxTypeExpense,
+			context.Background(), "Assets:Bank", "Expenses:Food", 0, "Zero", 0, model.StatusPending, model.TxTypeExpense,
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "positive")
@@ -290,7 +291,7 @@ func TestCreateSimpleTransaction(t *testing.T) {
 	t.Run("negative amount rejected", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
 		_, err := svc.CreateSimpleTransaction(
-			"Assets:Bank", "Expenses:Food", -100, "Negative", 0, model.StatusPending, model.TxTypeExpense,
+			context.Background(), "Assets:Bank", "Expenses:Food", -100, "Negative", 0, model.StatusPending, model.TxTypeExpense,
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "positive")
@@ -303,7 +304,7 @@ func TestCreateSimpleTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		detail, err := svc.CreateSimpleTransaction(
-			"Assets:Bank", "Expenses:Food", 500, "Inferred", 0, model.StatusPending, "",
+			context.Background(), "Assets:Bank", "Expenses:Food", 500, "Inferred", 0, model.StatusPending, "",
 		)
 		require.NoError(t, err)
 		assert.Equal(t, model.TxTypeExpense, detail.Type)
@@ -321,7 +322,7 @@ func TestDeleteTransaction(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(accRepo, txRepo)
 
-		err := svc.DeleteTransaction(5)
+		err := svc.DeleteTransaction(context.Background(), 5)
 		require.NoError(t, err)
 		_, exists := txRepo.transactions[5]
 		assert.False(t, exists, "transaction should not exist after deletion")
@@ -332,20 +333,20 @@ func TestDeleteTransaction(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 6, Status: model.StatusCleared}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.DeleteTransaction(6)
+		err := svc.DeleteTransaction(context.Background(), 6)
 		require.NoError(t, err)
 	})
 
 	t.Run("opening balance transaction (ID=1) rejected", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		err := svc.DeleteTransaction(model.SystemTransactionID)
+		err := svc.DeleteTransaction(context.Background(), model.SystemTransactionID)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrNotEditable), "expected ErrNotEditable, got: %v", err)
 	})
 
 	t.Run("non-existent transaction returns error", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		err := svc.DeleteTransaction(999)
+		err := svc.DeleteTransaction(context.Background(), 999)
 		require.Error(t, err)
 	})
 
@@ -354,7 +355,7 @@ func TestDeleteTransaction(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 7, Status: model.StatusReconciled}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.DeleteTransaction(7)
+		err := svc.DeleteTransaction(context.Background(), 7)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrReconciled), "expected ErrReconciled, got: %v", err)
 	})
@@ -364,7 +365,7 @@ func TestDeleteTransaction(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 8, Status: model.StatusReconciled}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.DeleteTransaction(8)
+		err := svc.DeleteTransaction(context.Background(), 8)
 		// wrapped with %w — errors.Is must unwrap correctly
 		assert.True(t, errors.Is(err, ErrReconciled))
 		assert.False(t, errors.Is(err, ErrNotEditable))
@@ -381,7 +382,7 @@ func TestUpdateTransactionStatus(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionStatus(5, model.StatusCleared)
+		err := svc.UpdateTransactionStatus(context.Background(), 5, model.StatusCleared)
 		require.NoError(t, err)
 		assert.Equal(t, model.StatusCleared, txRepo.transactions[5].Status)
 	})
@@ -391,7 +392,7 @@ func TestUpdateTransactionStatus(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusCleared}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionStatus(5, model.StatusPending)
+		err := svc.UpdateTransactionStatus(context.Background(), 5, model.StatusPending)
 		require.NoError(t, err)
 	})
 
@@ -400,7 +401,7 @@ func TestUpdateTransactionStatus(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionStatus(5, model.StatusReconciled)
+		err := svc.UpdateTransactionStatus(context.Background(), 5, model.StatusReconciled)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid status")
 	})
@@ -410,7 +411,7 @@ func TestUpdateTransactionStatus(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionStatus(5, model.TransactionStatus(99))
+		err := svc.UpdateTransactionStatus(context.Background(), 5, model.TransactionStatus(99))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid status")
 	})
@@ -420,21 +421,21 @@ func TestUpdateTransactionStatus(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusReconciled}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionStatus(5, model.StatusCleared)
+		err := svc.UpdateTransactionStatus(context.Background(), 5, model.StatusCleared)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrReconciled))
 	})
 
 	t.Run("system transaction (ID=1) rejected", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		err := svc.UpdateTransactionStatus(model.SystemTransactionID, model.StatusCleared)
+		err := svc.UpdateTransactionStatus(context.Background(), model.SystemTransactionID, model.StatusCleared)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrNotEditable), "expected ErrNotEditable, got: %v", err)
 	})
 
 	t.Run("non-existent transaction returns error", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		err := svc.UpdateTransactionStatus(999, model.StatusCleared)
+		err := svc.UpdateTransactionStatus(context.Background(), 999, model.StatusCleared)
 		require.Error(t, err)
 	})
 }
@@ -466,7 +467,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -800, Currency: "USD"},
 			{ID: 11, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 800, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(5, "Updated desc", 0, model.StatusCleared, model.TxTypeExpense, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), 5, "Updated desc", 0, model.StatusCleared, model.TxTypeExpense, splits)
 		require.NoError(t, err)
 	})
 
@@ -475,14 +476,14 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionComplete(5, "", 0, model.TransactionStatus(99), model.TxTypeExpense, nil)
+		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.TransactionStatus(99), model.TxTypeExpense, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid status")
 	})
 
 	t.Run("non-existent transaction returns error", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		err := svc.UpdateTransactionComplete(999, "", 0, model.StatusPending, model.TxTypeExpense,
+		err := svc.UpdateTransactionComplete(context.Background(), 999, "", 0, model.StatusPending, model.TxTypeExpense,
 			[]model.SplitDetail{{AccountID: 1, Amount: 0}, {AccountID: 2, Amount: 0}})
 		require.Error(t, err)
 	})
@@ -492,7 +493,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusReconciled}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusCleared, model.TxTypeExpense,
+		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusCleared, model.TxTypeExpense,
 			[]model.SplitDetail{{AccountID: 1, Amount: 500}, {AccountID: 2, Amount: -500}})
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrReconciled))
@@ -503,7 +504,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, model.TxTypeExpense,
+		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeExpense,
 			[]model.SplitDetail{{AccountID: 1, Amount: 0}})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "at least 2")
@@ -516,7 +517,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(accRepo, txRepo)
 
-		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, model.TxTypeExpense,
+		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeExpense,
 			[]model.SplitDetail{
 				{AccountID: 1, Amount: -500},
 				{AccountID: 2, Amount: 400}, // off by 100
@@ -531,7 +532,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(accRepo, txRepo)
 
-		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, model.TxTypeExpense,
+		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeExpense,
 			[]model.SplitDetail{
 				{AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -500},
 				{AccountID: 99, AccountType: model.AccountTypeExpense, Amount: 500}, // does not exist
@@ -559,7 +560,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -1000, Currency: "USD"},
 			{ID: 11, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 1000, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, model.TxTypeExpense, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeExpense, splits)
 		require.NoError(t, err)
 		assert.Contains(t, txRepo.deleteSplitCalls, int64(12), "split ID 12 should be deleted")
 	})
@@ -578,7 +579,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -1000, Currency: "USD"},
 			{ID: 0, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 1000, Currency: "USD"}, // new split
 		}
-		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, model.TxTypeExpense, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeExpense, splits)
 		require.NoError(t, err)
 		assert.Len(t, txRepo.createSplitCalls, 1, "CreateSplit should be called once")
 	})
@@ -600,7 +601,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -800, Currency: "USD"},
 			{ID: 11, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 800, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, model.TxTypeExpense, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeExpense, splits)
 		require.NoError(t, err)
 		assert.Contains(t, txRepo.updateSplitCalls, int64(10))
 		assert.Contains(t, txRepo.updateSplitCalls, int64(11))
@@ -621,7 +622,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
 			{AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(5, "", 0, model.StatusPending, model.TxTypeTransfer, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeTransfer, splits)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "splits do not match transaction type")
 	})
@@ -678,7 +679,7 @@ func TestCreateTransactionFromSplits(t *testing.T) {
 			{AccountName: "Assets:Bank", Amount: -200000},
 			{AccountName: "Expenses:Food", Amount: 200000},
 		}
-		result, err := svc.CreateTransactionFromSplits(splits, "team lunch", 0, model.StatusCleared, model.TxTypeExpense)
+		result, err := svc.CreateTransactionFromSplits(context.Background(), splits, "team lunch", 0, model.StatusCleared, model.TxTypeExpense)
 		require.NoError(t, err)
 		assert.Greater(t, result.ID, int64(0))
 		assert.Equal(t, "team lunch", result.Description)
@@ -697,7 +698,7 @@ func TestCreateTransactionFromSplits(t *testing.T) {
 			{AccountName: "Assets:Bank", Amount: -200000},
 			{AccountName: "Expenses:Food", Amount: 200000},
 		}
-		_, err := svc.CreateTransactionFromSplits(splits, "team lunch", 0, model.StatusCleared, model.TxTypeExpense)
+		_, err := svc.CreateTransactionFromSplits(context.Background(), splits, "team lunch", 0, model.StatusCleared, model.TxTypeExpense)
 		require.Error(t, err)
 	})
 }

--- a/internal/service/transaction_service.go
+++ b/internal/service/transaction_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hance08/kea/internal/config"
@@ -45,13 +46,13 @@ func (ts *TransactionService) GetTransactionRule(txType model.TransactionType) (
 }
 
 // GetTransactionByID retrieves a transaction with all split details
-func (ts *TransactionService) GetTransactionByID(txID int64) (*model.TransactionDetail, error) {
-	tx, err := ts.txRepo.GetTransactionByID(txID)
+func (ts *TransactionService) GetTransactionByID(ctx context.Context, txID int64) (*model.TransactionDetail, error) {
+	tx, err := ts.txRepo.GetTransactionByID(ctx, txID)
 	if err != nil {
 		return nil, err
 	}
 
-	splits, err := ts.txRepo.GetSplitsWithAccountsByTransaction(txID)
+	splits, err := ts.txRepo.GetSplitsWithAccountsByTransaction(ctx, txID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get splits for transaction: %w", err)
 	}
@@ -67,8 +68,8 @@ func (ts *TransactionService) GetTransactionByID(txID int64) (*model.Transaction
 }
 
 // GetRecentTransactions retrieves recent transactions across all accounts
-func (ts *TransactionService) GetRecentTransactions(limit int) ([]*model.Transaction, error) {
-	transactions, err := ts.txRepo.GetAllTransactions(limit)
+func (ts *TransactionService) GetRecentTransactions(ctx context.Context, limit int) ([]*model.Transaction, error) {
+	transactions, err := ts.txRepo.GetAllTransactions(ctx, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get recent transactions: %w", err)
 	}
@@ -76,15 +77,15 @@ func (ts *TransactionService) GetRecentTransactions(limit int) ([]*model.Transac
 }
 
 // GetTransactionHistory retrieves transaction history for a specific account
-func (ts *TransactionService) GetTransactionHistory(accountName string, limit int) ([]*model.Transaction, error) {
+func (ts *TransactionService) GetTransactionHistory(ctx context.Context, accountName string, limit int) ([]*model.Transaction, error) {
 	// Get account by name
-	account, err := ts.accRepo.GetAccountByName(accountName)
+	account, err := ts.accRepo.GetAccountByName(ctx, accountName)
 	if err != nil {
 		return nil, fmt.Errorf("account not found: %w", err)
 	}
 
 	// Get transactions for this account
-	transactions, err := ts.txRepo.GetTransactionsByAccount(account.ID, limit)
+	transactions, err := ts.txRepo.GetTransactionsByAccount(ctx, account.ID, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get transaction history: %w", err)
 	}

--- a/internal/service/transaction_validation.go
+++ b/internal/service/transaction_validation.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hance08/kea/internal/model"
@@ -32,7 +33,7 @@ func (ts *TransactionService) ValidateSplitsBalance(splits []model.Split) error 
 }
 
 // ValidateTransactionEdit validates a transaction edit without saving
-func (ts *TransactionService) ValidateTransactionEdit(splits []model.SplitDetail) error {
+func (ts *TransactionService) ValidateTransactionEdit(ctx context.Context, splits []model.SplitDetail) error {
 	// Check minimum splits
 	if len(splits) < model.MinSplitsCount {
 		return fmt.Errorf("transaction must have at least 2 splits")
@@ -49,7 +50,7 @@ func (ts *TransactionService) ValidateTransactionEdit(splits []model.SplitDetail
 
 	// Validate accounts exist
 	for i, split := range splits {
-		_, err := ts.accRepo.GetAccountByID(split.AccountID)
+		_, err := ts.accRepo.GetAccountByID(ctx, split.AccountID)
 		if err != nil {
 			return fmt.Errorf("split #%d: account ID %d not found", i+1, split.AccountID)
 		}

--- a/internal/service/transaction_validation_test.go
+++ b/internal/service/transaction_validation_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -111,7 +112,7 @@ func TestValidateTransactionEdit(t *testing.T) {
 			{AccountID: 1, Amount: -500, Currency: "USD"},
 			{AccountID: 2, Amount: 500, Currency: "USD"},
 		}
-		err := svc.ValidateTransactionEdit(splits)
+		err := svc.ValidateTransactionEdit(context.Background(), splits)
 		require.NoError(t, err)
 	})
 
@@ -120,14 +121,14 @@ func TestValidateTransactionEdit(t *testing.T) {
 		splits := []model.SplitDetail{
 			{AccountID: 1, Amount: 1000},
 		}
-		err := svc.ValidateTransactionEdit(splits)
+		err := svc.ValidateTransactionEdit(context.Background(), splits)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "at least 2")
 	})
 
 	t.Run("empty split list rejected", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		err := svc.ValidateTransactionEdit([]model.SplitDetail{})
+		err := svc.ValidateTransactionEdit(context.Background(), []model.SplitDetail{})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "at least 2")
 	})
@@ -142,7 +143,7 @@ func TestValidateTransactionEdit(t *testing.T) {
 			{AccountID: 1, Amount: -500},
 			{AccountID: 2, Amount: 600}, // off by 100
 		}
-		err := svc.ValidateTransactionEdit(splits)
+		err := svc.ValidateTransactionEdit(context.Background(), splits)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "balance")
 	})
@@ -157,7 +158,7 @@ func TestValidateTransactionEdit(t *testing.T) {
 			{AccountID: 1, Amount: -500},
 			{AccountID: 99, Amount: 500},
 		}
-		err := svc.ValidateTransactionEdit(splits)
+		err := svc.ValidateTransactionEdit(context.Background(), splits)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "99")
 	})
@@ -172,7 +173,7 @@ func TestValidateTransactionEdit(t *testing.T) {
 			{AccountID: 1, Amount: -500},
 			{AccountID: 2, Amount: 500},
 		}
-		err := svc.ValidateTransactionEdit(splits)
+		err := svc.ValidateTransactionEdit(context.Background(), splits)
 		require.Error(t, err)
 		// error message should reference split #2
 		assert.Contains(t, err.Error(), "#2")
@@ -190,7 +191,7 @@ func TestValidateTransactionEdit(t *testing.T) {
 			{AccountID: 3, Amount: 300},
 			{AccountID: 4, Amount: 300},
 		}
-		err := svc.ValidateTransactionEdit(splits)
+		err := svc.ValidateTransactionEdit(context.Background(), splits)
 		require.NoError(t, err)
 	})
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -17,10 +17,10 @@ import (
 )
 
 type DBTX interface {
-	Exec(query string, args ...any) (sql.Result, error)
-	Prepare(query string) (*sql.Stmt, error)
-	Query(query string, args ...any) (*sql.Rows, error)
-	QueryRow(query string, args ...any) *sql.Row
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
 type Store struct {

--- a/internal/store/sqlite_account.go
+++ b/internal/store/sqlite_account.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -10,7 +11,7 @@ import (
 )
 
 func (s *Store) CreateAccount(name string, accType model.AccountType, currency string, description string, parentID *int64) (int64, error) {
-	stmt, err := s.db.Prepare(`
+	stmt, err := s.db.PrepareContext(context.Background(), `
         INSERT INTO accounts (name, type, currency, description, parent_id)
         VALUES (?, ?, ?, ?, ?)
         RETURNING id;
@@ -24,7 +25,7 @@ func (s *Store) CreateAccount(name string, accType model.AccountType, currency s
 
 	var newID int64
 
-	err = stmt.QueryRow(name, string(accType), currency, description, parentID).Scan(&newID)
+	err = stmt.QueryRowContext(context.Background(), name, string(accType), currency, description, parentID).Scan(&newID)
 
 	if err != nil {
 		var sqliteErr sqlite.Error
@@ -40,7 +41,7 @@ func (s *Store) CreateAccount(name string, accType model.AccountType, currency s
 }
 
 func (s *Store) GetAllAccounts() ([]*model.Account, error) {
-	rows, err := s.db.Query(`
+	rows, err := s.db.QueryContext(context.Background(), `
         SELECT id, name, type, parent_id, currency, description, is_hidden
         FROM accounts
         ORDER BY name
@@ -56,7 +57,7 @@ func (s *Store) GetAllAccounts() ([]*model.Account, error) {
 }
 
 func (s *Store) GetAccountByName(name string) (*model.Account, error) {
-	row := s.db.QueryRow("SELECT id, name, type, parent_id, currency, description, is_hidden FROM accounts WHERE name = ?", name)
+	row := s.db.QueryRowContext(context.Background(), "SELECT id, name, type, parent_id, currency, description, is_hidden FROM accounts WHERE name = ?", name)
 
 	acc := &model.Account{}
 	var parentID sql.NullInt64
@@ -82,7 +83,7 @@ func (s *Store) GetAccountByName(name string) (*model.Account, error) {
 }
 
 func (s *Store) GetAccountByID(id int64) (*model.Account, error) {
-	row := s.db.QueryRow("SELECT id, name, type, parent_id, currency, description, is_hidden FROM accounts WHERE id = ?", id)
+	row := s.db.QueryRowContext(context.Background(), "SELECT id, name, type, parent_id, currency, description, is_hidden FROM accounts WHERE id = ?", id)
 
 	acc := &model.Account{}
 	var parentID sql.NullInt64
@@ -109,7 +110,7 @@ func (s *Store) GetAccountByID(id int64) (*model.Account, error) {
 
 func (s *Store) AccountExists(name string) (bool, error) {
 	var exists bool
-	row := s.db.QueryRow("SELECT EXISTS(SELECT 1 FROM accounts WHERE name = ?)", name)
+	row := s.db.QueryRowContext(context.Background(), "SELECT EXISTS(SELECT 1 FROM accounts WHERE name = ?)", name)
 	if err := row.Scan(&exists); err != nil {
 		return false, fmt.Errorf("failed to check account existence: %w", err)
 	}
@@ -117,7 +118,7 @@ func (s *Store) AccountExists(name string) (bool, error) {
 }
 
 func (s *Store) GetAllAccountBalances(asOf int64) (map[int64]int64, error) {
-	rows, err := s.db.Query(`
+	rows, err := s.db.QueryContext(context.Background(), `
         SELECT s.account_id, SUM(s.amount)
         FROM splits s
         JOIN transactions t ON s.transaction_id = t.id
@@ -148,7 +149,7 @@ func (s *Store) GetAllAccountBalances(asOf int64) (map[int64]int64, error) {
 
 func (s *Store) HasChildAccounts(accountID int64) (bool, error) {
 	var exists bool
-	row := s.db.QueryRow("SELECT EXISTS(SELECT 1 FROM accounts WHERE parent_id = ?)", accountID)
+	row := s.db.QueryRowContext(context.Background(), "SELECT EXISTS(SELECT 1 FROM accounts WHERE parent_id = ?)", accountID)
 	if err := row.Scan(&exists); err != nil {
 		return false, fmt.Errorf("failed to check child accounts: %w", err)
 	}
@@ -156,7 +157,7 @@ func (s *Store) HasChildAccounts(accountID int64) (bool, error) {
 }
 
 func (s *Store) GetAccountsByType(accType model.AccountType) ([]*model.Account, error) {
-	rows, err := s.db.Query(`
+	rows, err := s.db.QueryContext(context.Background(), `
         SELECT id, name, type, parent_id, currency, description, is_hidden
         FROM accounts
         WHERE type = ?
@@ -175,7 +176,7 @@ func (s *Store) GetAccountsByType(accType model.AccountType) ([]*model.Account, 
 
 func (s *Store) GetAccountBalance(accountID int64) (int64, error) {
 	var balance sql.NullInt64
-	err := s.db.QueryRow(`
+	err := s.db.QueryRowContext(context.Background(), `
         SELECT SUM(amount)
         FROM splits
         WHERE account_id = ?
@@ -223,7 +224,7 @@ func (s *Store) scanAccounts(rows *sql.Rows) ([]*model.Account, error) {
 // AccountHasTransactions returns true when the account is referenced by any split.
 func (s *Store) AccountHasTransactions(accountID int64) (bool, error) {
 	var exists bool
-	row := s.db.QueryRow("SELECT EXISTS(SELECT 1 FROM splits WHERE account_id = ?)", accountID)
+	row := s.db.QueryRowContext(context.Background(), "SELECT EXISTS(SELECT 1 FROM splits WHERE account_id = ?)", accountID)
 	if err := row.Scan(&exists); err != nil {
 		return false, fmt.Errorf("failed to check account transactions: %w", err)
 	}
@@ -237,13 +238,13 @@ func (s *Store) RenameAccount(oldName, newName string) error {
 		return fmt.Errorf("store is already in a transaction")
 	}
 
-	tx, err := s.rawDB.Begin()
+	tx, err := s.rawDB.BeginTx(context.Background(), nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	res, err := tx.Exec(`UPDATE accounts SET name = ? WHERE name = ?`, newName, oldName)
+	res, err := tx.ExecContext(context.Background(), `UPDATE accounts SET name = ? WHERE name = ?`, newName, oldName)
 	if err != nil {
 		return fmt.Errorf("failed to rename account %q: %w", oldName, err)
 	}
@@ -255,7 +256,7 @@ func (s *Store) RenameAccount(oldName, newName string) error {
 		return fmt.Errorf("account %q not found", oldName)
 	}
 
-	_, err = tx.Exec(
+	_, err = tx.ExecContext(context.Background(),
 		`UPDATE accounts SET name = replace(name, ?, ?) WHERE name LIKE ? || ':%'`,
 		oldName, newName, oldName,
 	)
@@ -268,7 +269,7 @@ func (s *Store) RenameAccount(oldName, newName string) error {
 
 // DeleteAccount removes an account record by ID.
 func (s *Store) DeleteAccount(accountID int64) error {
-	result, err := s.db.Exec("DELETE FROM accounts WHERE id = ?", accountID)
+	result, err := s.db.ExecContext(context.Background(), "DELETE FROM accounts WHERE id = ?", accountID)
 	if err != nil {
 		return fmt.Errorf("failed to delete account: %w", err)
 	}
@@ -287,7 +288,7 @@ func (s *Store) DeleteAccount(accountID int64) error {
 
 // UpdateAccountMetadata updates the description and hidden status of an account.
 func (s *Store) UpdateAccountMetadata(accountID int64, description string, isHidden bool) error {
-	res, err := s.db.Exec(
+	res, err := s.db.ExecContext(context.Background(),
 		`UPDATE accounts SET description = ?, is_hidden = ? WHERE id = ?`,
 		description, isHidden, accountID,
 	)

--- a/internal/store/sqlite_account.go
+++ b/internal/store/sqlite_account.go
@@ -10,8 +10,8 @@ import (
 	sqlite "github.com/mattn/go-sqlite3"
 )
 
-func (s *Store) CreateAccount(name string, accType model.AccountType, currency string, description string, parentID *int64) (int64, error) {
-	stmt, err := s.db.PrepareContext(context.Background(), `
+func (s *Store) CreateAccount(ctx context.Context, name string, accType model.AccountType, currency string, description string, parentID *int64) (int64, error) {
+	stmt, err := s.db.PrepareContext(ctx, `
         INSERT INTO accounts (name, type, currency, description, parent_id)
         VALUES (?, ?, ?, ?, ?)
         RETURNING id;
@@ -25,7 +25,7 @@ func (s *Store) CreateAccount(name string, accType model.AccountType, currency s
 
 	var newID int64
 
-	err = stmt.QueryRowContext(context.Background(), name, string(accType), currency, description, parentID).Scan(&newID)
+	err = stmt.QueryRowContext(ctx, name, string(accType), currency, description, parentID).Scan(&newID)
 
 	if err != nil {
 		var sqliteErr sqlite.Error
@@ -40,8 +40,8 @@ func (s *Store) CreateAccount(name string, accType model.AccountType, currency s
 	return newID, nil
 }
 
-func (s *Store) GetAllAccounts() ([]*model.Account, error) {
-	rows, err := s.db.QueryContext(context.Background(), `
+func (s *Store) GetAllAccounts(ctx context.Context) ([]*model.Account, error) {
+	rows, err := s.db.QueryContext(ctx, `
         SELECT id, name, type, parent_id, currency, description, is_hidden
         FROM accounts
         ORDER BY name
@@ -56,8 +56,8 @@ func (s *Store) GetAllAccounts() ([]*model.Account, error) {
 	return s.scanAccounts(rows)
 }
 
-func (s *Store) GetAccountByName(name string) (*model.Account, error) {
-	row := s.db.QueryRowContext(context.Background(), "SELECT id, name, type, parent_id, currency, description, is_hidden FROM accounts WHERE name = ?", name)
+func (s *Store) GetAccountByName(ctx context.Context, name string) (*model.Account, error) {
+	row := s.db.QueryRowContext(ctx, "SELECT id, name, type, parent_id, currency, description, is_hidden FROM accounts WHERE name = ?", name)
 
 	acc := &model.Account{}
 	var parentID sql.NullInt64
@@ -82,8 +82,8 @@ func (s *Store) GetAccountByName(name string) (*model.Account, error) {
 	return acc, nil
 }
 
-func (s *Store) GetAccountByID(id int64) (*model.Account, error) {
-	row := s.db.QueryRowContext(context.Background(), "SELECT id, name, type, parent_id, currency, description, is_hidden FROM accounts WHERE id = ?", id)
+func (s *Store) GetAccountByID(ctx context.Context, id int64) (*model.Account, error) {
+	row := s.db.QueryRowContext(ctx, "SELECT id, name, type, parent_id, currency, description, is_hidden FROM accounts WHERE id = ?", id)
 
 	acc := &model.Account{}
 	var parentID sql.NullInt64
@@ -108,17 +108,17 @@ func (s *Store) GetAccountByID(id int64) (*model.Account, error) {
 	return acc, nil
 }
 
-func (s *Store) AccountExists(name string) (bool, error) {
+func (s *Store) AccountExists(ctx context.Context, name string) (bool, error) {
 	var exists bool
-	row := s.db.QueryRowContext(context.Background(), "SELECT EXISTS(SELECT 1 FROM accounts WHERE name = ?)", name)
+	row := s.db.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM accounts WHERE name = ?)", name)
 	if err := row.Scan(&exists); err != nil {
 		return false, fmt.Errorf("failed to check account existence: %w", err)
 	}
 	return exists, nil
 }
 
-func (s *Store) GetAllAccountBalances(asOf int64) (map[int64]int64, error) {
-	rows, err := s.db.QueryContext(context.Background(), `
+func (s *Store) GetAllAccountBalances(ctx context.Context, asOf int64) (map[int64]int64, error) {
+	rows, err := s.db.QueryContext(ctx, `
         SELECT s.account_id, SUM(s.amount)
         FROM splits s
         JOIN transactions t ON s.transaction_id = t.id
@@ -147,17 +147,17 @@ func (s *Store) GetAllAccountBalances(asOf int64) (map[int64]int64, error) {
 	return result, nil
 }
 
-func (s *Store) HasChildAccounts(accountID int64) (bool, error) {
+func (s *Store) HasChildAccounts(ctx context.Context, accountID int64) (bool, error) {
 	var exists bool
-	row := s.db.QueryRowContext(context.Background(), "SELECT EXISTS(SELECT 1 FROM accounts WHERE parent_id = ?)", accountID)
+	row := s.db.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM accounts WHERE parent_id = ?)", accountID)
 	if err := row.Scan(&exists); err != nil {
 		return false, fmt.Errorf("failed to check child accounts: %w", err)
 	}
 	return exists, nil
 }
 
-func (s *Store) GetAccountsByType(accType model.AccountType) ([]*model.Account, error) {
-	rows, err := s.db.QueryContext(context.Background(), `
+func (s *Store) GetAccountsByType(ctx context.Context, accType model.AccountType) ([]*model.Account, error) {
+	rows, err := s.db.QueryContext(ctx, `
         SELECT id, name, type, parent_id, currency, description, is_hidden
         FROM accounts
         WHERE type = ?
@@ -174,9 +174,9 @@ func (s *Store) GetAccountsByType(accType model.AccountType) ([]*model.Account, 
 	return s.scanAccounts(rows)
 }
 
-func (s *Store) GetAccountBalance(accountID int64) (int64, error) {
+func (s *Store) GetAccountBalance(ctx context.Context, accountID int64) (int64, error) {
 	var balance sql.NullInt64
-	err := s.db.QueryRowContext(context.Background(), `
+	err := s.db.QueryRowContext(ctx, `
         SELECT SUM(amount)
         FROM splits
         WHERE account_id = ?
@@ -222,9 +222,9 @@ func (s *Store) scanAccounts(rows *sql.Rows) ([]*model.Account, error) {
 }
 
 // AccountHasTransactions returns true when the account is referenced by any split.
-func (s *Store) AccountHasTransactions(accountID int64) (bool, error) {
+func (s *Store) AccountHasTransactions(ctx context.Context, accountID int64) (bool, error) {
 	var exists bool
-	row := s.db.QueryRowContext(context.Background(), "SELECT EXISTS(SELECT 1 FROM splits WHERE account_id = ?)", accountID)
+	row := s.db.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM splits WHERE account_id = ?)", accountID)
 	if err := row.Scan(&exists); err != nil {
 		return false, fmt.Errorf("failed to check account transactions: %w", err)
 	}
@@ -233,18 +233,18 @@ func (s *Store) AccountHasTransactions(accountID int64) (bool, error) {
 
 // RenameAccount updates the name of an account and cascades the rename to all descendants.
 // Both updates run in a single transaction.
-func (s *Store) RenameAccount(oldName, newName string) error {
+func (s *Store) RenameAccount(ctx context.Context, oldName, newName string) error {
 	if s.rawDB == nil {
 		return fmt.Errorf("store is already in a transaction")
 	}
 
-	tx, err := s.rawDB.BeginTx(context.Background(), nil)
+	tx, err := s.rawDB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	res, err := tx.ExecContext(context.Background(), `UPDATE accounts SET name = ? WHERE name = ?`, newName, oldName)
+	res, err := tx.ExecContext(ctx, `UPDATE accounts SET name = ? WHERE name = ?`, newName, oldName)
 	if err != nil {
 		return fmt.Errorf("failed to rename account %q: %w", oldName, err)
 	}
@@ -256,7 +256,7 @@ func (s *Store) RenameAccount(oldName, newName string) error {
 		return fmt.Errorf("account %q not found", oldName)
 	}
 
-	_, err = tx.ExecContext(context.Background(),
+	_, err = tx.ExecContext(ctx,
 		`UPDATE accounts SET name = replace(name, ?, ?) WHERE name LIKE ? || ':%'`,
 		oldName, newName, oldName,
 	)
@@ -268,8 +268,8 @@ func (s *Store) RenameAccount(oldName, newName string) error {
 }
 
 // DeleteAccount removes an account record by ID.
-func (s *Store) DeleteAccount(accountID int64) error {
-	result, err := s.db.ExecContext(context.Background(), "DELETE FROM accounts WHERE id = ?", accountID)
+func (s *Store) DeleteAccount(ctx context.Context, accountID int64) error {
+	result, err := s.db.ExecContext(ctx, "DELETE FROM accounts WHERE id = ?", accountID)
 	if err != nil {
 		return fmt.Errorf("failed to delete account: %w", err)
 	}
@@ -287,8 +287,8 @@ func (s *Store) DeleteAccount(accountID int64) error {
 }
 
 // UpdateAccountMetadata updates the description and hidden status of an account.
-func (s *Store) UpdateAccountMetadata(accountID int64, description string, isHidden bool) error {
-	res, err := s.db.ExecContext(context.Background(),
+func (s *Store) UpdateAccountMetadata(ctx context.Context, accountID int64, description string, isHidden bool) error {
+	res, err := s.db.ExecContext(ctx,
 		`UPDATE accounts SET description = ?, is_hidden = ? WHERE id = ?`,
 		description, isHidden, accountID,
 	)

--- a/internal/store/sqlite_reconcile.go
+++ b/internal/store/sqlite_reconcile.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -15,7 +16,7 @@ import (
 // ensures multi-account transactions remain visible for other accounts after one
 // account has already been reconciled. Results are ordered by timestamp ASC.
 func (s *Store) GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.ReconcileEntry, error) {
-	rows, err := s.db.Query(`
+	rows, err := s.db.QueryContext(context.Background(), `
         SELECT
             t.id, t.timestamp, t.description, t.status,
             SUM(s.amount) AS amount,
@@ -91,7 +92,7 @@ func (s *Store) MarkSplitsReconciledByAccount(accountID int64, txIDs []int64) (i
 		"UPDATE splits SET reconciled = 1 WHERE account_id = ? AND transaction_id IN (%s)",
 		placeholders,
 	)
-	result, err := s.db.Exec(splitQuery, splitArgs...)
+	result, err := s.db.ExecContext(context.Background(), splitQuery, splitArgs...)
 	if err != nil {
 		return 0, fmt.Errorf("failed to mark splits as reconciled: %w", err)
 	}
@@ -126,7 +127,7 @@ func (s *Store) BulkUpdateTransactionStatus(txIDs []int64, status model.Transact
 		args = append(args, id)
 	}
 
-	result, err := s.db.Exec(query, args...)
+	result, err := s.db.ExecContext(context.Background(), query, args...)
 	if err != nil {
 		return fmt.Errorf("failed to bulk update transaction status: %w", err)
 	}
@@ -146,7 +147,7 @@ func (s *Store) BulkUpdateTransactionStatus(txIDs []int64, status model.Transact
 // account_reconcile_state for this account yet).
 func (s *Store) GetLastReconciledBalance(accountID int64) (int64, error) {
 	var balance int64
-	err := s.db.QueryRow(
+	err := s.db.QueryRowContext(context.Background(),
 		"SELECT last_reconciled_balance FROM account_reconcile_state WHERE account_id = ?",
 		accountID,
 	).Scan(&balance)
@@ -163,7 +164,7 @@ func (s *Store) GetLastReconciledBalance(accountID int64) (int64, error) {
 // accountID. An upsert is used so that the first reconcile for an account
 // inserts a row; subsequent reconciles update it.
 func (s *Store) SetLastReconciledBalance(accountID int64, balance int64) error {
-	_, err := s.db.Exec(`
+	_, err := s.db.ExecContext(context.Background(), `
         INSERT INTO account_reconcile_state (account_id, last_reconciled_balance)
         VALUES (?, ?)
         ON CONFLICT(account_id) DO UPDATE SET last_reconciled_balance = excluded.last_reconciled_balance

--- a/internal/store/sqlite_reconcile.go
+++ b/internal/store/sqlite_reconcile.go
@@ -15,8 +15,8 @@ import (
 // cases). Filtering on the split flag — rather than the transaction status —
 // ensures multi-account transactions remain visible for other accounts after one
 // account has already been reconciled. Results are ordered by timestamp ASC.
-func (s *Store) GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.ReconcileEntry, error) {
-	rows, err := s.db.QueryContext(context.Background(), `
+func (s *Store) GetUnreconciledTransactionsByAccount(ctx context.Context, accountID int64) ([]*model.ReconcileEntry, error) {
+	rows, err := s.db.QueryContext(ctx, `
         SELECT
             t.id, t.timestamp, t.description, t.status,
             SUM(s.amount) AS amount,
@@ -74,7 +74,7 @@ func (s *Store) GetUnreconciledTransactionsByAccount(accountID int64) ([]*model.
 // The reconcile TUI filters on s.reconciled = 0 (not t.status), so marking the
 // transaction Reconciled here does not hide it from other accounts that still
 // need to reconcile their own splits.
-func (s *Store) MarkSplitsReconciledByAccount(accountID int64, txIDs []int64) (int64, error) {
+func (s *Store) MarkSplitsReconciledByAccount(ctx context.Context, accountID int64, txIDs []int64) (int64, error) {
 	if len(txIDs) == 0 {
 		return 0, nil
 	}
@@ -92,7 +92,7 @@ func (s *Store) MarkSplitsReconciledByAccount(accountID int64, txIDs []int64) (i
 		"UPDATE splits SET reconciled = 1 WHERE account_id = ? AND transaction_id IN (%s)",
 		placeholders,
 	)
-	result, err := s.db.ExecContext(context.Background(), splitQuery, splitArgs...)
+	result, err := s.db.ExecContext(ctx, splitQuery, splitArgs...)
 	if err != nil {
 		return 0, fmt.Errorf("failed to mark splits as reconciled: %w", err)
 	}
@@ -102,13 +102,13 @@ func (s *Store) MarkSplitsReconciledByAccount(accountID int64, txIDs []int64) (i
 	}
 
 	// 2. Upgrade all affected transactions to StatusReconciled.
-	return rowsAffected, s.BulkUpdateTransactionStatus(txIDs, model.StatusReconciled)
+	return rowsAffected, s.BulkUpdateTransactionStatus(ctx, txIDs, model.StatusReconciled)
 }
 
 // BulkUpdateTransactionStatus sets the status of all listed transaction IDs
 // in a single UPDATE statement. Returns an error if the affected row count
 // does not match len(txIDs) — indicating one or more IDs did not exist.
-func (s *Store) BulkUpdateTransactionStatus(txIDs []int64, status model.TransactionStatus) error {
+func (s *Store) BulkUpdateTransactionStatus(ctx context.Context, txIDs []int64, status model.TransactionStatus) error {
 	if len(txIDs) == 0 {
 		return nil
 	}
@@ -127,7 +127,7 @@ func (s *Store) BulkUpdateTransactionStatus(txIDs []int64, status model.Transact
 		args = append(args, id)
 	}
 
-	result, err := s.db.ExecContext(context.Background(), query, args...)
+	result, err := s.db.ExecContext(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("failed to bulk update transaction status: %w", err)
 	}
@@ -145,9 +145,9 @@ func (s *Store) BulkUpdateTransactionStatus(txIDs []int64, status model.Transact
 // GetLastReconciledBalance returns the running reconciled balance for
 // accountID. Returns 0 if the account has never been reconciled (no row in
 // account_reconcile_state for this account yet).
-func (s *Store) GetLastReconciledBalance(accountID int64) (int64, error) {
+func (s *Store) GetLastReconciledBalance(ctx context.Context, accountID int64) (int64, error) {
 	var balance int64
-	err := s.db.QueryRowContext(context.Background(),
+	err := s.db.QueryRowContext(ctx,
 		"SELECT last_reconciled_balance FROM account_reconcile_state WHERE account_id = ?",
 		accountID,
 	).Scan(&balance)
@@ -163,8 +163,8 @@ func (s *Store) GetLastReconciledBalance(accountID int64) (int64, error) {
 // SetLastReconciledBalance persists the new running reconciled balance for
 // accountID. An upsert is used so that the first reconcile for an account
 // inserts a row; subsequent reconciles update it.
-func (s *Store) SetLastReconciledBalance(accountID int64, balance int64) error {
-	_, err := s.db.ExecContext(context.Background(), `
+func (s *Store) SetLastReconciledBalance(ctx context.Context, accountID int64, balance int64) error {
+	_, err := s.db.ExecContext(ctx, `
         INSERT INTO account_reconcile_state (account_id, last_reconciled_balance)
         VALUES (?, ?)
         ON CONFLICT(account_id) DO UPDATE SET last_reconciled_balance = excluded.last_reconciled_balance

--- a/internal/store/sqlite_transaction.go
+++ b/internal/store/sqlite_transaction.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -12,7 +13,7 @@ import (
 // CreateTransactionWithSplits inserts a transaction and its splits.
 // It relies on the caller (Service layer) to wrap it in ExecTx for atomicity.
 func (s *Store) CreateTransactionWithSplits(tx model.Transaction, splits []model.Split) (int64, error) {
-	stmtTx, err := s.db.Prepare(`
+	stmtTx, err := s.db.PrepareContext(context.Background(), `
         INSERT INTO transactions (timestamp, description, status, external_id, type)
         VALUES (?, ?, ?, ?, ?)
         RETURNING id;
@@ -25,7 +26,7 @@ func (s *Store) CreateTransactionWithSplits(tx model.Transaction, splits []model
 	}()
 
 	var newTxID int64
-	err = stmtTx.QueryRow(tx.Timestamp, tx.Description, tx.Status, tx.ExternalID, tx.Type).Scan(&newTxID)
+	err = stmtTx.QueryRowContext(context.Background(), tx.Timestamp, tx.Description, tx.Status, tx.ExternalID, tx.Type).Scan(&newTxID)
 
 	if err != nil {
 		var sqliteErr sqlite.Error
@@ -37,7 +38,7 @@ func (s *Store) CreateTransactionWithSplits(tx model.Transaction, splits []model
 		return 0, fmt.Errorf("failed to insert transaction: %w", err)
 	}
 
-	stmtSplit, err := s.db.Prepare(`
+	stmtSplit, err := s.db.PrepareContext(context.Background(), `
         INSERT INTO splits (transaction_id, account_id, amount, currency, memo)
         VALUES (?, ?, ?, ?, ?);
     `)
@@ -49,7 +50,7 @@ func (s *Store) CreateTransactionWithSplits(tx model.Transaction, splits []model
 	}()
 
 	for _, split := range splits {
-		_, err := stmtSplit.Exec(newTxID, split.AccountID, split.Amount, split.Currency, split.Memo)
+		_, err := stmtSplit.ExecContext(context.Background(), newTxID, split.AccountID, split.Amount, split.Currency, split.Memo)
 		if err != nil {
 			return 0, fmt.Errorf("failed to insert split (account_id: %d): %w", split.AccountID, err)
 		}
@@ -60,7 +61,7 @@ func (s *Store) CreateTransactionWithSplits(tx model.Transaction, splits []model
 
 func (s *Store) GetTransactionByID(txID int64) (*model.Transaction, error) {
 	var tx model.Transaction
-	err := s.db.QueryRow(`
+	err := s.db.QueryRowContext(context.Background(), `
         SELECT id, timestamp, description, status, external_id, type
         FROM transactions
         WHERE id = ?
@@ -79,7 +80,7 @@ func (s *Store) GetTransactionsByAccount(accountID int64, limit int) ([]*model.T
 		limit = 100
 	}
 
-	rows, err := s.db.Query(`
+	rows, err := s.db.QueryContext(context.Background(), `
         SELECT DISTINCT t.id, t.timestamp, t.description, t.status, t.external_id, t.type
         FROM transactions t
         INNER JOIN splits s ON t.id = s.transaction_id
@@ -98,7 +99,7 @@ func (s *Store) GetTransactionsByAccount(accountID int64, limit int) ([]*model.T
 }
 
 func (s *Store) GetTransactionsByDateRange(startTime, endTime int64) ([]*model.Transaction, error) {
-	rows, err := s.db.Query(`
+	rows, err := s.db.QueryContext(context.Background(), `
         SELECT id, timestamp, description, status, external_id, type
         FROM transactions
         WHERE timestamp >= ? AND timestamp <= ?
@@ -119,7 +120,7 @@ func (s *Store) GetAllTransactions(limit int) ([]*model.Transaction, error) {
 		limit = 100
 	}
 
-	rows, err := s.db.Query(`
+	rows, err := s.db.QueryContext(context.Background(), `
         SELECT id, timestamp, description, status, external_id, type
         FROM transactions
         ORDER BY timestamp DESC, id DESC
@@ -136,7 +137,7 @@ func (s *Store) GetAllTransactions(limit int) ([]*model.Transaction, error) {
 }
 
 func (s *Store) UpdateTransactionStatus(txID int64, status model.TransactionStatus) error {
-	result, err := s.db.Exec(`
+	result, err := s.db.ExecContext(context.Background(), `
         UPDATE transactions
         SET status = ?
         WHERE id = ?
@@ -158,7 +159,7 @@ func (s *Store) UpdateTransactionStatus(txID int64, status model.TransactionStat
 }
 
 func (s *Store) DeleteTransaction(txID int64) error {
-	result, err := s.db.Exec(`
+	result, err := s.db.ExecContext(context.Background(), `
         DELETE FROM transactions
         WHERE id = ?
     `, txID)
@@ -179,7 +180,7 @@ func (s *Store) DeleteTransaction(txID int64) error {
 }
 
 func (s *Store) UpdateTransactionBasic(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error {
-	result, err := s.db.Exec(`
+	result, err := s.db.ExecContext(context.Background(), `
         UPDATE transactions
         SET description = ?, timestamp = ?, status = ?, type = ?
         WHERE id = ?
@@ -201,7 +202,7 @@ func (s *Store) UpdateTransactionBasic(txID int64, description string, timestamp
 }
 
 func (s *Store) UpdateSplit(splitID int64, accountID int64, amount int64, currency string, memo string) error {
-	result, err := s.db.Exec(`
+	result, err := s.db.ExecContext(context.Background(), `
         UPDATE splits
         SET account_id = ?, amount = ?, currency = ?, memo = ?
         WHERE id = ?
@@ -223,7 +224,7 @@ func (s *Store) UpdateSplit(splitID int64, accountID int64, amount int64, curren
 }
 
 func (s *Store) DeleteSplit(splitID int64) error {
-	result, err := s.db.Exec(`
+	result, err := s.db.ExecContext(context.Background(), `
         DELETE FROM splits
         WHERE id = ?
     `, splitID)
@@ -244,7 +245,7 @@ func (s *Store) DeleteSplit(splitID int64) error {
 }
 
 func (s *Store) CreateSplit(txID int64, split *model.Split) (int64, error) {
-	result, err := s.db.Exec(`
+	result, err := s.db.ExecContext(context.Background(), `
         INSERT INTO splits (transaction_id, account_id, amount, currency, memo)
         VALUES (?, ?, ?, ?, ?)
     `, txID, split.AccountID, split.Amount, split.Currency, split.Memo)
@@ -261,7 +262,7 @@ func (s *Store) CreateSplit(txID int64, split *model.Split) (int64, error) {
 }
 
 func (s *Store) GetSplitsByTransaction(txID int64) ([]*model.Split, error) {
-	rows, err := s.db.Query(`
+	rows, err := s.db.QueryContext(context.Background(), `
         SELECT id, transaction_id, account_id, amount, currency, memo
         FROM splits
         WHERE transaction_id = ?
@@ -295,7 +296,7 @@ func (s *Store) GetSplitsByTransaction(txID int64) ([]*model.Split, error) {
 }
 
 func (s *Store) GetSplitsWithAccountsByDateRange(startTime, endTime int64) (map[int64][]model.SplitDetail, error) {
-	rows, err := s.db.Query(`
+	rows, err := s.db.QueryContext(context.Background(), `
         SELECT
             s.id, s.transaction_id, s.account_id, s.amount, s.currency, s.memo,
             a.name, a.type
@@ -329,7 +330,7 @@ func (s *Store) GetSplitsWithAccountsByDateRange(startTime, endTime int64) (map[
 }
 
 func (s *Store) GetSplitsWithAccountsByTransaction(txID int64) ([]model.SplitDetail, error) {
-	rows, err := s.db.Query(`
+	rows, err := s.db.QueryContext(context.Background(), `
         SELECT
             s.id, s.account_id, s.amount, s.currency, s.memo,
             a.name, a.type

--- a/internal/store/sqlite_transaction.go
+++ b/internal/store/sqlite_transaction.go
@@ -12,8 +12,8 @@ import (
 
 // CreateTransactionWithSplits inserts a transaction and its splits.
 // It relies on the caller (Service layer) to wrap it in ExecTx for atomicity.
-func (s *Store) CreateTransactionWithSplits(tx model.Transaction, splits []model.Split) (int64, error) {
-	stmtTx, err := s.db.PrepareContext(context.Background(), `
+func (s *Store) CreateTransactionWithSplits(ctx context.Context, tx model.Transaction, splits []model.Split) (int64, error) {
+	stmtTx, err := s.db.PrepareContext(ctx, `
         INSERT INTO transactions (timestamp, description, status, external_id, type)
         VALUES (?, ?, ?, ?, ?)
         RETURNING id;
@@ -26,7 +26,7 @@ func (s *Store) CreateTransactionWithSplits(tx model.Transaction, splits []model
 	}()
 
 	var newTxID int64
-	err = stmtTx.QueryRowContext(context.Background(), tx.Timestamp, tx.Description, tx.Status, tx.ExternalID, tx.Type).Scan(&newTxID)
+	err = stmtTx.QueryRowContext(ctx, tx.Timestamp, tx.Description, tx.Status, tx.ExternalID, tx.Type).Scan(&newTxID)
 
 	if err != nil {
 		var sqliteErr sqlite.Error
@@ -38,7 +38,7 @@ func (s *Store) CreateTransactionWithSplits(tx model.Transaction, splits []model
 		return 0, fmt.Errorf("failed to insert transaction: %w", err)
 	}
 
-	stmtSplit, err := s.db.PrepareContext(context.Background(), `
+	stmtSplit, err := s.db.PrepareContext(ctx, `
         INSERT INTO splits (transaction_id, account_id, amount, currency, memo)
         VALUES (?, ?, ?, ?, ?);
     `)
@@ -50,7 +50,7 @@ func (s *Store) CreateTransactionWithSplits(tx model.Transaction, splits []model
 	}()
 
 	for _, split := range splits {
-		_, err := stmtSplit.ExecContext(context.Background(), newTxID, split.AccountID, split.Amount, split.Currency, split.Memo)
+		_, err := stmtSplit.ExecContext(ctx, newTxID, split.AccountID, split.Amount, split.Currency, split.Memo)
 		if err != nil {
 			return 0, fmt.Errorf("failed to insert split (account_id: %d): %w", split.AccountID, err)
 		}
@@ -59,9 +59,9 @@ func (s *Store) CreateTransactionWithSplits(tx model.Transaction, splits []model
 	return newTxID, nil
 }
 
-func (s *Store) GetTransactionByID(txID int64) (*model.Transaction, error) {
+func (s *Store) GetTransactionByID(ctx context.Context, txID int64) (*model.Transaction, error) {
 	var tx model.Transaction
-	err := s.db.QueryRowContext(context.Background(), `
+	err := s.db.QueryRowContext(ctx, `
         SELECT id, timestamp, description, status, external_id, type
         FROM transactions
         WHERE id = ?
@@ -75,12 +75,12 @@ func (s *Store) GetTransactionByID(txID int64) (*model.Transaction, error) {
 	return &tx, nil
 }
 
-func (s *Store) GetTransactionsByAccount(accountID int64, limit int) ([]*model.Transaction, error) {
+func (s *Store) GetTransactionsByAccount(ctx context.Context, accountID int64, limit int) ([]*model.Transaction, error) {
 	if limit <= 0 {
 		limit = 100
 	}
 
-	rows, err := s.db.QueryContext(context.Background(), `
+	rows, err := s.db.QueryContext(ctx, `
         SELECT DISTINCT t.id, t.timestamp, t.description, t.status, t.external_id, t.type
         FROM transactions t
         INNER JOIN splits s ON t.id = s.transaction_id
@@ -98,8 +98,8 @@ func (s *Store) GetTransactionsByAccount(accountID int64, limit int) ([]*model.T
 	return s.scanTransactions(rows)
 }
 
-func (s *Store) GetTransactionsByDateRange(startTime, endTime int64) ([]*model.Transaction, error) {
-	rows, err := s.db.QueryContext(context.Background(), `
+func (s *Store) GetTransactionsByDateRange(ctx context.Context, startTime, endTime int64) ([]*model.Transaction, error) {
+	rows, err := s.db.QueryContext(ctx, `
         SELECT id, timestamp, description, status, external_id, type
         FROM transactions
         WHERE timestamp >= ? AND timestamp <= ?
@@ -115,12 +115,12 @@ func (s *Store) GetTransactionsByDateRange(startTime, endTime int64) ([]*model.T
 	return s.scanTransactions(rows)
 }
 
-func (s *Store) GetAllTransactions(limit int) ([]*model.Transaction, error) {
+func (s *Store) GetAllTransactions(ctx context.Context, limit int) ([]*model.Transaction, error) {
 	if limit <= 0 {
 		limit = 100
 	}
 
-	rows, err := s.db.QueryContext(context.Background(), `
+	rows, err := s.db.QueryContext(ctx, `
         SELECT id, timestamp, description, status, external_id, type
         FROM transactions
         ORDER BY timestamp DESC, id DESC
@@ -136,8 +136,8 @@ func (s *Store) GetAllTransactions(limit int) ([]*model.Transaction, error) {
 	return s.scanTransactions(rows)
 }
 
-func (s *Store) UpdateTransactionStatus(txID int64, status model.TransactionStatus) error {
-	result, err := s.db.ExecContext(context.Background(), `
+func (s *Store) UpdateTransactionStatus(ctx context.Context, txID int64, status model.TransactionStatus) error {
+	result, err := s.db.ExecContext(ctx, `
         UPDATE transactions
         SET status = ?
         WHERE id = ?
@@ -158,8 +158,8 @@ func (s *Store) UpdateTransactionStatus(txID int64, status model.TransactionStat
 	return nil
 }
 
-func (s *Store) DeleteTransaction(txID int64) error {
-	result, err := s.db.ExecContext(context.Background(), `
+func (s *Store) DeleteTransaction(ctx context.Context, txID int64) error {
+	result, err := s.db.ExecContext(ctx, `
         DELETE FROM transactions
         WHERE id = ?
     `, txID)
@@ -179,8 +179,8 @@ func (s *Store) DeleteTransaction(txID int64) error {
 	return nil
 }
 
-func (s *Store) UpdateTransactionBasic(txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error {
-	result, err := s.db.ExecContext(context.Background(), `
+func (s *Store) UpdateTransactionBasic(ctx context.Context, txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error {
+	result, err := s.db.ExecContext(ctx, `
         UPDATE transactions
         SET description = ?, timestamp = ?, status = ?, type = ?
         WHERE id = ?
@@ -201,8 +201,8 @@ func (s *Store) UpdateTransactionBasic(txID int64, description string, timestamp
 	return nil
 }
 
-func (s *Store) UpdateSplit(splitID int64, accountID int64, amount int64, currency string, memo string) error {
-	result, err := s.db.ExecContext(context.Background(), `
+func (s *Store) UpdateSplit(ctx context.Context, splitID int64, accountID int64, amount int64, currency string, memo string) error {
+	result, err := s.db.ExecContext(ctx, `
         UPDATE splits
         SET account_id = ?, amount = ?, currency = ?, memo = ?
         WHERE id = ?
@@ -223,8 +223,8 @@ func (s *Store) UpdateSplit(splitID int64, accountID int64, amount int64, curren
 	return nil
 }
 
-func (s *Store) DeleteSplit(splitID int64) error {
-	result, err := s.db.ExecContext(context.Background(), `
+func (s *Store) DeleteSplit(ctx context.Context, splitID int64) error {
+	result, err := s.db.ExecContext(ctx, `
         DELETE FROM splits
         WHERE id = ?
     `, splitID)
@@ -244,8 +244,8 @@ func (s *Store) DeleteSplit(splitID int64) error {
 	return nil
 }
 
-func (s *Store) CreateSplit(txID int64, split *model.Split) (int64, error) {
-	result, err := s.db.ExecContext(context.Background(), `
+func (s *Store) CreateSplit(ctx context.Context, txID int64, split *model.Split) (int64, error) {
+	result, err := s.db.ExecContext(ctx, `
         INSERT INTO splits (transaction_id, account_id, amount, currency, memo)
         VALUES (?, ?, ?, ?, ?)
     `, txID, split.AccountID, split.Amount, split.Currency, split.Memo)
@@ -261,8 +261,8 @@ func (s *Store) CreateSplit(txID int64, split *model.Split) (int64, error) {
 	return splitID, nil
 }
 
-func (s *Store) GetSplitsByTransaction(txID int64) ([]*model.Split, error) {
-	rows, err := s.db.QueryContext(context.Background(), `
+func (s *Store) GetSplitsByTransaction(ctx context.Context, txID int64) ([]*model.Split, error) {
+	rows, err := s.db.QueryContext(ctx, `
         SELECT id, transaction_id, account_id, amount, currency, memo
         FROM splits
         WHERE transaction_id = ?
@@ -295,8 +295,8 @@ func (s *Store) GetSplitsByTransaction(txID int64) ([]*model.Split, error) {
 	return splits, rows.Err()
 }
 
-func (s *Store) GetSplitsWithAccountsByDateRange(startTime, endTime int64) (map[int64][]model.SplitDetail, error) {
-	rows, err := s.db.QueryContext(context.Background(), `
+func (s *Store) GetSplitsWithAccountsByDateRange(ctx context.Context, startTime, endTime int64) (map[int64][]model.SplitDetail, error) {
+	rows, err := s.db.QueryContext(ctx, `
         SELECT
             s.id, s.transaction_id, s.account_id, s.amount, s.currency, s.memo,
             a.name, a.type
@@ -329,8 +329,8 @@ func (s *Store) GetSplitsWithAccountsByDateRange(startTime, endTime int64) (map[
 	return result, nil
 }
 
-func (s *Store) GetSplitsWithAccountsByTransaction(txID int64) ([]model.SplitDetail, error) {
-	rows, err := s.db.QueryContext(context.Background(), `
+func (s *Store) GetSplitsWithAccountsByTransaction(ctx context.Context, txID int64) ([]model.SplitDetail, error) {
+	rows, err := s.db.QueryContext(ctx, `
         SELECT
             s.id, s.account_id, s.amount, s.currency, s.memo,
             a.name, a.type


### PR DESCRIPTION
## Summary

- Threads `context.Context` as the first parameter through every DB-touching method across the store, repository interface, service, and cmd layers, enabling per-request cancellation, timeouts, and graceful shutdown.
- `DBTX` interface switched to `*Context` variants (`ExecContext`, `QueryContext`, `QueryRowContext`, `PrepareContext`); ctx propagates from `cmd.Context()` at each Cobra `RunE` down through runner methods, action helpers, service calls, and into `database/sql` calls. `initSysAcc`/`migrateLegacySysAcc` use `context.Background()` since they run pre-`rootCmd.Execute()`.
- Bottom-up mechanical sweep landed in two commits: an internal-only DBTX swap (5081f9a, compile-safe checkpoint) and the full ctx threading across 44 files.

Closes #37.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all packages pass
- [x] `go vet ./...` clean across non-test code
- [ ] Manual smoke test of common CLI flows (`kea account create`, `kea add`, `kea report`, `kea reconcile`, `kea transaction list/edit/delete`)
- [ ] Confirm Ctrl+C interrupt during a long-running command propagates cancellation cleanly

## Notes

- Drive-by: dropped the unused `rootName` parameter from `createRunner.applyTypeSettings` (it was already unreferenced).
- Atomicity bug in `CreateAccountWithBalance` (#29) is intentionally NOT addressed here — `createOpeningBalance` keeps its own `ExecTx`. That fix belongs in its own PR.
- Plan document committed at [docs/superpowers/plans/2026-04-28-context-threading.md](docs/superpowers/plans/2026-04-28-context-threading.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)