### PR TITLE
fix: enable SQLite WAL mode, busy timeout, and connection pool limit

### DIFF
--- a/internal/store/export_test.go
+++ b/internal/store/export_test.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package store
+
+import (
+	"context"
+	"database/sql"
+)
+
+func (s *Store) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return s.db.QueryRowContext(ctx, query, args...)
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -37,7 +37,7 @@ func NewStore(dbPath string, migrationsFS fs.FS) (*Store, error) {
 		return nil, fmt.Errorf("can not create database directory %s: %w", dbDir, err)
 	}
 
-	db, err := sql.Open("sqlite3", dbPath+"?_foreign_keys=on")
+	db, err := sql.Open("sqlite3", dbPath+"?_foreign_keys=on&_journal_mode=WAL&_busy_timeout=5000")
 	success := false
 	defer func() {
 		if !success {
@@ -48,6 +48,9 @@ func NewStore(dbPath string, migrationsFS fs.FS) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("can not open database : %w", err)
 	}
+
+	db.SetMaxOpenConns(1)
+
 	if err = db.Ping(); err != nil {
 		return nil, fmt.Errorf("can not connect with database : %w", err)
 	}

--- a/internal/store/sqlite_pragma_test.go
+++ b/internal/store/sqlite_pragma_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStore_EnablesWALMode(t *testing.T) {
+	s := setupTestDB(t)
+
+	var journalMode string
+	err := s.QueryRowContext(context.Background(), "PRAGMA journal_mode").Scan(&journalMode)
+	require.NoError(t, err)
+	assert.Equal(t, "wal", journalMode)
+}
+
+func TestNewStore_SetsBusyTimeout(t *testing.T) {
+	s := setupTestDB(t)
+
+	var timeout int
+	err := s.QueryRowContext(context.Background(), "PRAGMA busy_timeout").Scan(&timeout)
+	require.NoError(t, err)
+	assert.Equal(t, 5000, timeout)
+}


### PR DESCRIPTION
## Summary

- Add `_journal_mode=WAL` and `_busy_timeout=5000` to the SQLite DSN so readers and writers can operate concurrently without "database is locked" errors
- Set `MaxOpenConns(1)` to serialize writes through Go's connection pool, preventing multiple goroutines from contending on SQLite's single-writer constraint
- Add pragma verification tests (`TestNewStore_EnablesWALMode`, `TestNewStore_SetsBusyTimeout`) using a test-only `export_test.go` helper to keep the production `Store` API clean

## Test plan

- [x] `TestNewStore_EnablesWALMode` confirms journal mode is `wal`
- [x] `TestNewStore_SetsBusyTimeout` confirms busy timeout is `5000`
- [x] Full test suite (`go test ./...`) passes with no regressions
- [x] `make build` succeeds

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)