### PR TITLE
fix: group report totals by currency (issue #47)

### DIFF
--- a/cmd/report_actions.go
+++ b/cmd/report_actions.go
@@ -57,8 +57,8 @@ func (r *reportRunner) runIncomeStatement(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to fetch net worth for previous period: %w", err)
 	}
-	result.PreviousNetWorth = &previousNetWorth
-	result.NetWorthGrowthPct = computeNetWorthGrowthPct(currentNetWorth, previousNetWorth)
+	result.PreviousNetWorth = previousNetWorth
+	result.NetWorthGrowthPct = computeNetWorthGrowthPctMap(currentNetWorth, previousNetWorth)
 
 	return r.view.RenderIncomeStatement(result)
 }
@@ -191,12 +191,24 @@ func previousPeriodRange(startTime, endTime int64) (prevStart, prevEnd int64) {
 	return
 }
 
-// computeNetWorthGrowthPct returns growth percentage; nil means N/A (previous is zero).
-func computeNetWorthGrowthPct(current, previous int64) *float64 {
-	if previous == 0 {
-		return nil
+// computeNetWorthGrowthPctMap returns per-currency growth percentages; currencies with a
+// zero previous value are omitted (N/A).
+func computeNetWorthGrowthPctMap(current, previous map[string]int64) map[string]float64 {
+	result := map[string]float64{}
+	allCurrencies := map[string]struct{}{}
+	for ccy := range current {
+		allCurrencies[ccy] = struct{}{}
 	}
-
-	growth := (float64(current-previous) / float64(utils.AbsInt64(previous))) * 100
-	return &growth
+	for ccy := range previous {
+		allCurrencies[ccy] = struct{}{}
+	}
+	for ccy := range allCurrencies {
+		prev := previous[ccy]
+		if prev == 0 {
+			continue
+		}
+		cur := current[ccy]
+		result[ccy] = (float64(cur-prev) / float64(utils.AbsInt64(prev))) * 100
+	}
+	return result
 }

--- a/cmd/report_types.go
+++ b/cmd/report_types.go
@@ -24,7 +24,7 @@ type ReportProvider interface {
 	GenerateIncomeBreakdown(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error)
 	GenerateExpenseBreakdown(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error)
 	GenerateBalanceSheet(ctx context.Context, asOf int64) (*model.BalanceSheetResult, error)
-	GetNetWorthAt(ctx context.Context, endTime int64) (int64, error)
+	GetNetWorthAt(ctx context.Context, endTime int64) (map[string]int64, error)
 }
 
 // ReportView is the view interface used to render report output.

--- a/docs/superpowers/plans/2026-05-08-fix-cross-currency-report-totals.md
+++ b/docs/superpowers/plans/2026-05-08-fix-cross-currency-report-totals.md
@@ -1,0 +1,794 @@
+# Fix Cross-Currency Report Totals — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop reports from summing amounts across different currencies into a single misleading total. Group totals by currency so multi-currency ledgers produce financially valid output.
+
+**Architecture:** Replace scalar total fields (`TotalIncome int64`, etc.) with `map[string]int64` keyed by currency code. Each report method aggregates per-currency. The UI and JSON rendering layers iterate the map to display one total line per currency. `GetNetWorthAt` returns a map too. The single `Currency string` field on result structs becomes unnecessary for totals (kept only for backward compat in JSON where needed, or removed).
+
+**Tech Stack:** Go, existing mock-based white-box tests in `internal/service`, pterm/tablewriter UI in `ui/views`.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `internal/model/report.go` | Modify | Change total fields from `int64` → `map[string]int64`; remove top-level `Currency` field from result structs |
+| `internal/service/report_service.go` | Modify | Aggregate totals per currency in all report methods + `GetNetWorthAt` |
+| `internal/service/report_service_test.go` | Modify | Add multi-currency test cases; update existing assertions for new types |
+| `cmd/report_types.go` | Modify | Update `ReportProvider` interface for new `GetNetWorthAt` return type |
+| `cmd/report_actions.go` | Modify | Adapt net-worth growth calculation for per-currency maps |
+| `ui/views/report.go` | Modify | Render per-currency total lines in tables |
+| `ui/views/report_json.go` | Modify | Update JSON DTOs to expose per-currency totals |
+
+---
+
+### Task 1: Update Model Structs
+
+**Files:**
+- Modify: `internal/model/report.go`
+
+- [ ] **Step 1: Change `ReportResult` total fields to per-currency maps and remove `Currency`**
+
+```go
+type ReportResult struct {
+	Period            string            `json:"period"`
+	TotalIncome       map[string]int64  `json:"total_income"`
+	TotalExpense      map[string]int64  `json:"total_expense"`
+	NetAmount         map[string]int64  `json:"net_amount"`
+	NetWorth          map[string]int64  `json:"net_worth"`
+	PreviousNetWorth  map[string]int64  `json:"previous_net_worth"`
+	NetWorthGrowthPct map[string]float64 `json:"net_worth_growth_pct"`
+	IncomeRows        []ReportRow       `json:"income_rows"`
+	ExpenseRows       []ReportRow       `json:"expense_rows"`
+}
+```
+
+- [ ] **Step 2: Change `BalanceSheetResult` total fields to per-currency maps and remove `Currency`**
+
+```go
+type BalanceSheetResult struct {
+	Assets           []ReportRow      `json:"assets"`
+	Liabilities      []ReportRow      `json:"liabilities"`
+	Equity           []ReportRow      `json:"equity"`
+	TotalAssets      map[string]int64 `json:"total_assets"`
+	TotalLiabilities map[string]int64 `json:"total_liabilities"`
+	TotalEquity      map[string]int64 `json:"total_equity"`
+	NetWorth         map[string]int64 `json:"net_worth"`
+	AsOf             int64            `json:"as_of"`
+}
+```
+
+- [ ] **Step 3: Verify the project does NOT compile (expected — dependents reference old types)**
+
+Run: `go build ./... 2>&1 | head -30`
+Expected: compile errors in `report_service.go`, `report_actions.go`, `ui/views/report.go`, `ui/views/report_json.go`, tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/model/report.go
+git commit -m "refactor: change report total fields to per-currency maps"
+```
+
+---
+
+### Task 2: Update Service — `GetNetWorthAt`
+
+**Files:**
+- Modify: `internal/service/report_service.go:15-34`
+- Test: `internal/service/report_service_test.go`
+
+- [ ] **Step 1: Write failing multi-currency test for `GetNetWorthAt`**
+
+Add this test to `report_service_test.go` inside `TestGetNetWorthAt`:
+
+```go
+t.Run("multi-currency keeps totals separate", func(t *testing.T) {
+	txRepo := newMockTransactionRepo()
+	addTxSplits(txRepo.splitsWithAccts, 1,
+		model.SplitDetail{AccountName: "Assets:USD_Bank", AccountType: model.AccountTypeAsset, Amount: 10000, Currency: "USD"},
+		model.SplitDetail{AccountName: "Equity:Opening_USD", AccountType: model.AccountTypeEquity, Amount: -10000, Currency: "USD"},
+	)
+	addTxSplits(txRepo.splitsWithAccts, 2,
+		model.SplitDetail{AccountName: "Assets:TWD_Bank", AccountType: model.AccountTypeAsset, Amount: 50000, Currency: "TWD"},
+		model.SplitDetail{AccountName: "Equity:Opening_TWD", AccountType: model.AccountTypeEquity, Amount: -50000, Currency: "TWD"},
+	)
+	addTxSplits(txRepo.splitsWithAccts, 3,
+		model.SplitDetail{AccountName: "Liabilities:Card", AccountType: model.AccountTypeLiability, Amount: 2000, Currency: "USD"},
+		model.SplitDetail{AccountName: "Assets:USD_Bank", AccountType: model.AccountTypeAsset, Amount: -2000, Currency: "USD"},
+	)
+	svc := newTestTransactionService(newMockAccountRepo(), txRepo)
+
+	nw, err := svc.GetNetWorthAt(context.Background(), 0)
+	require.NoError(t, err)
+	// USD: assets 10000-2000=8000, liabilities 2000 → net 6000
+	assert.Equal(t, int64(6000), nw["USD"])
+	// TWD: assets 50000, liabilities 0 → net 50000
+	assert.Equal(t, int64(50000), nw["TWD"])
+	assert.Len(t, nw, 2)
+})
+```
+
+- [ ] **Step 2: Update the return type of `GetNetWorthAt` to `map[string]int64`**
+
+```go
+func (ts *TransactionService) GetNetWorthAt(ctx context.Context, endTime int64) (map[string]int64, error) {
+	txSplitsMap, err := ts.txRepo.GetSplitsWithAccountsByDateRange(ctx, 0, endTime)
+	if err != nil {
+		return nil, err
+	}
+
+	assets := map[string]int64{}
+	liabilities := map[string]int64{}
+	for _, splits := range txSplitsMap {
+		for _, split := range splits {
+			switch split.AccountType {
+			case model.AccountTypeAsset:
+				assets[split.Currency] += split.Amount
+			case model.AccountTypeLiability:
+				liabilities[split.Currency] += split.Amount
+			}
+		}
+	}
+
+	nw := map[string]int64{}
+	for ccy, amt := range assets {
+		nw[ccy] = amt - liabilities[ccy]
+	}
+	for ccy, amt := range liabilities {
+		if _, ok := nw[ccy]; !ok {
+			nw[ccy] = -amt
+		}
+	}
+	return nw, nil
+}
+```
+
+- [ ] **Step 3: Update existing `GetNetWorthAt` tests to use the new return type**
+
+All existing tests that do `worth, err := svc.GetNetWorthAt(...)` need to change. The single-currency tests used splits without a `Currency` field, so they'll aggregate under `""`. Update them to set `Currency: "USD"` on every `SplitDetail` and assert `nw["USD"]` instead of a bare `int64`.
+
+For the "assets only" test:
+```go
+t.Run("assets only", func(t *testing.T) {
+	txRepo := newMockTransactionRepo()
+	addTxSplits(txRepo.splitsWithAccts, 1,
+		model.SplitDetail{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: 10000, Currency: "USD"},
+		model.SplitDetail{AccountName: "Equity:Opening", AccountType: model.AccountTypeEquity, Amount: -10000, Currency: "USD"},
+	)
+	svc := newTestTransactionService(newMockAccountRepo(), txRepo)
+
+	nw, err := svc.GetNetWorthAt(context.Background(), 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10000), nw["USD"])
+})
+```
+
+Apply the same pattern for "assets minus liabilities", "no transactions returns zero net worth" (returns empty map), and "only income/expense splits are excluded from net worth" (returns empty map). The "repo failure" test just checks `err != nil` — no change needed beyond the return variable name.
+
+- [ ] **Step 4: Run `GetNetWorthAt` tests**
+
+Run: `go test ./internal/service/ -run TestGetNetWorthAt -v`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/report_service.go internal/service/report_service_test.go
+git commit -m "refactor: GetNetWorthAt returns per-currency net worth map"
+```
+
+---
+
+### Task 3: Update Service — Income Statement and Breakdowns
+
+**Files:**
+- Modify: `internal/service/report_service.go:110-175`
+- Test: `internal/service/report_service_test.go`
+
+- [ ] **Step 1: Write failing multi-currency test for `GenerateIncomeStatement`**
+
+Add to `TestGenerateIncomeStatement`:
+
+```go
+t.Run("multi-currency totals are grouped by currency", func(t *testing.T) {
+	txRepo := newMockTransactionRepo()
+	addTxSplits(txRepo.splitsWithAccts, 1,
+		model.SplitDetail{AccountName: "Revenue:Salary", AccountType: model.AccountTypeRevenue, Amount: -3000, Currency: "USD"},
+		model.SplitDetail{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: 3000, Currency: "USD"},
+	)
+	addTxSplits(txRepo.splitsWithAccts, 2,
+		model.SplitDetail{AccountName: "Revenue:Freelance", AccountType: model.AccountTypeRevenue, Amount: -90000, Currency: "TWD"},
+		model.SplitDetail{AccountName: "Assets:TWD_Bank", AccountType: model.AccountTypeAsset, Amount: 90000, Currency: "TWD"},
+	)
+	addTxSplits(txRepo.splitsWithAccts, 3,
+		model.SplitDetail{AccountName: "Expenses:Food", AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
+		model.SplitDetail{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"},
+	)
+	txRepo.addTransaction(&model.Transaction{ID: 1, Type: model.TxTypeIncome}, nil)
+	txRepo.addTransaction(&model.Transaction{ID: 2, Type: model.TxTypeIncome}, nil)
+	txRepo.addTransaction(&model.Transaction{ID: 3, Type: model.TxTypeExpense}, nil)
+	svc := newTestTransactionService(newMockAccountRepo(), txRepo)
+
+	result, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3000), result.TotalIncome["USD"])
+	assert.Equal(t, int64(90000), result.TotalIncome["TWD"])
+	assert.Equal(t, int64(500), result.TotalExpense["USD"])
+	assert.Equal(t, int64(2500), result.NetAmount["USD"])   // 3000 - 500
+	assert.Equal(t, int64(90000), result.NetAmount["TWD"])   // 90000 - 0
+})
+```
+
+- [ ] **Step 2: Update `GenerateIncomeStatement` to aggregate per currency**
+
+```go
+func (ts *TransactionService) GenerateIncomeStatement(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error) {
+	incomeByAccount, expenseByAccount, err := ts.buildReportMaps(ctx, startTime, endTime, true, true)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &model.ReportResult{
+		TotalIncome:  map[string]int64{},
+		TotalExpense: map[string]int64{},
+		NetAmount:    map[string]int64{},
+		IncomeRows:   rowsFromMap(incomeByAccount),
+		ExpenseRows:  rowsFromMap(expenseByAccount),
+	}
+	for _, r := range result.IncomeRows {
+		result.TotalIncome[r.Currency] += r.Amount
+	}
+	for _, r := range result.ExpenseRows {
+		result.TotalExpense[r.Currency] += r.Amount
+	}
+	for ccy, inc := range result.TotalIncome {
+		result.NetAmount[ccy] = inc - result.TotalExpense[ccy]
+	}
+	for ccy, exp := range result.TotalExpense {
+		if _, ok := result.NetAmount[ccy]; !ok {
+			result.NetAmount[ccy] = -exp
+		}
+	}
+
+	return result, nil
+}
+```
+
+- [ ] **Step 3: Update `GenerateIncomeBreakdown` and `GenerateExpenseBreakdown`**
+
+`GenerateIncomeBreakdown`:
+```go
+func (ts *TransactionService) GenerateIncomeBreakdown(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error) {
+	incomeByAccount, _, err := ts.buildReportMaps(ctx, startTime, endTime, true, false)
+	if err != nil {
+		return nil, err
+	}
+
+	rows := rowsFromMap(incomeByAccount)
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Amount > rows[j].Amount })
+
+	total := map[string]int64{}
+	for _, r := range rows {
+		total[r.Currency] += r.Amount
+	}
+
+	return &model.ReportResult{
+		IncomeRows:  rows,
+		TotalIncome: total,
+	}, nil
+}
+```
+
+`GenerateExpenseBreakdown`:
+```go
+func (ts *TransactionService) GenerateExpenseBreakdown(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error) {
+	_, expenseByAccount, err := ts.buildReportMaps(ctx, startTime, endTime, false, true)
+	if err != nil {
+		return nil, err
+	}
+
+	rows := rowsFromMap(expenseByAccount)
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Amount > rows[j].Amount })
+
+	total := map[string]int64{}
+	for _, r := range rows {
+		total[r.Currency] += r.Amount
+	}
+
+	return &model.ReportResult{
+		ExpenseRows:  rows,
+		TotalExpense: total,
+	}, nil
+}
+```
+
+- [ ] **Step 4: Update all existing income/expense tests for new map types**
+
+Every assertion like `assert.Equal(t, int64(2000), result.TotalIncome)` must change to `assert.Equal(t, int64(2000), result.TotalIncome["USD"])`. Set `Currency: "USD"` on every `SplitDetail` in existing tests (use `model.SplitDetail{...}` struct literal form — not the `split()` helper if it doesn't support currency). The "empty data" test should assert `assert.Empty(t, result.TotalIncome)`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./internal/service/ -run "TestGenerateIncomeStatement|TestGenerateIncomeBreakdown|TestGenerateExpenseBreakdown" -v`
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/service/report_service.go internal/service/report_service_test.go
+git commit -m "refactor: income/expense reports aggregate totals per currency"
+```
+
+---
+
+### Task 4: Update Service — Balance Sheet
+
+**Files:**
+- Modify: `internal/service/report_service.go:177-238`
+- Test: `internal/service/report_service_test.go`
+
+- [ ] **Step 1: Write failing multi-currency test for `GenerateBalanceSheet`**
+
+Add to `TestGenerateBalanceSheet`:
+
+```go
+t.Run("multi-currency totals are grouped by currency", func(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:USD_Bank", Type: model.AccountTypeAsset, Currency: "USD"})
+	accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:TWD_Bank", Type: model.AccountTypeAsset, Currency: "TWD"})
+	accRepo.addAccount(&model.Account{ID: 3, Name: "Liabilities:Card", Type: model.AccountTypeLiability, Currency: "USD"})
+	accRepo.balances[1] = 10000
+	accRepo.balances[2] = 50000
+	accRepo.balances[3] = 3000
+	svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+	result, err := svc.GenerateBalanceSheet(context.Background(), 9999999999)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10000), result.TotalAssets["USD"])
+	assert.Equal(t, int64(50000), result.TotalAssets["TWD"])
+	assert.Equal(t, int64(3000), result.TotalLiabilities["USD"])
+	assert.Equal(t, int64(7000), result.NetWorth["USD"])   // 10000 - 3000
+	assert.Equal(t, int64(50000), result.NetWorth["TWD"])  // 50000 - 0
+})
+```
+
+- [ ] **Step 2: Update `GenerateBalanceSheet` to aggregate per currency**
+
+```go
+func (ts *TransactionService) GenerateBalanceSheet(ctx context.Context, asOf int64) (*model.BalanceSheetResult, error) {
+	allAccounts, err := ts.accRepo.GetAllAccounts(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	balances, err := ts.accRepo.GetAllAccountBalances(ctx, asOf)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &model.BalanceSheetResult{
+		AsOf:             asOf,
+		TotalAssets:      map[string]int64{},
+		TotalLiabilities: map[string]int64{},
+		TotalEquity:      map[string]int64{},
+		NetWorth:         map[string]int64{},
+	}
+
+	for _, acc := range allAccounts {
+		balance := balances[acc.ID]
+		if balance == 0 {
+			continue
+		}
+
+		currency := acc.Currency
+		if currency == "" {
+			currency = ts.config.Defaults.Currency
+		}
+
+		row := model.ReportRow{
+			AccountName: acc.Name,
+			Amount:      balance,
+			Currency:    currency,
+		}
+
+		switch acc.Type {
+		case model.AccountTypeAsset:
+			result.Assets = append(result.Assets, row)
+			result.TotalAssets[currency] += balance
+		case model.AccountTypeLiability:
+			result.Liabilities = append(result.Liabilities, row)
+			result.TotalLiabilities[currency] += balance
+		case model.AccountTypeEquity:
+			result.Equity = append(result.Equity, row)
+			result.TotalEquity[currency] += balance
+		}
+	}
+
+	for ccy, assets := range result.TotalAssets {
+		result.NetWorth[ccy] = assets - result.TotalLiabilities[ccy]
+	}
+	for ccy, liab := range result.TotalLiabilities {
+		if _, ok := result.NetWorth[ccy]; !ok {
+			result.NetWorth[ccy] = -liab
+		}
+	}
+
+	sort.Slice(result.Assets, func(i, j int) bool {
+		return result.Assets[i].Amount > result.Assets[j].Amount
+	})
+	sort.Slice(result.Liabilities, func(i, j int) bool {
+		return result.Liabilities[i].Amount > result.Liabilities[j].Amount
+	})
+	sort.Slice(result.Equity, func(i, j int) bool {
+		return result.Equity[i].Amount > result.Equity[j].Amount
+	})
+
+	return result, nil
+}
+```
+
+- [ ] **Step 3: Update existing balance sheet tests for new map types**
+
+Change `assert.Equal(t, int64(10000), result.TotalAssets)` → `assert.Equal(t, int64(10000), result.TotalAssets["USD"])`, etc. For accounts without explicit `Currency`, the service falls back to config default `"USD"`, so assertions key on `"USD"`. The `Currency` assertion test (`"account with custom currency uses account currency"`) now only checks the row-level `Currency` field (unchanged). Remove any assertion on `result.Currency` since the field no longer exists.
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/service/ -run TestGenerateBalanceSheet -v`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/report_service.go internal/service/report_service_test.go
+git commit -m "refactor: balance sheet aggregates totals per currency"
+```
+
+---
+
+### Task 5: Update `ReportProvider` Interface and `report_actions.go`
+
+**Files:**
+- Modify: `cmd/report_types.go:22-28`
+- Modify: `cmd/report_actions.go:36-64, 195-202`
+
+- [ ] **Step 1: Update `ReportProvider` interface**
+
+Change `GetNetWorthAt` return type:
+
+```go
+type ReportProvider interface {
+	GenerateIncomeStatement(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error)
+	GenerateIncomeBreakdown(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error)
+	GenerateExpenseBreakdown(ctx context.Context, startTime, endTime int64) (*model.ReportResult, error)
+	GenerateBalanceSheet(ctx context.Context, asOf int64) (*model.BalanceSheetResult, error)
+	GetNetWorthAt(ctx context.Context, endTime int64) (map[string]int64, error)
+}
+```
+
+- [ ] **Step 2: Update `runIncomeStatement` to use per-currency net worth**
+
+The `result.NetWorth`, `result.PreviousNetWorth`, and `result.NetWorthGrowthPct` are now maps. Update `runIncomeStatement`:
+
+```go
+func (r *reportRunner) runIncomeStatement(ctx context.Context) error {
+	start, end, period, err := r.resolveDateRange()
+	if err != nil {
+		return err
+	}
+
+	result, err := r.provider.GenerateIncomeStatement(ctx, start, end)
+	if err != nil {
+		return fmt.Errorf("failed to generate income statement: %w", err)
+	}
+
+	result.Period = period
+
+	currentNetWorth, err := r.provider.GetNetWorthAt(ctx, end)
+	if err != nil {
+		return fmt.Errorf("failed to fetch net worth for current period: %w", err)
+	}
+	result.NetWorth = currentNetWorth
+
+	_, prevEnd := previousPeriodRange(start, end)
+	previousNetWorth, err := r.provider.GetNetWorthAt(ctx, prevEnd)
+	if err != nil {
+		return fmt.Errorf("failed to fetch net worth for previous period: %w", err)
+	}
+	result.PreviousNetWorth = previousNetWorth
+	result.NetWorthGrowthPct = computeNetWorthGrowthPctMap(currentNetWorth, previousNetWorth)
+
+	return r.view.RenderIncomeStatement(result)
+}
+```
+
+- [ ] **Step 3: Replace `computeNetWorthGrowthPct` with `computeNetWorthGrowthPctMap`**
+
+```go
+func computeNetWorthGrowthPctMap(current, previous map[string]int64) map[string]float64 {
+	result := map[string]float64{}
+	allCurrencies := map[string]struct{}{}
+	for ccy := range current {
+		allCurrencies[ccy] = struct{}{}
+	}
+	for ccy := range previous {
+		allCurrencies[ccy] = struct{}{}
+	}
+	for ccy := range allCurrencies {
+		prev := previous[ccy]
+		if prev == 0 {
+			continue
+		}
+		cur := current[ccy]
+		result[ccy] = (float64(cur-prev) / float64(utils.AbsInt64(prev))) * 100
+	}
+	return result
+}
+```
+
+Remove the old `computeNetWorthGrowthPct` function.
+
+- [ ] **Step 4: Verify project compiles (excluding UI)**
+
+Run: `go build ./cmd/... 2>&1 | head -20`
+Expected: compile errors only from `ui/views/` (the render functions still reference old types). The `cmd` package should compile after this step — if not, fix remaining references.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/report_types.go cmd/report_actions.go
+git commit -m "refactor: update ReportProvider and report_actions for per-currency totals"
+```
+
+---
+
+### Task 6: Update UI — Table Rendering
+
+**Files:**
+- Modify: `ui/views/report.go`
+
+- [ ] **Step 1: Add a helper to render per-currency summary lines**
+
+Add this helper at the bottom of `report.go`:
+
+```go
+func (v *ReportView) renderPerCurrencyTotals(label string, totals map[string]int64, colorFn func(string) string) {
+	currencies := sortedKeys(totals)
+	for _, ccy := range currencies {
+		amt := totals[ccy]
+		v.renderSummaryLine(label, colorFn(utils.FormatAmount(amt)), ccy)
+	}
+}
+
+func sortedKeys(m map[string]int64) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+```
+
+Add `"sort"` to the imports.
+
+- [ ] **Step 2: Update `RenderIncomeStatement`**
+
+Replace the summary section (after the expense table) with:
+
+```go
+// Summary
+v.renderPerCurrencyTotals("Total Income", result.TotalIncome, pterm.Green)
+v.renderPerCurrencyTotals("Total Expenses", result.TotalExpense, pterm.Red)
+
+for _, ccy := range sortedKeys(result.NetAmount) {
+	net := result.NetAmount[ccy]
+	netStr := utils.FormatAmount(utils.AbsInt64(net))
+	if net >= 0 {
+		v.renderSummaryLine("Net", pterm.Green(netStr), ccy)
+	} else {
+		v.renderSummaryLine("Net", pterm.Red("-"+netStr), ccy)
+	}
+}
+
+for _, ccy := range sortedKeys(result.NetWorth) {
+	nw := result.NetWorth[ccy]
+	nwStr := utils.FormatAmount(utils.AbsInt64(nw))
+	if nw >= 0 {
+		v.renderSummaryLine("Net Worth", pterm.Green(nwStr), ccy)
+	} else {
+		v.renderSummaryLine("Net Worth", pterm.Red("-"+nwStr), ccy)
+	}
+}
+
+growthCurrencies := make([]string, 0, len(result.NetWorthGrowthPct))
+for ccy := range result.NetWorthGrowthPct {
+	growthCurrencies = append(growthCurrencies, ccy)
+}
+sort.Strings(growthCurrencies)
+
+if len(growthCurrencies) == 0 {
+	v.renderSummaryLineNoCurrency("Net Worth Growth", "N/A")
+} else {
+	for _, ccy := range growthCurrencies {
+		pct := result.NetWorthGrowthPct[ccy]
+		pctText := fmt.Sprintf("%+.2f%%", pct)
+		switch {
+		case pct > 0:
+			v.renderSummaryLine("Net Worth Growth", pterm.Green(pctText), ccy)
+		case pct < 0:
+			v.renderSummaryLine("Net Worth Growth", pterm.Red(pctText), ccy)
+		default:
+			v.renderSummaryLine("Net Worth Growth", pctText, ccy)
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Update `RenderExpenseBreakdown` summary**
+
+Replace the summary line:
+```go
+v.renderPerCurrencyTotals("Total Expenses", result.TotalExpense, pterm.Red)
+```
+
+- [ ] **Step 4: Update `RenderIncomeBreakdown` summary**
+
+Replace the summary line:
+```go
+v.renderPerCurrencyTotals("Total Income", result.TotalIncome, pterm.Green)
+```
+
+- [ ] **Step 5: Update `RenderBalanceSheet` summary**
+
+Replace the three summary lines at the bottom with:
+
+```go
+v.renderPerCurrencyTotals("Total Assets", result.TotalAssets, pterm.Green)
+v.renderPerCurrencyTotals("Total Liabilities", result.TotalLiabilities, pterm.Red)
+
+for _, ccy := range sortedKeys(result.NetWorth) {
+	nw := result.NetWorth[ccy]
+	nwStr := utils.FormatAmount(utils.AbsInt64(nw))
+	if nw >= 0 {
+		v.renderSummaryLine("Net Worth", pterm.Green(nwStr), ccy)
+	} else {
+		v.renderSummaryLine("Net Worth", pterm.Red("-"+nwStr), ccy)
+	}
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/views/report.go
+git commit -m "feat: render per-currency totals in report tables"
+```
+
+---
+
+### Task 7: Update JSON Rendering
+
+**Files:**
+- Modify: `ui/views/report_json.go`
+
+- [ ] **Step 1: Update JSON DTOs**
+
+Replace the scalar total fields with per-currency maps:
+
+```go
+type jsonReportResult struct {
+	Period            string             `json:"period"`
+	TotalIncome       map[string]float64 `json:"total_income"`
+	TotalExpense      map[string]float64 `json:"total_expense"`
+	NetAmount         map[string]float64 `json:"net_amount"`
+	NetWorth          map[string]float64 `json:"net_worth"`
+	PreviousNetWorth  map[string]float64 `json:"previous_net_worth"`
+	NetWorthGrowthPct map[string]float64 `json:"net_worth_growth_pct"`
+	IncomeRows        []jsonReportRow    `json:"income_rows"`
+	ExpenseRows       []jsonReportRow    `json:"expense_rows"`
+}
+
+type jsonBalanceSheetResult struct {
+	Assets           []jsonReportRow    `json:"assets"`
+	Liabilities      []jsonReportRow    `json:"liabilities"`
+	Equity           []jsonReportRow    `json:"equity"`
+	TotalAssets      map[string]float64 `json:"total_assets"`
+	TotalLiabilities map[string]float64 `json:"total_liabilities"`
+	TotalEquity      map[string]float64 `json:"total_equity"`
+	NetWorth         map[string]float64 `json:"net_worth"`
+	AsOf             int64              `json:"as_of"`
+}
+```
+
+- [ ] **Step 2: Add a `centsMapToUnitMap` helper**
+
+```go
+func centsMapToUnitMap(m map[string]int64) map[string]float64 {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]float64, len(m))
+	for k, v := range m {
+		out[k] = CentsToUnit(v)
+	}
+	return out
+}
+```
+
+- [ ] **Step 3: Update `toJSONReportResult`**
+
+```go
+func toJSONReportResult(r *model.ReportResult) jsonReportResult {
+	return jsonReportResult{
+		Period:            r.Period,
+		TotalIncome:       centsMapToUnitMap(r.TotalIncome),
+		TotalExpense:      centsMapToUnitMap(r.TotalExpense),
+		NetAmount:         centsMapToUnitMap(r.NetAmount),
+		NetWorth:          centsMapToUnitMap(r.NetWorth),
+		PreviousNetWorth:  centsMapToUnitMap(r.PreviousNetWorth),
+		NetWorthGrowthPct: r.NetWorthGrowthPct,
+		IncomeRows:        toJSONRows(r.IncomeRows),
+		ExpenseRows:       toJSONRows(r.ExpenseRows),
+	}
+}
+```
+
+- [ ] **Step 4: Update `toJSONBalanceSheetResult`**
+
+```go
+func toJSONBalanceSheetResult(r *model.BalanceSheetResult) jsonBalanceSheetResult {
+	return jsonBalanceSheetResult{
+		Assets:           toJSONRows(r.Assets),
+		Liabilities:      toJSONRows(r.Liabilities),
+		Equity:           toJSONRows(r.Equity),
+		TotalAssets:      centsMapToUnitMap(r.TotalAssets),
+		TotalLiabilities: centsMapToUnitMap(r.TotalLiabilities),
+		TotalEquity:      centsMapToUnitMap(r.TotalEquity),
+		NetWorth:         centsMapToUnitMap(r.NetWorth),
+		AsOf:             r.AsOf,
+	}
+}
+```
+
+- [ ] **Step 5: Build and verify**
+
+Run: `go build ./...`
+Expected: clean compile with no errors.
+
+- [ ] **Step 6: Run all tests**
+
+Run: `go test ./... -v`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ui/views/report_json.go
+git commit -m "feat: update JSON report output for per-currency totals"
+```
+
+---
+
+### Task 8: Update `report_actions_test.go` (if it exists) and Clean Up
+
+**Files:**
+- Modify: `cmd/report_actions.go` (remove old `computeNetWorthGrowthPct` if not done in Task 5)
+
+- [ ] **Step 1: Search for any remaining references to old fields**
+
+Run: `grep -rn "result\.Currency\|\.TotalAssets[^[]" --include="*.go" . | grep -v "_test.go | grep -v "\.md"`
+Expected: no matches (all code paths use per-currency maps now).
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `go test ./...`
+Expected: all pass.
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add -A
+git commit -m "chore: clean up remaining old currency field references"
+```

--- a/internal/model/report.go
+++ b/internal/model/report.go
@@ -14,27 +14,25 @@ type ReportRow struct {
 
 // ReportResult holds the result of an income statement or expense breakdown report.
 type ReportResult struct {
-	Period            string      `json:"period"`
-	TotalIncome       int64       `json:"total_income"`
-	TotalExpense      int64       `json:"total_expense"`
-	NetAmount         int64       `json:"net_amount"`
-	NetWorth          int64       `json:"net_worth"` // cumulative net worth (assets - liabilities) at report time
-	PreviousNetWorth  *int64      `json:"previous_net_worth"`
-	NetWorthGrowthPct *float64    `json:"net_worth_growth_pct"`
-	Currency          string      `json:"currency"`
-	IncomeRows        []ReportRow `json:"income_rows"`
-	ExpenseRows       []ReportRow `json:"expense_rows"`
+	Period            string             `json:"period"`
+	TotalIncome       map[string]int64   `json:"total_income"`
+	TotalExpense      map[string]int64   `json:"total_expense"`
+	NetAmount         map[string]int64   `json:"net_amount"`
+	NetWorth          map[string]int64   `json:"net_worth"`
+	PreviousNetWorth  map[string]int64   `json:"previous_net_worth"`
+	NetWorthGrowthPct map[string]float64 `json:"net_worth_growth_pct"`
+	IncomeRows        []ReportRow        `json:"income_rows"`
+	ExpenseRows       []ReportRow        `json:"expense_rows"`
 }
 
 // BalanceSheetResult holds the result of a balance sheet report.
 type BalanceSheetResult struct {
-	Assets           []ReportRow `json:"assets"`
-	Liabilities      []ReportRow `json:"liabilities"`
-	Equity           []ReportRow `json:"equity"`
-	TotalAssets      int64       `json:"total_assets"`
-	TotalLiabilities int64       `json:"total_liabilities"`
-	TotalEquity      int64       `json:"total_equity"`
-	NetWorth         int64       `json:"net_worth"`
-	Currency         string      `json:"currency"`
-	AsOf             int64       `json:"as_of"` // Unix timestamp of the snapshot
+	Assets           []ReportRow      `json:"assets"`
+	Liabilities      []ReportRow      `json:"liabilities"`
+	Equity           []ReportRow      `json:"equity"`
+	TotalAssets      map[string]int64 `json:"total_assets"`
+	TotalLiabilities map[string]int64 `json:"total_liabilities"`
+	TotalEquity      map[string]int64 `json:"total_equity"`
+	NetWorth         map[string]int64 `json:"net_worth"`
+	AsOf             int64            `json:"as_of"`
 }

--- a/internal/service/report_service.go
+++ b/internal/service/report_service.go
@@ -93,7 +93,7 @@ func (ts *TransactionService) buildReportMaps(ctx context.Context, startTime, en
 			offset := offsetAccountName(details, model.AccountTypeRevenue)
 			for _, split := range details {
 				if split.AccountType == model.AccountTypeRevenue {
-					key := split.AccountName + "|" + offset
+					key := split.AccountName + "|" + offset + "|" + split.Currency
 					row := getOrCreateRowWithOffset(incomeByAccount, key, split.AccountName, offset, split.Currency)
 					row.Amount += utils.AbsInt64(split.Amount)
 					row.TxCount++
@@ -105,7 +105,7 @@ func (ts *TransactionService) buildReportMaps(ctx context.Context, startTime, en
 			offset := offsetAccountName(details, model.AccountTypeExpense)
 			for _, split := range details {
 				if split.AccountType == model.AccountTypeExpense {
-					key := split.AccountName + "|" + offset
+					key := split.AccountName + "|" + offset + "|" + split.Currency
 					row := getOrCreateRowWithOffset(expenseByAccount, key, split.AccountName, offset, split.Currency)
 					row.Amount += utils.AbsInt64(split.Amount)
 					row.TxCount++

--- a/internal/service/report_service.go
+++ b/internal/service/report_service.go
@@ -11,26 +11,36 @@ import (
 	"github.com/hance08/kea/internal/utils"
 )
 
-// GetNetWorthAt returns net worth (assets - liabilities) using all posted splits up to endTime.
-func (ts *TransactionService) GetNetWorthAt(ctx context.Context, endTime int64) (int64, error) {
+// GetNetWorthAt returns net worth (assets - liabilities) per currency using all posted splits up to endTime.
+func (ts *TransactionService) GetNetWorthAt(ctx context.Context, endTime int64) (map[string]int64, error) {
 	txSplitsMap, err := ts.txRepo.GetSplitsWithAccountsByDateRange(ctx, 0, endTime)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
-	var totalAssets, totalLiabilities int64
+	assets := map[string]int64{}
+	liabilities := map[string]int64{}
 	for _, splits := range txSplitsMap {
 		for _, split := range splits {
 			switch split.AccountType {
 			case model.AccountTypeAsset:
-				totalAssets += split.Amount
+				assets[split.Currency] += split.Amount
 			case model.AccountTypeLiability:
-				totalLiabilities += split.Amount
+				liabilities[split.Currency] += split.Amount
 			}
 		}
 	}
 
-	return totalAssets - totalLiabilities, nil
+	nw := map[string]int64{}
+	for ccy, amt := range assets {
+		nw[ccy] = amt - liabilities[ccy]
+	}
+	for ccy, amt := range liabilities {
+		if _, ok := nw[ccy]; !ok {
+			nw[ccy] = -amt
+		}
+	}
+	return nw, nil
 }
 
 // offsetAccountName inspects the splits of a transaction and returns the name of the
@@ -115,17 +125,26 @@ func (ts *TransactionService) GenerateIncomeStatement(ctx context.Context, start
 	}
 
 	result := &model.ReportResult{
-		Currency:    ts.config.Defaults.Currency,
 		IncomeRows:  rowsFromMap(incomeByAccount),
 		ExpenseRows: rowsFromMap(expenseByAccount),
+		TotalIncome:  map[string]int64{},
+		TotalExpense: map[string]int64{},
+		NetAmount:    map[string]int64{},
 	}
 	for _, r := range result.IncomeRows {
-		result.TotalIncome += r.Amount
+		result.TotalIncome[r.Currency] += r.Amount
 	}
 	for _, r := range result.ExpenseRows {
-		result.TotalExpense += r.Amount
+		result.TotalExpense[r.Currency] += r.Amount
 	}
-	result.NetAmount = result.TotalIncome - result.TotalExpense
+	for ccy, inc := range result.TotalIncome {
+		result.NetAmount[ccy] = inc - result.TotalExpense[ccy]
+	}
+	for ccy, exp := range result.TotalExpense {
+		if _, ok := result.NetAmount[ccy]; !ok {
+			result.NetAmount[ccy] = -exp
+		}
+	}
 
 	return result, nil
 }
@@ -140,13 +159,12 @@ func (ts *TransactionService) GenerateIncomeBreakdown(ctx context.Context, start
 	rows := rowsFromMap(incomeByAccount)
 	sort.Slice(rows, func(i, j int) bool { return rows[i].Amount > rows[j].Amount })
 
-	var total int64
+	total := map[string]int64{}
 	for _, r := range rows {
-		total += r.Amount
+		total[r.Currency] += r.Amount
 	}
 
 	return &model.ReportResult{
-		Currency:    ts.config.Defaults.Currency,
 		IncomeRows:  rows,
 		TotalIncome: total,
 	}, nil
@@ -162,13 +180,12 @@ func (ts *TransactionService) GenerateExpenseBreakdown(ctx context.Context, star
 	rows := rowsFromMap(expenseByAccount)
 	sort.Slice(rows, func(i, j int) bool { return rows[i].Amount > rows[j].Amount })
 
-	var total int64
+	total := map[string]int64{}
 	for _, r := range rows {
-		total += r.Amount
+		total[r.Currency] += r.Amount
 	}
 
 	return &model.ReportResult{
-		Currency:     ts.config.Defaults.Currency,
 		ExpenseRows:  rows,
 		TotalExpense: total,
 	}, nil
@@ -188,8 +205,11 @@ func (ts *TransactionService) GenerateBalanceSheet(ctx context.Context, asOf int
 	}
 
 	result := &model.BalanceSheetResult{
-		Currency: ts.config.Defaults.Currency,
-		AsOf:     asOf,
+		AsOf:             asOf,
+		TotalAssets:      map[string]int64{},
+		TotalLiabilities: map[string]int64{},
+		TotalEquity:      map[string]int64{},
+		NetWorth:         map[string]int64{},
 	}
 
 	for _, acc := range allAccounts {
@@ -212,17 +232,24 @@ func (ts *TransactionService) GenerateBalanceSheet(ctx context.Context, asOf int
 		switch acc.Type {
 		case model.AccountTypeAsset:
 			result.Assets = append(result.Assets, row)
-			result.TotalAssets += balance
+			result.TotalAssets[currency] += balance
 		case model.AccountTypeLiability:
 			result.Liabilities = append(result.Liabilities, row)
-			result.TotalLiabilities += balance
+			result.TotalLiabilities[currency] += balance
 		case model.AccountTypeEquity:
 			result.Equity = append(result.Equity, row)
-			result.TotalEquity += balance
+			result.TotalEquity[currency] += balance
 		}
 	}
 
-	result.NetWorth = result.TotalAssets - result.TotalLiabilities
+	for ccy, assets := range result.TotalAssets {
+		result.NetWorth[ccy] = assets - result.TotalLiabilities[ccy]
+	}
+	for ccy, liabs := range result.TotalLiabilities {
+		if _, ok := result.NetWorth[ccy]; !ok {
+			result.NetWorth[ccy] = -liabs
+		}
+	}
 
 	sort.Slice(result.Assets, func(i, j int) bool {
 		return result.Assets[i].Amount > result.Assets[j].Amount

--- a/internal/service/report_service_test.go
+++ b/internal/service/report_service_test.go
@@ -317,6 +317,34 @@ func TestGenerateIncomeStatement(t *testing.T) {
 		_, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
 		assert.Error(t, err)
 	})
+
+	t.Run("multi-currency totals are grouped by currency", func(t *testing.T) {
+		txRepo := newMockTransactionRepo()
+		addTxSplits(txRepo.splitsWithAccts, 1,
+			model.SplitDetail{AccountName: "Revenue:Salary", AccountType: model.AccountTypeRevenue, Amount: -3000, Currency: "USD"},
+			model.SplitDetail{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: 3000, Currency: "USD"},
+		)
+		addTxSplits(txRepo.splitsWithAccts, 2,
+			model.SplitDetail{AccountName: "Revenue:Freelance", AccountType: model.AccountTypeRevenue, Amount: -90000, Currency: "TWD"},
+			model.SplitDetail{AccountName: "Assets:TWD_Bank", AccountType: model.AccountTypeAsset, Amount: 90000, Currency: "TWD"},
+		)
+		addTxSplits(txRepo.splitsWithAccts, 3,
+			model.SplitDetail{AccountName: "Expenses:Food", AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
+			model.SplitDetail{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"},
+		)
+		txRepo.addTransaction(&model.Transaction{ID: 1, Type: model.TxTypeIncome}, nil)
+		txRepo.addTransaction(&model.Transaction{ID: 2, Type: model.TxTypeIncome}, nil)
+		txRepo.addTransaction(&model.Transaction{ID: 3, Type: model.TxTypeExpense}, nil)
+		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
+
+		result, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
+		require.NoError(t, err)
+		assert.Equal(t, int64(3000), result.TotalIncome["USD"])
+		assert.Equal(t, int64(90000), result.TotalIncome["TWD"])
+		assert.Equal(t, int64(500), result.TotalExpense["USD"])
+		assert.Equal(t, int64(2500), result.NetAmount["USD"])  // 3000 - 500
+		assert.Equal(t, int64(90000), result.NetAmount["TWD"]) // 90000 - 0
+	})
 }
 
 // ──────────────────────────────────────────────
@@ -487,5 +515,24 @@ func TestGenerateBalanceSheet(t *testing.T) {
 
 		_, err := svc.GenerateBalanceSheet(context.Background(), 9999999999)
 		assert.Error(t, err)
+	})
+
+	t.Run("multi-currency totals are grouped by currency", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:USD_Bank", Type: model.AccountTypeAsset, Currency: "USD"})
+		accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:TWD_Bank", Type: model.AccountTypeAsset, Currency: "TWD"})
+		accRepo.addAccount(&model.Account{ID: 3, Name: "Liabilities:Card", Type: model.AccountTypeLiability, Currency: "USD"})
+		accRepo.balances[1] = 10000
+		accRepo.balances[2] = 50000
+		accRepo.balances[3] = 3000
+		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+		result, err := svc.GenerateBalanceSheet(context.Background(), 9999999999)
+		require.NoError(t, err)
+		assert.Equal(t, int64(10000), result.TotalAssets["USD"])
+		assert.Equal(t, int64(50000), result.TotalAssets["TWD"])
+		assert.Equal(t, int64(3000), result.TotalLiabilities["USD"])
+		assert.Equal(t, int64(7000), result.NetWorth["USD"])   // 10000 - 3000
+		assert.Equal(t, int64(50000), result.NetWorth["TWD"])  // 50000 - 0
 	})
 }

--- a/internal/service/report_service_test.go
+++ b/internal/service/report_service_test.go
@@ -84,54 +84,54 @@ func TestGetNetWorthAt(t *testing.T) {
 	t.Run("assets only", func(t *testing.T) {
 		txRepo := newMockTransactionRepo()
 		addTxSplits(txRepo.splitsWithAccts, 1,
-			split("Assets:Bank", model.AccountTypeAsset, 10000),
-			split("Equity:Opening", model.AccountTypeEquity, -10000),
+			model.SplitDetail{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: 10000, Currency: "USD"},
+			model.SplitDetail{AccountName: "Equity:Opening", AccountType: model.AccountTypeEquity, Amount: -10000, Currency: "USD"},
 		)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		worth, err := svc.GetNetWorthAt(context.Background(), 0)
+		nw, err := svc.GetNetWorthAt(context.Background(), 0)
 		require.NoError(t, err)
-		assert.Equal(t, int64(10000), worth)
+		assert.Equal(t, int64(10000), nw["USD"])
 	})
 
 	t.Run("assets minus liabilities", func(t *testing.T) {
 		txRepo := newMockTransactionRepo()
 		addTxSplits(txRepo.splitsWithAccts, 1,
-			split("Assets:Bank", model.AccountTypeAsset, 15000),
-			split("Equity:Opening", model.AccountTypeEquity, -15000),
+			model.SplitDetail{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: 15000, Currency: "USD"},
+			model.SplitDetail{AccountName: "Equity:Opening", AccountType: model.AccountTypeEquity, Amount: -15000, Currency: "USD"},
 		)
 		addTxSplits(txRepo.splitsWithAccts, 2,
-			split("Liabilities:Card", model.AccountTypeLiability, 5000),
-			split("Assets:Bank", model.AccountTypeAsset, -5000),
+			model.SplitDetail{AccountName: "Liabilities:Card", AccountType: model.AccountTypeLiability, Amount: 5000, Currency: "USD"},
+			model.SplitDetail{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: -5000, Currency: "USD"},
 		)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
 		// totalAssets = 15000 + (-5000) = 10000
 		// totalLiabilities = 5000
 		// netWorth = 10000 - 5000 = 5000
-		worth, err := svc.GetNetWorthAt(context.Background(), 0)
+		nw, err := svc.GetNetWorthAt(context.Background(), 0)
 		require.NoError(t, err)
-		assert.Equal(t, int64(5000), worth)
+		assert.Equal(t, int64(5000), nw["USD"])
 	})
 
 	t.Run("no transactions returns zero net worth", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		worth, err := svc.GetNetWorthAt(context.Background(), 0)
+		nw, err := svc.GetNetWorthAt(context.Background(), 0)
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), worth)
+		assert.Empty(t, nw)
 	})
 
 	t.Run("only income/expense splits are excluded from net worth", func(t *testing.T) {
 		txRepo := newMockTransactionRepo()
 		addTxSplits(txRepo.splitsWithAccts, 1,
-			split("Expenses:Food", model.AccountTypeExpense, 500),
-			split("Revenue:Salary", model.AccountTypeRevenue, -500),
+			model.SplitDetail{AccountName: "Expenses:Food", AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
+			model.SplitDetail{AccountName: "Revenue:Salary", AccountType: model.AccountTypeRevenue, Amount: -500, Currency: "USD"},
 		)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		worth, err := svc.GetNetWorthAt(context.Background(), 0)
+		nw, err := svc.GetNetWorthAt(context.Background(), 0)
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), worth)
+		assert.Empty(t, nw)
 	})
 
 	t.Run("repo failure returns error", func(t *testing.T) {
@@ -141,6 +141,31 @@ func TestGetNetWorthAt(t *testing.T) {
 
 		_, err := svc.GetNetWorthAt(context.Background(), 0)
 		assert.Error(t, err)
+	})
+
+	t.Run("multi-currency keeps totals separate", func(t *testing.T) {
+		txRepo := newMockTransactionRepo()
+		addTxSplits(txRepo.splitsWithAccts, 1,
+			model.SplitDetail{AccountName: "Assets:USD_Bank", AccountType: model.AccountTypeAsset, Amount: 10000, Currency: "USD"},
+			model.SplitDetail{AccountName: "Equity:Opening_USD", AccountType: model.AccountTypeEquity, Amount: -10000, Currency: "USD"},
+		)
+		addTxSplits(txRepo.splitsWithAccts, 2,
+			model.SplitDetail{AccountName: "Assets:TWD_Bank", AccountType: model.AccountTypeAsset, Amount: 50000, Currency: "TWD"},
+			model.SplitDetail{AccountName: "Equity:Opening_TWD", AccountType: model.AccountTypeEquity, Amount: -50000, Currency: "TWD"},
+		)
+		addTxSplits(txRepo.splitsWithAccts, 3,
+			model.SplitDetail{AccountName: "Liabilities:Card", AccountType: model.AccountTypeLiability, Amount: 2000, Currency: "USD"},
+			model.SplitDetail{AccountName: "Assets:USD_Bank", AccountType: model.AccountTypeAsset, Amount: -2000, Currency: "USD"},
+		)
+		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
+
+		nw, err := svc.GetNetWorthAt(context.Background(), 0)
+		require.NoError(t, err)
+		// USD: assets 10000-2000=8000, liabilities 2000 → net 6000
+		assert.Equal(t, int64(6000), nw["USD"])
+		// TWD: assets 50000, liabilities 0 → net 50000
+		assert.Equal(t, int64(50000), nw["TWD"])
+		assert.Len(t, nw, 2)
 	})
 }
 
@@ -160,9 +185,9 @@ func TestGenerateIncomeStatement(t *testing.T) {
 
 		result, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
 		require.NoError(t, err)
-		assert.Equal(t, int64(2000), result.TotalIncome)
-		assert.Equal(t, int64(0), result.TotalExpense)
-		assert.Equal(t, int64(2000), result.NetAmount)
+		assert.Equal(t, int64(2000), result.TotalIncome["USD"])
+		assert.Empty(t, result.TotalExpense)
+		assert.Equal(t, int64(2000), result.NetAmount["USD"])
 		require.Len(t, result.IncomeRows, 1)
 		assert.Equal(t, "Revenue:Salary", result.IncomeRows[0].AccountName)
 	})
@@ -178,9 +203,9 @@ func TestGenerateIncomeStatement(t *testing.T) {
 
 		result, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), result.TotalIncome)
-		assert.Equal(t, int64(500), result.TotalExpense)
-		assert.Equal(t, int64(-500), result.NetAmount)
+		assert.Empty(t, result.TotalIncome)
+		assert.Equal(t, int64(500), result.TotalExpense["USD"])
+		assert.Equal(t, int64(-500), result.NetAmount["USD"])
 		require.Len(t, result.ExpenseRows, 1)
 		assert.Equal(t, "Expenses:Food", result.ExpenseRows[0].AccountName)
 	})
@@ -201,9 +226,9 @@ func TestGenerateIncomeStatement(t *testing.T) {
 
 		result, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
 		require.NoError(t, err)
-		assert.Equal(t, int64(3000), result.TotalIncome)
-		assert.Equal(t, int64(800), result.TotalExpense)
-		assert.Equal(t, int64(2200), result.NetAmount) // 3000 - 800
+		assert.Equal(t, int64(3000), result.TotalIncome["USD"])
+		assert.Equal(t, int64(800), result.TotalExpense["USD"])
+		assert.Equal(t, int64(2200), result.NetAmount["USD"]) // 3000 - 800
 	})
 
 	t.Run("transfer transaction excluded from income statement", func(t *testing.T) {
@@ -217,8 +242,8 @@ func TestGenerateIncomeStatement(t *testing.T) {
 
 		result, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), result.TotalIncome)
-		assert.Equal(t, int64(0), result.TotalExpense)
+		assert.Empty(t, result.TotalIncome)
+		assert.Empty(t, result.TotalExpense)
 		assert.Empty(t, result.IncomeRows)
 		assert.Empty(t, result.ExpenseRows)
 	})
@@ -227,9 +252,9 @@ func TestGenerateIncomeStatement(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
 		result, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
 		require.NoError(t, err)
-		assert.Equal(t, int64(0), result.TotalIncome)
-		assert.Equal(t, int64(0), result.TotalExpense)
-		assert.Equal(t, int64(0), result.NetAmount)
+		assert.Empty(t, result.TotalIncome)
+		assert.Empty(t, result.TotalExpense)
+		assert.Empty(t, result.NetAmount)
 	})
 
 	t.Run("IncomeRows sorted by amount descending", func(t *testing.T) {
@@ -268,7 +293,7 @@ func TestGenerateIncomeStatement(t *testing.T) {
 
 		result, err := svc.GenerateIncomeStatement(context.Background(), 0, 0)
 		require.NoError(t, err)
-		assert.Equal(t, int64(500), result.TotalExpense)
+		assert.Equal(t, int64(500), result.TotalExpense["USD"])
 		// two transactions for the same account should be merged into one row
 		require.Len(t, result.ExpenseRows, 1)
 		assert.Equal(t, int64(500), result.ExpenseRows[0].Amount)
@@ -315,7 +340,7 @@ func TestGenerateIncomeBreakdown(t *testing.T) {
 
 		result, err := svc.GenerateIncomeBreakdown(context.Background(), 0, 0)
 		require.NoError(t, err)
-		assert.Equal(t, int64(2000), result.TotalIncome)
+		assert.Equal(t, int64(2000), result.TotalIncome["USD"])
 		assert.NotEmpty(t, result.IncomeRows)
 		assert.Empty(t, result.ExpenseRows)
 	})
@@ -362,7 +387,7 @@ func TestGenerateExpenseBreakdown(t *testing.T) {
 
 		result, err := svc.GenerateExpenseBreakdown(context.Background(), 0, 0)
 		require.NoError(t, err)
-		assert.Equal(t, int64(500), result.TotalExpense)
+		assert.Equal(t, int64(500), result.TotalExpense["USD"])
 		assert.NotEmpty(t, result.ExpenseRows)
 		assert.Empty(t, result.IncomeRows)
 	})
@@ -383,9 +408,9 @@ func TestGenerateBalanceSheet(t *testing.T) {
 
 		result, err := svc.GenerateBalanceSheet(context.Background(), 9999999999)
 		require.NoError(t, err)
-		assert.Equal(t, int64(10000), result.TotalAssets)
-		assert.Equal(t, int64(3000), result.TotalLiabilities)
-		assert.Equal(t, int64(7000), result.NetWorth) // 10000 - 3000
+		assert.Equal(t, int64(10000), result.TotalAssets["USD"])
+		assert.Equal(t, int64(3000), result.TotalLiabilities["USD"])
+		assert.Equal(t, int64(7000), result.NetWorth["USD"]) // 10000 - 3000
 		require.Len(t, result.Assets, 1)
 		require.Len(t, result.Liabilities, 1)
 	})
@@ -412,7 +437,7 @@ func TestGenerateBalanceSheet(t *testing.T) {
 
 		result, err := svc.GenerateBalanceSheet(context.Background(), 9999999999)
 		require.NoError(t, err)
-		assert.Equal(t, int64(5000), result.TotalEquity)
+		assert.Equal(t, int64(5000), result.TotalEquity["USD"])
 		require.Len(t, result.Equity, 1)
 	})
 

--- a/ui/views/report.go
+++ b/ui/views/report.go
@@ -80,8 +80,8 @@ func (v *ReportView) RenderIncomeStatement(result *model.ReportResult) error {
 	}
 
 	// Summary
-	v.renderPerCurrencyTotals("Total Income", result.TotalIncome, pterm.Green)
-	v.renderPerCurrencyTotals("Total Expenses", result.TotalExpense, pterm.Red)
+	v.renderPerCurrencyTotals("Total Income", result.TotalIncome, ptermGreen)
+	v.renderPerCurrencyTotals("Total Expenses", result.TotalExpense, ptermRed)
 
 	for _, ccy := range sortedKeys(result.NetAmount) {
 		net := result.NetAmount[ccy]
@@ -163,7 +163,7 @@ func (v *ReportView) RenderExpenseBreakdown(result *model.ReportResult) error {
 	t.Render()
 	pterm.Println()
 
-	v.renderPerCurrencyTotals("Total Expenses", result.TotalExpense, pterm.Red)
+	v.renderPerCurrencyTotals("Total Expenses", result.TotalExpense, ptermRed)
 	pterm.Println()
 
 	return nil
@@ -202,7 +202,7 @@ func (v *ReportView) RenderIncomeBreakdown(result *model.ReportResult) error {
 	t.Render()
 	pterm.Println()
 
-	v.renderPerCurrencyTotals("Total Income", result.TotalIncome, pterm.Green)
+	v.renderPerCurrencyTotals("Total Income", result.TotalIncome, ptermGreen)
 	pterm.Println()
 
 	return nil
@@ -283,8 +283,8 @@ func (v *ReportView) RenderBalanceSheet(result *model.BalanceSheetResult) error 
 	pterm.Println()
 
 	// Summary
-	v.renderPerCurrencyTotals("Total Assets", result.TotalAssets, pterm.Green)
-	v.renderPerCurrencyTotals("Total Liabilities", result.TotalLiabilities, pterm.Red)
+	v.renderPerCurrencyTotals("Total Assets", result.TotalAssets, ptermGreen)
+	v.renderPerCurrencyTotals("Total Liabilities", result.TotalLiabilities, ptermRed)
 
 	for _, ccy := range sortedKeys(result.NetWorth) {
 		nw := result.NetWorth[ccy]
@@ -318,6 +318,9 @@ func (v *ReportView) renderSummaryLine(label, value, currency string) {
 func (v *ReportView) renderSummaryLineNoCurrency(label, value string) {
 	pterm.Printf("  %-20s  %s\n", label, value)
 }
+
+func ptermGreen(s string) string { return pterm.Green(s) }
+func ptermRed(s string) string   { return pterm.Red(s) }
 
 func (v *ReportView) renderPerCurrencyTotals(label string, totals map[string]int64, colorFn func(string) string) {
 	currencies := sortedKeys(totals)

--- a/ui/views/report.go
+++ b/ui/views/report.go
@@ -6,6 +6,7 @@ package views
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/utils"
@@ -79,35 +80,49 @@ func (v *ReportView) RenderIncomeStatement(result *model.ReportResult) error {
 	}
 
 	// Summary
-	v.renderSummaryLine("Total Income", pterm.Green(utils.FormatAmount(result.TotalIncome)), result.Currency)
-	v.renderSummaryLine("Total Expenses", pterm.Red(utils.FormatAmount(result.TotalExpense)), result.Currency)
+	v.renderPerCurrencyTotals("Total Income", result.TotalIncome, pterm.Green)
+	v.renderPerCurrencyTotals("Total Expenses", result.TotalExpense, pterm.Red)
 
-	netStr := utils.FormatAmount(utils.AbsInt64(result.NetAmount))
-	if result.NetAmount >= 0 {
-		v.renderSummaryLine("Net", pterm.Green(netStr), result.Currency)
-	} else {
-		v.renderSummaryLine("Net", pterm.Red("-"+netStr), result.Currency)
+	for _, ccy := range sortedKeys(result.NetAmount) {
+		net := result.NetAmount[ccy]
+		netStr := utils.FormatAmount(utils.AbsInt64(net))
+		if net >= 0 {
+			v.renderSummaryLine("Net", pterm.Green(netStr), ccy)
+		} else {
+			v.renderSummaryLine("Net", pterm.Red("-"+netStr), ccy)
+		}
 	}
 
-	// Net Worth: cumulative assets minus liabilities
-	nwStr := utils.FormatAmount(utils.AbsInt64(result.NetWorth))
-	if result.NetWorth >= 0 {
-		v.renderSummaryLine("Net Worth", pterm.Green(nwStr), result.Currency)
-	} else {
-		v.renderSummaryLine("Net Worth", pterm.Red("-"+nwStr), result.Currency)
+	for _, ccy := range sortedKeys(result.NetWorth) {
+		nw := result.NetWorth[ccy]
+		nwStr := utils.FormatAmount(utils.AbsInt64(nw))
+		if nw >= 0 {
+			v.renderSummaryLine("Net Worth", pterm.Green(nwStr), ccy)
+		} else {
+			v.renderSummaryLine("Net Worth", pterm.Red("-"+nwStr), ccy)
+		}
 	}
 
-	if result.NetWorthGrowthPct == nil {
+	growthCurrencies := make([]string, 0, len(result.NetWorthGrowthPct))
+	for ccy := range result.NetWorthGrowthPct {
+		growthCurrencies = append(growthCurrencies, ccy)
+	}
+	sort.Strings(growthCurrencies)
+
+	if len(growthCurrencies) == 0 {
 		v.renderSummaryLineNoCurrency("Net Worth Growth", "N/A")
 	} else {
-		pctText := fmt.Sprintf("%+.2f%%", *result.NetWorthGrowthPct)
-		switch {
-		case *result.NetWorthGrowthPct > 0:
-			v.renderSummaryLineNoCurrency("Net Worth Growth", pterm.Green(pctText))
-		case *result.NetWorthGrowthPct < 0:
-			v.renderSummaryLineNoCurrency("Net Worth Growth", pterm.Red(pctText))
-		default:
-			v.renderSummaryLineNoCurrency("Net Worth Growth", pctText)
+		for _, ccy := range growthCurrencies {
+			pct := result.NetWorthGrowthPct[ccy]
+			pctText := fmt.Sprintf("%+.2f%%", pct)
+			switch {
+			case pct > 0:
+				v.renderSummaryLine("Net Worth Growth", pterm.Green(pctText), ccy)
+			case pct < 0:
+				v.renderSummaryLine("Net Worth Growth", pterm.Red(pctText), ccy)
+			default:
+				v.renderSummaryLine("Net Worth Growth", pctText, ccy)
+			}
 		}
 	}
 
@@ -148,7 +163,7 @@ func (v *ReportView) RenderExpenseBreakdown(result *model.ReportResult) error {
 	t.Render()
 	pterm.Println()
 
-	v.renderSummaryLine("Total Expenses", pterm.Red(utils.FormatAmount(result.TotalExpense)), result.Currency)
+	v.renderPerCurrencyTotals("Total Expenses", result.TotalExpense, pterm.Red)
 	pterm.Println()
 
 	return nil
@@ -187,7 +202,7 @@ func (v *ReportView) RenderIncomeBreakdown(result *model.ReportResult) error {
 	t.Render()
 	pterm.Println()
 
-	v.renderSummaryLine("Total Income", pterm.Green(utils.FormatAmount(result.TotalIncome)), result.Currency)
+	v.renderPerCurrencyTotals("Total Income", result.TotalIncome, pterm.Green)
 	pterm.Println()
 
 	return nil
@@ -268,14 +283,17 @@ func (v *ReportView) RenderBalanceSheet(result *model.BalanceSheetResult) error 
 	pterm.Println()
 
 	// Summary
-	v.renderSummaryLine("Total Assets", pterm.Green(utils.FormatAmount(result.TotalAssets)), result.Currency)
-	v.renderSummaryLine("Total Liabilities", pterm.Red(utils.FormatAmount(result.TotalLiabilities)), result.Currency)
+	v.renderPerCurrencyTotals("Total Assets", result.TotalAssets, pterm.Green)
+	v.renderPerCurrencyTotals("Total Liabilities", result.TotalLiabilities, pterm.Red)
 
-	nwStr := utils.FormatAmount(utils.AbsInt64(result.NetWorth))
-	if result.NetWorth >= 0 {
-		v.renderSummaryLine("Net Worth", pterm.Green(nwStr), result.Currency)
-	} else {
-		v.renderSummaryLine("Net Worth", pterm.Red("-"+nwStr), result.Currency)
+	for _, ccy := range sortedKeys(result.NetWorth) {
+		nw := result.NetWorth[ccy]
+		nwStr := utils.FormatAmount(utils.AbsInt64(nw))
+		if nw >= 0 {
+			v.renderSummaryLine("Net Worth", pterm.Green(nwStr), ccy)
+		} else {
+			v.renderSummaryLine("Net Worth", pterm.Red("-"+nwStr), ccy)
+		}
 	}
 
 	pterm.Println()
@@ -299,4 +317,21 @@ func (v *ReportView) renderSummaryLine(label, value, currency string) {
 
 func (v *ReportView) renderSummaryLineNoCurrency(label, value string) {
 	pterm.Printf("  %-20s  %s\n", label, value)
+}
+
+func (v *ReportView) renderPerCurrencyTotals(label string, totals map[string]int64, colorFn func(string) string) {
+	currencies := sortedKeys(totals)
+	for _, ccy := range currencies {
+		amt := totals[ccy]
+		v.renderSummaryLine(label, colorFn(utils.FormatAmount(amt)), ccy)
+	}
+}
+
+func sortedKeys(m map[string]int64) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/ui/views/report_json.go
+++ b/ui/views/report_json.go
@@ -46,28 +46,26 @@ type jsonReportRow struct {
 }
 
 type jsonReportResult struct {
-	Period            string          `json:"period"`
-	TotalIncome       float64         `json:"total_income"`
-	TotalExpense      float64         `json:"total_expense"`
-	NetAmount         float64         `json:"net_amount"`
-	NetWorth          float64         `json:"net_worth"`
-	PreviousNetWorth  *float64        `json:"previous_net_worth"`
-	NetWorthGrowthPct *float64        `json:"net_worth_growth_pct"`
-	Currency          string          `json:"currency"`
-	IncomeRows        []jsonReportRow `json:"income_rows"`
-	ExpenseRows       []jsonReportRow `json:"expense_rows"`
+	Period            string             `json:"period"`
+	TotalIncome       map[string]float64 `json:"total_income"`
+	TotalExpense      map[string]float64 `json:"total_expense"`
+	NetAmount         map[string]float64 `json:"net_amount"`
+	NetWorth          map[string]float64 `json:"net_worth"`
+	PreviousNetWorth  map[string]float64 `json:"previous_net_worth"`
+	NetWorthGrowthPct map[string]float64 `json:"net_worth_growth_pct"`
+	IncomeRows        []jsonReportRow    `json:"income_rows"`
+	ExpenseRows       []jsonReportRow    `json:"expense_rows"`
 }
 
 type jsonBalanceSheetResult struct {
-	Assets           []jsonReportRow `json:"assets"`
-	Liabilities      []jsonReportRow `json:"liabilities"`
-	Equity           []jsonReportRow `json:"equity"`
-	TotalAssets      float64         `json:"total_assets"`
-	TotalLiabilities float64         `json:"total_liabilities"`
-	TotalEquity      float64         `json:"total_equity"`
-	NetWorth         float64         `json:"net_worth"`
-	Currency         string          `json:"currency"`
-	AsOf             int64           `json:"as_of"`
+	Assets           []jsonReportRow    `json:"assets"`
+	Liabilities      []jsonReportRow    `json:"liabilities"`
+	Equity           []jsonReportRow    `json:"equity"`
+	TotalAssets      map[string]float64 `json:"total_assets"`
+	TotalLiabilities map[string]float64 `json:"total_liabilities"`
+	TotalEquity      map[string]float64 `json:"total_equity"`
+	NetWorth         map[string]float64 `json:"net_worth"`
+	AsOf             int64              `json:"as_of"`
 }
 
 func toJSONRow(r model.ReportRow) jsonReportRow {
@@ -80,6 +78,17 @@ func toJSONRow(r model.ReportRow) jsonReportRow {
 	}
 }
 
+func centsMapToUnitMap(m map[string]int64) map[string]float64 {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]float64, len(m))
+	for k, v := range m {
+		out[k] = CentsToUnit(v)
+	}
+	return out
+}
+
 func toJSONRows(rows []model.ReportRow) []jsonReportRow {
 	out := make([]jsonReportRow, len(rows))
 	for i, r := range rows {
@@ -89,21 +98,14 @@ func toJSONRows(rows []model.ReportRow) []jsonReportRow {
 }
 
 func toJSONReportResult(r *model.ReportResult) jsonReportResult {
-	var previousNetWorth *float64
-	if r.PreviousNetWorth != nil {
-		v := CentsToUnit(*r.PreviousNetWorth)
-		previousNetWorth = &v
-	}
-
 	return jsonReportResult{
 		Period:            r.Period,
-		TotalIncome:       CentsToUnit(r.TotalIncome),
-		TotalExpense:      CentsToUnit(r.TotalExpense),
-		NetAmount:         CentsToUnit(r.NetAmount),
-		NetWorth:          CentsToUnit(r.NetWorth),
-		PreviousNetWorth:  previousNetWorth,
+		TotalIncome:       centsMapToUnitMap(r.TotalIncome),
+		TotalExpense:      centsMapToUnitMap(r.TotalExpense),
+		NetAmount:         centsMapToUnitMap(r.NetAmount),
+		NetWorth:          centsMapToUnitMap(r.NetWorth),
+		PreviousNetWorth:  centsMapToUnitMap(r.PreviousNetWorth),
 		NetWorthGrowthPct: r.NetWorthGrowthPct,
-		Currency:          r.Currency,
 		IncomeRows:        toJSONRows(r.IncomeRows),
 		ExpenseRows:       toJSONRows(r.ExpenseRows),
 	}
@@ -114,11 +116,10 @@ func toJSONBalanceSheetResult(r *model.BalanceSheetResult) jsonBalanceSheetResul
 		Assets:           toJSONRows(r.Assets),
 		Liabilities:      toJSONRows(r.Liabilities),
 		Equity:           toJSONRows(r.Equity),
-		TotalAssets:      CentsToUnit(r.TotalAssets),
-		TotalLiabilities: CentsToUnit(r.TotalLiabilities),
-		TotalEquity:      CentsToUnit(r.TotalEquity),
-		NetWorth:         CentsToUnit(r.NetWorth),
-		Currency:         r.Currency,
+		TotalAssets:      centsMapToUnitMap(r.TotalAssets),
+		TotalLiabilities: centsMapToUnitMap(r.TotalLiabilities),
+		TotalEquity:      centsMapToUnitMap(r.TotalEquity),
+		NetWorth:         centsMapToUnitMap(r.NetWorth),
 		AsOf:             r.AsOf,
 	}
 }


### PR DESCRIPTION
## Summary

- **Fixes #47** — reports no longer aggregate raw cents across different currencies into a single misleading total.
- All report total fields (`TotalIncome`, `TotalExpense`, `NetAmount`, `NetWorth`, `TotalAssets`, `TotalLiabilities`, `TotalEquity`) changed from scalar `int64` to `map[string]int64` keyed by currency code.
- Text and JSON output now render one total line per currency in alphabetical order.
- Multi-currency tests added for `GetNetWorthAt`, `GenerateIncomeStatement`, and `GenerateBalanceSheet` with USD + TWD accounts.

## Breaking changes

The JSON report output format changes: total fields go from numbers to objects (e.g., `"total_income": 30` becomes `"total_income": {"USD": 30, "TWD": 900}`). The top-level `currency` field is removed from both `ReportResult` and `BalanceSheetResult`. Consumers parsing JSON reports will need to update.

## Test plan

- [x] All existing report service tests updated and passing
- [x] New multi-currency tests verify USD and TWD totals are never combined
- [x] `go build ./...` clean
- [x] `go test ./...` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)