### PR TITLE
fix: reject foreign and duplicate split IDs in UpdateTransactionComplete

### DIFF
--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -301,6 +301,21 @@ func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, txI
 		existingAccountByID[s.ID] = s.AccountID
 	}
 
+	// Reject duplicate or foreign split IDs before any mutation.
+	seenSplitIDs := make(map[int64]bool, len(splits))
+	for _, split := range splits {
+		if split.ID == 0 {
+			continue
+		}
+		if seenSplitIDs[split.ID] {
+			return fmt.Errorf("duplicate split ID %d in input", split.ID)
+		}
+		seenSplitIDs[split.ID] = true
+		if _, ok := existingAccountByID[split.ID]; !ok {
+			return fmt.Errorf("split ID %d does not belong to transaction %d", split.ID, txID)
+		}
+	}
+
 	// Validate all accounts exist; enforce selectability only for new splits
 	// or splits whose account is being changed.
 	for _, split := range splits {

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -763,6 +763,54 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "splits do not match transaction type")
 	})
+
+	t.Run("split ID from another transaction rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		txRepo.addTransaction(
+			&model.Transaction{ID: 5, Status: model.StatusPending},
+			makeExistingSplits(10, 11),
+		)
+		txRepo.addTransaction(
+			&model.Transaction{ID: 6, Status: model.StatusPending},
+			[]*model.Split{{ID: 20, AccountID: 1, Amount: 100}, {ID: 21, AccountID: 2, Amount: -100}},
+		)
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		splits := []model.SplitDetail{
+			{ID: 20, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"},
+			{ID: 11, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
+		}
+		err := svc.UpdateTransactionComplete(context.Background(), 5, "cross-tx", 0, model.StatusPending, model.TxTypeExpense, splits)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to transaction")
+		assert.Empty(t, txRepo.deleteSplitCalls, "no splits should be deleted")
+		assert.Empty(t, txRepo.updateSplitCalls, "no splits should be updated")
+		assert.Empty(t, txRepo.createSplitCalls, "no splits should be created")
+	})
+
+	t.Run("duplicate split IDs rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		txRepo.addTransaction(
+			&model.Transaction{ID: 5, Status: model.StatusPending},
+			makeExistingSplits(10, 11),
+		)
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		splits := []model.SplitDetail{
+			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"},
+			{ID: 10, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
+		}
+		err := svc.UpdateTransactionComplete(context.Background(), 5, "dup", 0, model.StatusPending, model.TxTypeExpense, splits)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate split ID")
+		assert.Empty(t, txRepo.deleteSplitCalls)
+		assert.Empty(t, txRepo.updateSplitCalls)
+		assert.Empty(t, txRepo.createSplitCalls)
+	})
 }
 
 // ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Validate that every non-zero split ID in the input belongs to the transaction being edited, preventing cross-transaction split mutation
- Reject duplicate non-zero split IDs in the input
- Both checks run before any mutation (delete/update/create), so no partial writes occur on failure

Closes #41

## Test plan
- [x] Added test: split ID from another transaction is rejected with `"does not belong to transaction"` error
- [x] Added test: duplicate split IDs are rejected with `"duplicate split ID"` error
- [x] Both tests assert no delete/update/create calls are made on failure
- [x] All existing `TestUpdateTransactionComplete` sub-tests still pass
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)