### PR TITLE
fix: make CreateAccountWithBalance atomic (issue #29)

### DIFF
--- a/internal/service/account_ops.go
+++ b/internal/service/account_ops.go
@@ -47,30 +47,65 @@ func (as *AccountService) validateParentChain(ctx context.Context, accountID int
 }
 
 func (as *AccountService) CreateAccount(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64) (*model.Account, error) {
+	if err := as.validateAccountFields(ctx, name, accType, currency, parentID); err != nil {
+		return nil, err
+	}
+	currency = strings.ToUpper(strings.TrimSpace(currency))
+	return as.createAccountViaRepo(ctx, as.repo, name, accType, currency, description, parentID)
+}
+
+func (as *AccountService) CreateAccountWithBalance(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64, balance int64) (*model.Account, error) {
+	if err := as.validateAccountFields(ctx, name, accType, currency, parentID); err != nil {
+		return nil, err
+	}
+	currency = strings.ToUpper(strings.TrimSpace(currency))
+
+	if balance == 0 {
+		return as.createAccountViaRepo(ctx, as.repo, name, accType, currency, description, parentID)
+	}
+
+	var account *model.Account
+	err := as.tm.ExecTx(ctx, func(repo repository.Repository) error {
+		acc, createErr := as.createAccountViaRepo(ctx, repo, name, accType, currency, description, parentID)
+		if createErr != nil {
+			return createErr
+		}
+		account = acc
+		return as.createOpeningBalanceInRepo(ctx, repo, account, balance)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return account, nil
+}
+
+func (as *AccountService) validateAccountFields(ctx context.Context, name string, accType model.AccountType, currency string, parentID *int64) error {
 	if err := as.ValidateFullAccountName(name); err != nil {
-		return nil, fmt.Errorf("invalid account name: %w", err)
+		return fmt.Errorf("invalid account name: %w", err)
 	}
 	currency = strings.ToUpper(strings.TrimSpace(currency))
 	if err := as.ValidateCurrency(currency); err != nil {
-		return nil, fmt.Errorf("invalid currency: %w", err)
+		return fmt.Errorf("invalid currency: %w", err)
 	}
 	if !accType.IsValid() {
-		return nil, fmt.Errorf("invalid account type: %s", accType)
+		return fmt.Errorf("invalid account type: %s", accType)
 	}
 	if parentID != nil {
 		if err := as.validateParentChain(ctx, 0, parentID); err != nil {
-			return nil, err
+			return err
 		}
 	}
+	return nil
+}
 
-	newID, err := as.repo.CreateAccount(ctx, name, accType, currency, description, parentID)
+func (as *AccountService) createAccountViaRepo(ctx context.Context, repo repository.AccountRepository, name string, accType model.AccountType, currency, description string, parentID *int64) (*model.Account, error) {
+	newID, err := repo.CreateAccount(ctx, name, accType, currency, description, parentID)
 	if err != nil {
 		if errors.Is(err, repository.ErrAlreadyExists) {
 			return nil, fmt.Errorf("account %q: %w", name, ErrAlreadyExists)
 		}
 		return nil, err
 	}
-
 	return &model.Account{
 		ID:          newID,
 		Name:        name,
@@ -82,22 +117,7 @@ func (as *AccountService) CreateAccount(ctx context.Context, name string, accTyp
 	}, nil
 }
 
-func (as *AccountService) CreateAccountWithBalance(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64, balance int64) (*model.Account, error) {
-	account, err := as.CreateAccount(ctx, name, accType, currency, description, parentID)
-	if err != nil {
-		return nil, err
-	}
-
-	if balance != 0 {
-		if err := as.createOpeningBalance(ctx, account, balance); err != nil {
-			return account, fmt.Errorf("account created but failed to set opening balance: %w", err)
-		}
-	}
-
-	return account, nil
-}
-
-func (as *AccountService) createOpeningBalance(ctx context.Context, account *model.Account, amountInCents int64) error {
+func (as *AccountService) createOpeningBalanceInRepo(ctx context.Context, repo repository.Repository, account *model.Account, amountInCents int64) error {
 	currency := account.Currency
 	if currency == "" {
 		currency = as.config.Defaults.Currency
@@ -114,7 +134,7 @@ func (as *AccountService) createOpeningBalance(ctx context.Context, account *mod
 		balanceAmount = -amountInCents
 		equityAmount = amountInCents
 	default:
-		return fmt.Errorf("only Assets(A) and Liabilities(L) accounts can set a balance")
+		return fmt.Errorf("only Assets(A) and Liabilities(L) accounts can set an opening balance")
 	}
 
 	tx := model.Transaction{
@@ -124,34 +144,31 @@ func (as *AccountService) createOpeningBalance(ctx context.Context, account *mod
 		Type:        model.TxTypeOpening,
 	}
 
-	return as.tm.ExecTx(ctx, func(repo repository.Repository) error {
-		equityAcc, err := repo.GetAccountByName(ctx, equityAccountName)
-		if err != nil {
-			if !errors.Is(err, repository.ErrNotFound) {
-				return fmt.Errorf("failed to look up %q: %w", equityAccountName, err)
-			}
-			// not found — create it
-			newID, createErr := repo.CreateAccount(
-				ctx,
-				equityAccountName,
-				model.AccountTypeEquity,
-				currency,
-				"Opening Balances (System Account)",
-				nil,
-			)
-			if createErr != nil {
-				return fmt.Errorf("failed to create %q: %w", equityAccountName, createErr)
-			}
-			equityAcc = &model.Account{ID: newID}
+	equityAcc, err := repo.GetAccountByName(ctx, equityAccountName)
+	if err != nil {
+		if !errors.Is(err, repository.ErrNotFound) {
+			return fmt.Errorf("failed to look up %q: %w", equityAccountName, err)
 		}
+		newID, createErr := repo.CreateAccount(
+			ctx,
+			equityAccountName,
+			model.AccountTypeEquity,
+			currency,
+			"Opening Balances (System Account)",
+			nil,
+		)
+		if createErr != nil {
+			return fmt.Errorf("failed to create %q: %w", equityAccountName, createErr)
+		}
+		equityAcc = &model.Account{ID: newID}
+	}
 
-		splits := []model.Split{
-			{AccountID: account.ID, Amount: balanceAmount, Currency: currency, Memo: model.OpeningAccountMemo},
-			{AccountID: equityAcc.ID, Amount: equityAmount, Currency: currency, Memo: model.OpeningAccountMemo},
-		}
-		_, err = repo.CreateTransactionWithSplits(ctx, tx, splits)
-		return err
-	})
+	splits := []model.Split{
+		{AccountID: account.ID, Amount: balanceAmount, Currency: currency, Memo: model.OpeningAccountMemo},
+		{AccountID: equityAcc.ID, Amount: equityAmount, Currency: currency, Memo: model.OpeningAccountMemo},
+	}
+	_, err = repo.CreateTransactionWithSplits(ctx, tx, splits)
+	return err
 }
 
 func (as *AccountService) DeleteAccountByName(ctx context.Context, name string) error {

--- a/internal/service/account_ops.go
+++ b/internal/service/account_ops.go
@@ -47,18 +47,18 @@ func (as *AccountService) validateParentChain(ctx context.Context, accountID int
 }
 
 func (as *AccountService) CreateAccount(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64) (*model.Account, error) {
+	currency = strings.ToUpper(strings.TrimSpace(currency))
 	if err := as.validateAccountFields(ctx, name, accType, currency, parentID); err != nil {
 		return nil, err
 	}
-	currency = strings.ToUpper(strings.TrimSpace(currency))
 	return as.createAccountViaRepo(ctx, as.repo, name, accType, currency, description, parentID)
 }
 
 func (as *AccountService) CreateAccountWithBalance(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64, balance int64) (*model.Account, error) {
+	currency = strings.ToUpper(strings.TrimSpace(currency))
 	if err := as.validateAccountFields(ctx, name, accType, currency, parentID); err != nil {
 		return nil, err
 	}
-	currency = strings.ToUpper(strings.TrimSpace(currency))
 
 	if balance == 0 {
 		return as.createAccountViaRepo(ctx, as.repo, name, accType, currency, description, parentID)
@@ -83,7 +83,6 @@ func (as *AccountService) validateAccountFields(ctx context.Context, name string
 	if err := as.ValidateFullAccountName(name); err != nil {
 		return fmt.Errorf("invalid account name: %w", err)
 	}
-	currency = strings.ToUpper(strings.TrimSpace(currency))
 	if err := as.ValidateCurrency(currency); err != nil {
 		return fmt.Errorf("invalid currency: %w", err)
 	}

--- a/internal/service/account_ops_test.go
+++ b/internal/service/account_ops_test.go
@@ -342,9 +342,13 @@ func TestCreateAccountWithBalance_SplitDirection(t *testing.T) {
 		addOpeningBalanceAccount(accRepo)
 		svc := newTestAccountService(accRepo, txRepo)
 
-		_, err := svc.CreateAccountWithBalance(context.Background(), "Expenses:Food", model.AccountTypeExpense, "USD", "", nil, 500)
+		acc, err := svc.CreateAccountWithBalance(context.Background(), "Expenses:Food", model.AccountTypeExpense, "USD", "", nil, 500)
 		require.Error(t, err)
+		assert.Nil(t, acc, "account should be nil on unsupported type")
 		assert.Contains(t, err.Error(), "opening balance")
+
+		_, lookupErr := accRepo.GetAccountByName(context.Background(), "Expenses:Food")
+		assert.ErrorIs(t, lookupErr, repository.ErrNotFound, "account should not exist after unsupported-type rollback")
 	})
 
 	t.Run("missing Equity:OpeningBalances_USD account is auto-created", func(t *testing.T) {

--- a/internal/service/account_ops_test.go
+++ b/internal/service/account_ops_test.go
@@ -361,6 +361,21 @@ func TestCreateAccountWithBalance_SplitDirection(t *testing.T) {
 		assert.Equal(t, model.AccountTypeEquity, equityAcc.Type)
 		assert.Equal(t, "USD", equityAcc.Currency)
 	})
+
+	t.Run("opening balance failure rolls back account creation", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		addOpeningBalanceAccount(accRepo)
+		txRepo.createErr = errors.New("forced DB error")
+		svc := newTestAccountService(accRepo, txRepo)
+
+		acc, err := svc.CreateAccountWithBalance(context.Background(), "Assets:Bank", model.AccountTypeAsset, "USD", "", nil, 5000)
+		require.Error(t, err)
+		assert.Nil(t, acc, "account should be nil on rollback")
+
+		_, lookupErr := accRepo.GetAccountByName(context.Background(), "Assets:Bank")
+		assert.ErrorIs(t, lookupErr, repository.ErrNotFound, "account should not exist after rollback")
+	})
 }
 
 func TestCreateAccountWithBalance_CurrencyRouting(t *testing.T) {

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -501,21 +501,26 @@ func (m *mockTransactionManager) ExecTx(_ context.Context, fn func(repository.Re
 	// Snapshot account state before the transaction so we can roll back.
 	accSnapshot := make(map[string]*model.Account, len(m.accRepo.accountsByName))
 	for k, v := range m.accRepo.accountsByName {
-		accSnapshot[k] = v
+		cp := *v
+		accSnapshot[k] = &cp
 	}
 	idSnapshot := make(map[int64]*model.Account, len(m.accRepo.accountsByID))
 	for k, v := range m.accRepo.accountsByID {
-		idSnapshot[k] = v
+		cp := *v
+		idSnapshot[k] = &cp
 	}
 	nextIDSnapshot := m.accRepo.nextID
 
 	txSnapshot := make(map[int64]*model.Transaction, len(m.txRepo.transactions))
 	for k, v := range m.txRepo.transactions {
-		txSnapshot[k] = v
+		cp := *v
+		txSnapshot[k] = &cp
 	}
 	splitsSnapshot := make(map[int64][]*model.Split, len(m.txRepo.splits))
 	for k, v := range m.txRepo.splits {
-		splitsSnapshot[k] = v
+		cp := make([]*model.Split, len(v))
+		copy(cp, v)
+		splitsSnapshot[k] = cp
 	}
 	nextTxIDSnapshot := m.txRepo.nextTxID
 	nextSplitIDSnapshot := m.txRepo.nextSplitID

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -497,11 +497,45 @@ func (m *mockTransactionManager) ExecTx(_ context.Context, fn func(repository.Re
 	if m.failTx {
 		return errors.New("transaction manager: forced failure")
 	}
+
+	// Snapshot account state before the transaction so we can roll back.
+	accSnapshot := make(map[string]*model.Account, len(m.accRepo.accountsByName))
+	for k, v := range m.accRepo.accountsByName {
+		accSnapshot[k] = v
+	}
+	idSnapshot := make(map[int64]*model.Account, len(m.accRepo.accountsByID))
+	for k, v := range m.accRepo.accountsByID {
+		idSnapshot[k] = v
+	}
+	nextIDSnapshot := m.accRepo.nextID
+
+	txSnapshot := make(map[int64]*model.Transaction, len(m.txRepo.transactions))
+	for k, v := range m.txRepo.transactions {
+		txSnapshot[k] = v
+	}
+	splitsSnapshot := make(map[int64][]*model.Split, len(m.txRepo.splits))
+	for k, v := range m.txRepo.splits {
+		splitsSnapshot[k] = v
+	}
+	nextTxIDSnapshot := m.txRepo.nextTxID
+	nextSplitIDSnapshot := m.txRepo.nextSplitID
+
 	combined := &mockCombinedRepo{
 		mockAccountRepo:     m.accRepo,
 		mockTransactionRepo: m.txRepo,
 	}
-	return fn(combined)
+	if err := fn(combined); err != nil {
+		// Rollback: restore pre-transaction state.
+		m.accRepo.accountsByName = accSnapshot
+		m.accRepo.accountsByID = idSnapshot
+		m.accRepo.nextID = nextIDSnapshot
+		m.txRepo.transactions = txSnapshot
+		m.txRepo.splits = splitsSnapshot
+		m.txRepo.nextTxID = nextTxIDSnapshot
+		m.txRepo.nextSplitID = nextSplitIDSnapshot
+		return err
+	}
+	return nil
 }
 
 // ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Wrapped both account creation and opening balance creation in a single `ExecTx` transaction in `CreateAccountWithBalance`, so they commit or roll back together
- Extracted shared `validateAccountFields`, `createAccountViaRepo`, and `createOpeningBalanceInRepo` helpers to enable repo-scoped writes within the transaction
- Removed the partial-success return path (`account created but failed to set opening balance`) — on failure now returns `(nil, err)`
- Added rollback simulation to `mockTransactionManager.ExecTx` so service tests can verify atomicity

Closes #29

## Test plan

- [x] Atomicity regression test: verifies account does not persist when opening balance fails
- [x] Rollback assertion for unsupported account type (Expense) with non-zero balance
- [x] All existing `CreateAccount` and `CreateAccountWithBalance` tests pass unchanged
- [x] Full test suite passes (`go test ./...`)
- [x] Clean build (`make build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)