### PR TITLE
fix: use typed constants for TxType in GetTransactionRule

### DIFF
--- a/internal/service/transaction_service.go
+++ b/internal/service/transaction_service.go
@@ -33,13 +33,13 @@ func (ts *TransactionService) GetTransactionRule(txType model.TransactionType) (
 		}, nil
 	case model.TxTypeIncome:
 		return model.TransactionRule{
-			TxType:      "income",
+			TxType:      model.TxTypeIncome,
 			SourceTypes: []string{"R"},      // Revenue (Income)
 			DestTypes:   []string{"A", "L"}, // Assets, Liabilities
 		}, nil
 	case model.TxTypeTransfer:
 		return model.TransactionRule{
-			TxType:      "transfer",
+			TxType:      model.TxTypeTransfer,
 			SourceTypes: []string{"A", "L"},
 			DestTypes:   []string{"A", "L"},
 		}, nil


### PR DESCRIPTION
## Summary
- Replace hardcoded lowercase strings `"income"` and `"transfer"` with `model.TxTypeIncome` and `model.TxTypeTransfer` constants in `GetTransactionRule`
- Ensures consistent `TxType` values across all `TransactionRule` cases

Closes #63

## Test plan
- [x] `go test ./...` passes
- [x] Verify `GetTransactionRule` returns correct typed constants for all transaction types

🤖 Generated with [Claude Code](https://claude.com/claude-code)