### PR TITLE
fix: parse transaction dates in local time instead of UTC

### DIFF
--- a/cmd/add_actions.go
+++ b/cmd/add_actions.go
@@ -204,7 +204,7 @@ func (r *addRunner) parseDate(dateStr string) (int64, error) {
 	if dateStr == "" {
 		return time.Now().Unix(), nil
 	}
-	t, err := time.Parse(model.DateFormat, dateStr)
+	t, err := time.ParseInLocation(model.DateFormat, dateStr, time.Local)
 	if err != nil {
 		return 0, fmt.Errorf("invalid date format, use %s: %w", model.DateFormat, err)
 	}

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/hance08/kea/internal/model"
 	"github.com/stretchr/testify/assert"
@@ -168,4 +169,29 @@ func TestRunFromFlags_SplitMode(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "-", input.Description)
 	})
+}
+
+// ──────────────────────────────────────────────
+// TestParseDate_LocalTime
+// ──────────────────────────────────────────────
+
+func TestParseDate_LocalTime(t *testing.T) {
+	runner := &addRunner{}
+
+	// Use a timezone with a negative UTC offset (UTC-5).
+	loc, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	origLocal := time.Local
+	time.Local = loc
+	t.Cleanup(func() { time.Local = origLocal })
+
+	ts, err := runner.parseDate("2026-04-01")
+	require.NoError(t, err)
+
+	got := time.Unix(ts, 0).In(loc)
+	assert.Equal(t, 2026, got.Year())
+	assert.Equal(t, time.April, got.Month())
+	assert.Equal(t, 1, got.Day())
+	assert.Equal(t, 0, got.Hour())
+	assert.Equal(t, 0, got.Minute())
 }

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -178,9 +178,7 @@ func TestRunFromFlags_SplitMode(t *testing.T) {
 func TestParseDate_LocalTime(t *testing.T) {
 	runner := &addRunner{}
 
-	// Use a timezone with a negative UTC offset (UTC-5).
-	loc, err := time.LoadLocation("America/New_York")
-	require.NoError(t, err)
+	loc := time.FixedZone("UTC-5", -5*60*60)
 	origLocal := time.Local
 	time.Local = loc
 	t.Cleanup(func() { time.Local = origLocal })

--- a/ui/views/json_test.go
+++ b/ui/views/json_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hance08/kea/internal/model"
 	"github.com/stretchr/testify/assert"
@@ -61,6 +62,23 @@ func TestToJSONTxDetail(t *testing.T) {
 	assert.Equal(t, -5.0, got.Splits[0].Amount)
 	assert.Equal(t, 5.0, got.Splits[1].Amount)
 	assert.Equal(t, "lunch", got.Splits[1].Memo)
+}
+
+func TestToJSONTxDetail_LocalDate(t *testing.T) {
+	loc := time.FixedZone("UTC+8", 8*60*60)
+	origLocal := time.Local
+	time.Local = loc
+	t.Cleanup(func() { time.Local = origLocal })
+
+	// 2026-04-01 00:00:00 UTC+8 = 2026-03-31T16:00:00Z
+	ts := time.Date(2026, time.April, 1, 0, 0, 0, 0, loc).Unix()
+	detail := &model.TransactionDetail{
+		ID:        1,
+		Timestamp: ts,
+		Status:    model.StatusCleared,
+	}
+	got := ToJSONTxDetail(detail)
+	assert.Equal(t, "2026-04-01", got.Date)
 }
 
 func TestToJSONTxListItem(t *testing.T) {

--- a/ui/views/json_types.go
+++ b/ui/views/json_types.go
@@ -99,7 +99,7 @@ func ToJSONTxDetail(d *model.TransactionDetail) JSONTxDetail {
 	}
 	return JSONTxDetail{
 		ID:          d.ID,
-		Date:        time.Unix(d.Timestamp, 0).UTC().Format("2006-01-02"),
+		Date:        time.Unix(d.Timestamp, 0).Format(model.DateFormat),
 		Description: d.Description,
 		Status:      d.Status.String(),
 		Splits:      splits,

--- a/ui/views/transaction_edit.go
+++ b/ui/views/transaction_edit.go
@@ -73,7 +73,11 @@ func (v *TransactionEditView) AskDate(currentTimestamp int64) (int64, error) {
 		return 0, err
 	}
 
-	t, err := time.Parse("2006-01-02", dateStr)
+	return parseDateLocal(dateStr)
+}
+
+func parseDateLocal(dateStr string) (int64, error) {
+	t, err := time.ParseInLocation("2006-01-02", dateStr, time.Local)
 	if err != nil {
 		return 0, fmt.Errorf("unexpected date format error: %w", err)
 	}

--- a/ui/views/transaction_edit.go
+++ b/ui/views/transaction_edit.go
@@ -77,7 +77,7 @@ func (v *TransactionEditView) AskDate(currentTimestamp int64) (int64, error) {
 }
 
 func parseDateLocal(dateStr string) (int64, error) {
-	t, err := time.ParseInLocation("2006-01-02", dateStr, time.Local)
+	t, err := time.ParseInLocation(model.DateFormat, dateStr, time.Local)
 	if err != nil {
 		return 0, fmt.Errorf("unexpected date format error: %w", err)
 	}

--- a/ui/views/transaction_edit_test.go
+++ b/ui/views/transaction_edit_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package views
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDateLocal(t *testing.T) {
+	loc := time.FixedZone("UTC-5", -5*60*60)
+	origLocal := time.Local
+	time.Local = loc
+	t.Cleanup(func() { time.Local = origLocal })
+
+	ts, err := parseDateLocal("2026-04-01")
+	require.NoError(t, err)
+
+	got := time.Unix(ts, 0).In(loc)
+	assert.Equal(t, 2026, got.Year())
+	assert.Equal(t, time.April, got.Month())
+	assert.Equal(t, 1, got.Day())
+	assert.Equal(t, 0, got.Hour())
+	assert.Equal(t, 0, got.Minute())
+}


### PR DESCRIPTION
## Summary
- Fixed `addRunner.parseDate` in `cmd/add_actions.go` to use `time.ParseInLocation(..., time.Local)` instead of `time.Parse` (UTC), so CLI-entered dates are anchored to local midnight
- Extracted `parseDateLocal` helper in `ui/views/transaction_edit.go` and fixed it the same way, so edited transaction dates are also parsed in local time
- Added tests for both paths using a fixed UTC-5 timezone to verify dates don't shift to the previous day

## Test plan
- [x] `TestParseDate_LocalTime` verifies `addRunner.parseDate` returns local midnight
- [x] `TestParseDateLocal` verifies `parseDateLocal` returns local midnight
- [x] Full test suite passes (`go test ./...`)

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)