### PR TITLE
fix: validate parent chain acyclicity on account creation

### DIFF
--- a/internal/service/account_ops.go
+++ b/internal/service/account_ops.go
@@ -14,18 +14,22 @@ import (
 	"github.com/hance08/kea/internal/repository"
 )
 
+const maxParentDepth = 100
+
 func (as *AccountService) validateParentChain(ctx context.Context, accountID int64, parentID *int64) error {
 	if parentID == nil {
 		return nil
 	}
 
 	visited := make(map[int64]bool)
-	visited[accountID] = true
+	if accountID != 0 {
+		visited[accountID] = true
+	}
 	currentID := *parentID
 
-	for {
+	for range maxParentDepth {
 		if visited[currentID] {
-			return fmt.Errorf("account %d would create a cycle via parent %d: %w", accountID, currentID, ErrCircularParent)
+			return fmt.Errorf("parent chain contains a cycle at account %d: %w", currentID, ErrCircularParent)
 		}
 		visited[currentID] = true
 
@@ -38,6 +42,8 @@ func (as *AccountService) validateParentChain(ctx context.Context, accountID int
 		}
 		currentID = *acc.ParentID
 	}
+
+	return fmt.Errorf("parent chain exceeds maximum depth (%d): %w", maxParentDepth, ErrCircularParent)
 }
 
 func (as *AccountService) CreateAccount(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64) (*model.Account, error) {

--- a/internal/service/account_ops.go
+++ b/internal/service/account_ops.go
@@ -14,6 +14,32 @@ import (
 	"github.com/hance08/kea/internal/repository"
 )
 
+func (as *AccountService) validateParentChain(ctx context.Context, accountID int64, parentID *int64) error {
+	if parentID == nil {
+		return nil
+	}
+
+	visited := make(map[int64]bool)
+	visited[accountID] = true
+	currentID := *parentID
+
+	for {
+		if visited[currentID] {
+			return fmt.Errorf("account %d would create a cycle via parent %d: %w", accountID, currentID, ErrCircularParent)
+		}
+		visited[currentID] = true
+
+		acc, err := as.repo.GetAccountByID(ctx, currentID)
+		if err != nil {
+			return fmt.Errorf("failed to look up parent account %d: %w", currentID, err)
+		}
+		if acc.ParentID == nil {
+			return nil
+		}
+		currentID = *acc.ParentID
+	}
+}
+
 func (as *AccountService) CreateAccount(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64) (*model.Account, error) {
 	if err := as.ValidateFullAccountName(name); err != nil {
 		return nil, fmt.Errorf("invalid account name: %w", err)
@@ -23,6 +49,11 @@ func (as *AccountService) CreateAccount(ctx context.Context, name string, accTyp
 	}
 	if !accType.IsValid() {
 		return nil, fmt.Errorf("invalid account type: %s", accType)
+	}
+	if parentID != nil {
+		if err := as.validateParentChain(ctx, 0, parentID); err != nil {
+			return nil, err
+		}
 	}
 
 	newID, err := as.repo.CreateAccount(ctx, name, accType, currency, description, parentID)

--- a/internal/service/account_ops_test.go
+++ b/internal/service/account_ops_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/hance08/kea/internal/model"
+	"github.com/hance08/kea/internal/repository"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -677,4 +678,107 @@ func TestUpdateAccountMetadata(t *testing.T) {
 		err := svc.UpdateAccountMetadata(context.Background(), 1, "desc", false)
 		require.Error(t, err)
 	})
+}
+
+// ──────────────────────────────────────────────
+// Parent chain validation
+// ──────────────────────────────────────────────
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}
+
+func TestCreateAccount_ValidParent(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestAccountService(accRepo, txRepo)
+
+	parent := &model.Account{ID: 10, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD"}
+	accRepo.addAccount(parent)
+
+	acc, err := svc.CreateAccount(context.Background(), "Assets:Bank:Checking", model.AccountTypeAsset, "USD", "", int64Ptr(10))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if acc.ParentID == nil || *acc.ParentID != 10 {
+		t.Fatalf("expected ParentID=10, got %v", acc.ParentID)
+	}
+}
+
+func TestCreateAccount_ParentNotFound(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestAccountService(accRepo, txRepo)
+
+	_, err := svc.CreateAccount(context.Background(), "Assets:Bank:Checking", model.AccountTypeAsset, "USD", "", int64Ptr(999))
+	if err == nil {
+		t.Fatal("expected error for non-existent parent, got nil")
+	}
+}
+
+func TestCreateAccount_DeepParentChain(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestAccountService(accRepo, txRepo)
+
+	a := &model.Account{ID: 1, Name: "Assets", Type: model.AccountTypeAsset, Currency: "USD", ParentID: nil}
+	b := &model.Account{ID: 2, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(1)}
+	c := &model.Account{ID: 3, Name: "Assets:Bank:Savings", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(2)}
+	accRepo.addAccount(a)
+	accRepo.addAccount(b)
+	accRepo.addAccount(c)
+
+	acc, err := svc.CreateAccount(context.Background(), "Assets:Bank:Savings:Sub", model.AccountTypeAsset, "USD", "", int64Ptr(3))
+	if err != nil {
+		t.Fatalf("deep chain should succeed: %v", err)
+	}
+	if acc.ParentID == nil || *acc.ParentID != 3 {
+		t.Fatalf("expected ParentID=3, got %v", acc.ParentID)
+	}
+}
+
+func TestValidateParentChain_DetectsCycle(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestAccountService(accRepo, txRepo)
+
+	// Circular chain: A(1)->C(3), B(2)->A(1), C(3)->B(2)
+	a := &model.Account{ID: 1, Name: "A", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(3)}
+	b := &model.Account{ID: 2, Name: "B", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(1)}
+	c := &model.Account{ID: 3, Name: "C", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(2)}
+	accRepo.addAccount(a)
+	accRepo.addAccount(b)
+	accRepo.addAccount(c)
+
+	err := svc.validateParentChain(context.Background(), 99, int64Ptr(3))
+	if err == nil {
+		t.Fatal("expected ErrCircularParent, got nil")
+	}
+	if !errors.Is(err, ErrCircularParent) {
+		t.Fatalf("expected ErrCircularParent, got: %v", err)
+	}
+}
+
+func TestValidateParentChain_NilParent(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestAccountService(accRepo, txRepo)
+
+	err := svc.validateParentChain(context.Background(), 1, nil)
+	if err != nil {
+		t.Fatalf("nil parentID should be valid: %v", err)
+	}
+}
+
+func TestValidateParentChain_RepoError(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestAccountService(accRepo, txRepo)
+
+	accRepo.getByIDErr[50] = repository.ErrNotFound
+
+	err := svc.validateParentChain(context.Background(), 1, int64Ptr(50))
+	if err == nil {
+		t.Fatal("expected error when parent not found")
+	}
 }

--- a/internal/service/account_ops_test.go
+++ b/internal/service/account_ops_test.go
@@ -688,97 +688,96 @@ func int64Ptr(v int64) *int64 {
 	return &v
 }
 
-func TestCreateAccount_ValidParent(t *testing.T) {
-	accRepo := newMockAccountRepo()
-	txRepo := newMockTransactionRepo()
-	svc := newTestAccountService(accRepo, txRepo)
+func TestCreateAccount_ParentValidation(t *testing.T) {
+	t.Run("valid parent accepted", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-	parent := &model.Account{ID: 10, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD"}
-	accRepo.addAccount(parent)
+		parent := &model.Account{ID: 10, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD"}
+		accRepo.addAccount(parent)
 
-	acc, err := svc.CreateAccount(context.Background(), "Assets:Bank:Checking", model.AccountTypeAsset, "USD", "", int64Ptr(10))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if acc.ParentID == nil || *acc.ParentID != 10 {
-		t.Fatalf("expected ParentID=10, got %v", acc.ParentID)
-	}
+		acc, err := svc.CreateAccount(context.Background(), "Assets:Bank:Checking", model.AccountTypeAsset, "USD", "", int64Ptr(10))
+		require.NoError(t, err)
+		require.NotNil(t, acc.ParentID)
+		assert.Equal(t, int64(10), *acc.ParentID)
+	})
+
+	t.Run("non-existent parent rejected", func(t *testing.T) {
+		svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
+
+		_, err := svc.CreateAccount(context.Background(), "Assets:Bank:Checking", model.AccountTypeAsset, "USD", "", int64Ptr(999))
+		require.Error(t, err)
+	})
+
+	t.Run("deep parent chain accepted", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets", Type: model.AccountTypeAsset, Currency: "USD"})
+		accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(1)})
+		accRepo.addAccount(&model.Account{ID: 3, Name: "Assets:Bank:Savings", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(2)})
+
+		acc, err := svc.CreateAccount(context.Background(), "Assets:Bank:Savings:Sub", model.AccountTypeAsset, "USD", "", int64Ptr(3))
+		require.NoError(t, err)
+		require.NotNil(t, acc.ParentID)
+		assert.Equal(t, int64(3), *acc.ParentID)
+	})
+
+	t.Run("circular parent chain rejected via CreateAccount", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		// Circular: A(1)->C(3), B(2)->A(1), C(3)->B(2)
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:A", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(3)})
+		accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:B", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(1)})
+		accRepo.addAccount(&model.Account{ID: 3, Name: "Assets:C", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(2)})
+
+		_, err := svc.CreateAccount(context.Background(), "Assets:C:Child", model.AccountTypeAsset, "USD", "", int64Ptr(3))
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrCircularParent), "expected ErrCircularParent, got: %v", err)
+	})
 }
 
