### PR TITLE
fix: normalize subaccount currency overrides (issue #44)

### DIFF
--- a/cmd/account/create.go
+++ b/cmd/account/create.go
@@ -163,7 +163,9 @@ func (r *createRunner) runInteractive(ctx context.Context) (createInput, error) 
 		if err != nil {
 			return createInput{}, err
 		}
-		r.applyParentSettings(parentAccount, parentAccount.Currency, &input)
+		if err := r.applyParentSettings(parentAccount, parentAccount.Currency, &input); err != nil {
+			return createInput{}, err
+		}
 		input.fullName = r.accSvc.FormatAccountName(parentAccount.Name, nameInput)
 	} else {
 		accType, err := r.promptType()

--- a/cmd/account/create_actions.go
+++ b/cmd/account/create_actions.go
@@ -27,6 +27,7 @@ func (r *createRunner) createAccount(ctx context.Context, input createInput) (*m
 func (r *createRunner) applyTypeSettings(accType, currencyOverride string, input *createInput) error {
 	input.accountType = model.AccountType(accType)
 	if currencyOverride != "" {
+		// Early rejection of invalid codes; normalization happens in CreateAccount.
 		if err := r.accSvc.ValidateCurrency(currencyOverride); err != nil {
 			return err
 		}
@@ -41,6 +42,7 @@ func (r *createRunner) applyParentSettings(parent *model.Account, currencyOverri
 	input.accountType = parent.Type
 	input.parentID = &parent.ID
 	if currencyOverride != "" {
+		// Early rejection of invalid codes; normalization happens in CreateAccount.
 		if err := r.accSvc.ValidateCurrency(currencyOverride); err != nil {
 			return err
 		}

--- a/cmd/account/create_actions.go
+++ b/cmd/account/create_actions.go
@@ -6,7 +6,6 @@ package account
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/utils"
@@ -31,21 +30,25 @@ func (r *createRunner) applyTypeSettings(accType, currencyOverride string, input
 		if err := r.accSvc.ValidateCurrency(currencyOverride); err != nil {
 			return err
 		}
-		input.currency = strings.ToUpper(strings.TrimSpace(currencyOverride))
+		input.currency = currencyOverride
 	} else {
 		input.currency = r.defaultCurrency
 	}
 	return nil
 }
 
-func (r *createRunner) applyParentSettings(parent *model.Account, currencyOverride string, input *createInput) {
+func (r *createRunner) applyParentSettings(parent *model.Account, currencyOverride string, input *createInput) error {
 	input.accountType = parent.Type
 	input.parentID = &parent.ID
 	if currencyOverride != "" {
+		if err := r.accSvc.ValidateCurrency(currencyOverride); err != nil {
+			return err
+		}
 		input.currency = currencyOverride
 	} else {
 		input.currency = parent.Currency
 	}
+	return nil
 }
 
 func (r *createRunner) buildFromParentName(ctx context.Context, parentName, currency string, input *createInput) error {
@@ -53,7 +56,9 @@ func (r *createRunner) buildFromParentName(ctx context.Context, parentName, curr
 	if err != nil {
 		return err
 	}
-	r.applyParentSettings(parentAccount, currency, input)
+	if err := r.applyParentSettings(parentAccount, currency, input); err != nil {
+		return err
+	}
 	input.fullName = parentAccount.Name // prefix for FormatAccountName in runFromFlags
 	return nil
 }

--- a/internal/service/account_ops.go
+++ b/internal/service/account_ops.go
@@ -50,6 +50,7 @@ func (as *AccountService) CreateAccount(ctx context.Context, name string, accTyp
 	if err := as.ValidateFullAccountName(name); err != nil {
 		return nil, fmt.Errorf("invalid account name: %w", err)
 	}
+	currency = strings.ToUpper(strings.TrimSpace(currency))
 	if err := as.ValidateCurrency(currency); err != nil {
 		return nil, fmt.Errorf("invalid currency: %w", err)
 	}

--- a/internal/service/account_ops_test.go
+++ b/internal/service/account_ops_test.go
@@ -231,6 +231,15 @@ func TestCreateAccount(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "USD", acc.Currency)
 	})
+
+	t.Run("currency with surrounding whitespace is trimmed and uppercased", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		acc, err := svc.CreateAccount(context.Background(), "Assets:Bank", model.AccountTypeAsset, " eur ", "My bank", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "EUR", acc.Currency)
+	})
 }
 
 // ──────────────────────────────────────────────

--- a/internal/service/account_ops_test.go
+++ b/internal/service/account_ops_test.go
@@ -222,6 +222,15 @@ func TestCreateAccount(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrAlreadyExists), "expected ErrAlreadyExists, got: %v", err)
 	})
+
+	t.Run("lowercase currency is normalized to uppercase", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		acc, err := svc.CreateAccount(context.Background(), "Assets:Bank", model.AccountTypeAsset, "usd", "My bank", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "USD", acc.Currency)
+	})
 }
 
 // ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Normalizes currency codes to uppercase in `AccountService.CreateAccount` so all callers receive canonical codes regardless of input casing
- Adds validation to `applyParentSettings` which previously skipped `ValidateCurrency` entirely
- Removes redundant normalization from `applyTypeSettings` in the cmd layer

Closes #44

## Test plan

- [x] New test: lowercase `"usd"` passed to `CreateAccount` asserts stored as `"USD"`
- [x] Full test suite passes (`go test ./...`)
- [x] Build succeeds (`make build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)