-func TestCreateAccount_ParentNotFound(t *testing.T) {
-	accRepo := newMockAccountRepo()
-	txRepo := newMockTransactionRepo()
-	svc := newTestAccountService(accRepo, txRepo)
+func TestValidateParentChain(t *testing.T) {
+	t.Run("detects cycle", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-	_, err := svc.CreateAccount(context.Background(), "Assets:Bank:Checking", model.AccountTypeAsset, "USD", "", int64Ptr(999))
-	if err == nil {
-		t.Fatal("expected error for non-existent parent, got nil")
-	}
-}
+		// Circular: A(1)->C(3), B(2)->A(1), C(3)->B(2)
+		accRepo.addAccount(&model.Account{ID: 1, Name: "A", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(3)})
+		accRepo.addAccount(&model.Account{ID: 2, Name: "B", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(1)})
+		accRepo.addAccount(&model.Account{ID: 3, Name: "C", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(2)})
 
-func TestCreateAccount_DeepParentChain(t *testing.T) {
-	accRepo := newMockAccountRepo()
-	txRepo := newMockTransactionRepo()
-	svc := newTestAccountService(accRepo, txRepo)
+		err := svc.validateParentChain(context.Background(), 99, int64Ptr(3))
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrCircularParent), "expected ErrCircularParent, got: %v", err)
+	})
 
-	a := &model.Account{ID: 1, Name: "Assets", Type: model.AccountTypeAsset, Currency: "USD", ParentID: nil}
-	b := &model.Account{ID: 2, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(1)}
-	c := &model.Account{ID: 3, Name: "Assets:Bank:Savings", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(2)}
-	accRepo.addAccount(a)
-	accRepo.addAccount(b)
-	accRepo.addAccount(c)
+	t.Run("nil parent is valid", func(t *testing.T) {
+		svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
 
-	acc, err := svc.CreateAccount(context.Background(), "Assets:Bank:Savings:Sub", model.AccountTypeAsset, "USD", "", int64Ptr(3))
-	if err != nil {
-		t.Fatalf("deep chain should succeed: %v", err)
-	}
-	if acc.ParentID == nil || *acc.ParentID != 3 {
-		t.Fatalf("expected ParentID=3, got %v", acc.ParentID)
-	}
-}
+		err := svc.validateParentChain(context.Background(), 1, nil)
+		require.NoError(t, err)
+	})
 
-func TestValidateParentChain_DetectsCycle(t *testing.T) {
-	accRepo := newMockAccountRepo()
-	txRepo := newMockTransactionRepo()
-	svc := newTestAccountService(accRepo, txRepo)
+	t.Run("repo error propagated", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-	// Circular chain: A(1)->C(3), B(2)->A(1), C(3)->B(2)
-	a := &model.Account{ID: 1, Name: "A", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(3)}
-	b := &model.Account{ID: 2, Name: "B", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(1)}
-	c := &model.Account{ID: 3, Name: "C", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(2)}
-	accRepo.addAccount(a)
-	accRepo.addAccount(b)
-	accRepo.addAccount(c)
+		accRepo.getByIDErr[50] = repository.ErrNotFound
 
-	err := svc.validateParentChain(context.Background(), 99, int64Ptr(3))
-	if err == nil {
-		t.Fatal("expected ErrCircularParent, got nil")
-	}
-	if !errors.Is(err, ErrCircularParent) {
-		t.Fatalf("expected ErrCircularParent, got: %v", err)
-	}
-}
+		err := svc.validateParentChain(context.Background(), 1, int64Ptr(50))
+		require.Error(t, err)
+	})
 
-func TestValidateParentChain_NilParent(t *testing.T) {
-	accRepo := newMockAccountRepo()
-	txRepo := newMockTransactionRepo()
-	svc := newTestAccountService(accRepo, txRepo)
+	t.Run("detects self-parent on reparent", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-	err := svc.validateParentChain(context.Background(), 1, nil)
-	if err != nil {
-		t.Fatalf("nil parentID should be valid: %v", err)
-	}
-}
+		accRepo.addAccount(&model.Account{ID: 5, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD"})
 
-func TestValidateParentChain_RepoError(t *testing.T) {
-	accRepo := newMockAccountRepo()
-	txRepo := newMockTransactionRepo()
-	svc := newTestAccountService(accRepo, txRepo)
-
-	accRepo.getByIDErr[50] = repository.ErrNotFound
-
-	err := svc.validateParentChain(context.Background(), 1, int64Ptr(50))
-	if err == nil {
-		t.Fatal("expected error when parent not found")
-	}
+		err := svc.validateParentChain(context.Background(), 5, int64Ptr(5))
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrCircularParent))
+	})
 }

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -6,8 +6,9 @@ package service
 import "errors"
 
 var (
-	ErrReconciled    = errors.New("transaction has been reconciled")
-	ErrNotEditable   = errors.New("operation denied on protected record")
-	ErrNotFound      = errors.New("record not found")
-	ErrAlreadyExists = errors.New("record already exists")
+	ErrReconciled     = errors.New("transaction has been reconciled")
+	ErrNotEditable    = errors.New("operation denied on protected record")
+	ErrNotFound       = errors.New("record not found")
+	ErrAlreadyExists  = errors.New("record already exists")
+	ErrCircularParent = errors.New("circular parent reference detected")
 )


### PR DESCRIPTION
## Summary
- Adds `validateParentChain` to detect circular parent references in the account hierarchy
- Called from `CreateAccount` when `parentID != nil`, ensuring the parent exists and the chain is acyclic
- Bounded walk (max 100 depth) prevents infinite loops on corrupt DB state
- Designed for reuse by any future reparent/move operation

Closes #22

## Test plan
- [x] Valid parent accepted
- [x] Non-existent parent rejected
- [x] Deep (3-level) chain accepted
- [x] Circular chain detected and rejected via `CreateAccount`
- [x] Nil parent always valid
- [x] Repo errors propagated
- [x] Self-parent detected (reparent scenario)
- [x] Full test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)