### PR TITLE
feat: add JSON tags to model structs (issue #74)

### DIFF
--- a/internal/model/account.go
+++ b/internal/model/account.go
@@ -4,11 +4,11 @@
 package model
 
 type Account struct {
-	ID          int64
-	Name        string
-	Type        AccountType
-	ParentID    *int64
-	Currency    string
-	Description string
-	IsHidden    bool
+	ID          int64       `json:"id"`
+	Name        string      `json:"name"`
+	Type        AccountType `json:"type"`
+	ParentID    *int64      `json:"parent_id,omitempty"`
+	Currency    string      `json:"currency"`
+	Description string      `json:"description"`
+	IsHidden    bool        `json:"is_hidden"`
 }

--- a/internal/model/json_test.go
+++ b/internal/model/json_test.go
@@ -218,3 +218,62 @@ func TestReconcileEntry_JSONKeys(t *testing.T) {
 
 	assert.NotContains(t, m, "OffsetAccount")
 }
+
+func TestTransactionStatus_JSONMarshal(t *testing.T) {
+	tests := []struct {
+		status model.TransactionStatus
+		want   string
+	}{
+		{model.StatusPending, `"Pending"`},
+		{model.StatusCleared, `"Cleared"`},
+		{model.StatusReconciled, `"Reconciled"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			data, err := json.Marshal(tt.status)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(data))
+		})
+	}
+}
+
+func TestTransactionStatus_JSONUnmarshal(t *testing.T) {
+	tests := []struct {
+		input string
+		want  model.TransactionStatus
+	}{
+		{`"Pending"`, model.StatusPending},
+		{`"Cleared"`, model.StatusCleared},
+		{`"Reconciled"`, model.StatusReconciled},
+		{`0`, model.StatusPending},
+		{`1`, model.StatusCleared},
+		{`2`, model.StatusReconciled},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			var s model.TransactionStatus
+			err := json.Unmarshal([]byte(tt.input), &s)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, s)
+		})
+	}
+}
+
+func TestTransactionStatus_JSONRoundTrip(t *testing.T) {
+	tx := model.Transaction{
+		ID:     1,
+		Status: model.StatusReconciled,
+		Type:   model.TxTypeExpense,
+	}
+
+	data, err := json.Marshal(tx)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &m))
+	assert.Equal(t, "Reconciled", m["status"])
+
+	var tx2 model.Transaction
+	require.NoError(t, json.Unmarshal(data, &tx2))
+	assert.Equal(t, model.StatusReconciled, tx2.Status)
+}

--- a/internal/model/json_test.go
+++ b/internal/model/json_test.go
@@ -277,3 +277,22 @@ func TestTransactionStatus_JSONRoundTrip(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &tx2))
 	assert.Equal(t, model.StatusReconciled, tx2.Status)
 }
+
+func TestTransactionStatus_JSONUnmarshal_Invalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"unknown string", `"Unknown"`},
+		{"garbage string", `"garbage"`},
+		{"out of range int", `99`},
+		{"negative int", `-1`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var s model.TransactionStatus
+			err := json.Unmarshal([]byte(tt.input), &s)
+			assert.Error(t, err)
+		})
+	}
+}

--- a/internal/model/json_test.go
+++ b/internal/model/json_test.go
@@ -192,3 +192,29 @@ func TestSplitDetail_JSONKeys(t *testing.T) {
 	assert.NotContains(t, m, "AccountName")
 	assert.NotContains(t, m, "AccountType")
 }
+
+func TestReconcileEntry_JSONKeys(t *testing.T) {
+	re := model.ReconcileEntry{
+		ID:            1,
+		Timestamp:     1700000000,
+		Description:   "Payment",
+		Status:        model.StatusCleared,
+		Amount:        5000,
+		OffsetAccount: "Expenses:Rent",
+	}
+
+	data, err := json.Marshal(re)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	assert.Contains(t, m, "id")
+	assert.Contains(t, m, "timestamp")
+	assert.Contains(t, m, "description")
+	assert.Contains(t, m, "status")
+	assert.Contains(t, m, "amount")
+	assert.Contains(t, m, "offset_account")
+
+	assert.NotContains(t, m, "OffsetAccount")
+}

--- a/internal/model/json_test.go
+++ b/internal/model/json_test.go
@@ -278,6 +278,12 @@ func TestTransactionStatus_JSONRoundTrip(t *testing.T) {
 	assert.Equal(t, model.StatusReconciled, tx2.Status)
 }
 
+func TestTransactionStatus_JSONMarshal_Invalid(t *testing.T) {
+	invalid := model.TransactionStatus(99)
+	_, err := json.Marshal(invalid)
+	assert.Error(t, err)
+}
+
 func TestTransactionStatus_JSONUnmarshal_Invalid(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/model/json_test.go
+++ b/internal/model/json_test.go
@@ -135,3 +135,60 @@ func TestTransactionDetail_JSONKeys(t *testing.T) {
 
 	assert.NotContains(t, m, "Splits")
 }
+
+func TestSplit_JSONKeys(t *testing.T) {
+	s := model.Split{
+		ID:            1,
+		TransactionID: 10,
+		AccountID:     2,
+		Amount:        1000,
+		Currency:      "USD",
+		Memo:          "test",
+	}
+
+	data, err := json.Marshal(s)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	assert.Contains(t, m, "id")
+	assert.Contains(t, m, "transaction_id")
+	assert.Contains(t, m, "account_id")
+	assert.Contains(t, m, "amount")
+	assert.Contains(t, m, "currency")
+	assert.Contains(t, m, "memo")
+
+	assert.NotContains(t, m, "TransactionID")
+	assert.NotContains(t, m, "AccountID")
+}
+
+func TestSplitDetail_JSONKeys(t *testing.T) {
+	sd := model.SplitDetail{
+		ID:          1,
+		AccountID:   2,
+		AccountName: "Assets:Bank",
+		AccountType: model.AccountTypeAsset,
+		Amount:      1000,
+		Currency:    "USD",
+		Memo:        "test",
+	}
+
+	data, err := json.Marshal(sd)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	assert.Contains(t, m, "id")
+	assert.Contains(t, m, "account_id")
+	assert.Contains(t, m, "account_name")
+	assert.Contains(t, m, "account_type")
+	assert.Contains(t, m, "amount")
+	assert.Contains(t, m, "currency")
+	assert.Contains(t, m, "memo")
+
+	assert.NotContains(t, m, "AccountID")
+	assert.NotContains(t, m, "AccountName")
+	assert.NotContains(t, m, "AccountType")
+}

--- a/internal/model/json_test.go
+++ b/internal/model/json_test.go
@@ -60,3 +60,78 @@ func TestAccount_JSON_OmitsNullParentID(t *testing.T) {
 	_, exists := m["parent_id"]
 	assert.False(t, exists, "parent_id should be omitted when nil")
 }
+
+func TestTransaction_JSONKeys(t *testing.T) {
+	extID := "ext-123"
+	tx := model.Transaction{
+		ID:          10,
+		Timestamp:   1700000000,
+		Description: "Groceries",
+		Status:      model.StatusCleared,
+		Type:        model.TxTypeExpense,
+		ExternalID:  &extID,
+	}
+
+	data, err := json.Marshal(tx)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	assert.Contains(t, m, "id")
+	assert.Contains(t, m, "timestamp")
+	assert.Contains(t, m, "description")
+	assert.Contains(t, m, "status")
+	assert.Contains(t, m, "type")
+	assert.Contains(t, m, "external_id")
+
+	assert.NotContains(t, m, "ID")
+	assert.NotContains(t, m, "ExternalID")
+}
+
+func TestTransaction_JSON_OmitsNullExternalID(t *testing.T) {
+	tx := model.Transaction{
+		ID:          10,
+		Timestamp:   1700000000,
+		Description: "Groceries",
+		Status:      model.StatusCleared,
+		Type:        model.TxTypeExpense,
+	}
+
+	data, err := json.Marshal(tx)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	_, exists := m["external_id"]
+	assert.False(t, exists, "external_id should be omitted when nil")
+}
+
+func TestTransactionDetail_JSONKeys(t *testing.T) {
+	td := model.TransactionDetail{
+		ID:          10,
+		Timestamp:   1700000000,
+		Description: "Groceries",
+		Status:      model.StatusCleared,
+		Type:        model.TxTypeExpense,
+		Splits: []model.SplitDetail{
+			{ID: 1, AccountID: 2, AccountName: "Expenses:Food", AccountType: model.AccountTypeExpense, Amount: 1000, Currency: "USD"},
+		},
+	}
+
+	data, err := json.Marshal(td)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	assert.Contains(t, m, "id")
+	assert.Contains(t, m, "timestamp")
+	assert.Contains(t, m, "description")
+	assert.Contains(t, m, "status")
+	assert.Contains(t, m, "type")
+	assert.Contains(t, m, "splits")
+
+	assert.NotContains(t, m, "Splits")
+}

--- a/internal/model/json_test.go
+++ b/internal/model/json_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package model_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hance08/kea/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccount_JSONKeys(t *testing.T) {
+	parentID := int64(5)
+	acc := model.Account{
+		ID:          1,
+		Name:        "Assets:Bank",
+		Type:        model.AccountTypeAsset,
+		ParentID:    &parentID,
+		Currency:    "USD",
+		Description: "Main bank",
+		IsHidden:    false,
+	}
+
+	data, err := json.Marshal(acc)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	assert.Contains(t, m, "id")
+	assert.Contains(t, m, "name")
+	assert.Contains(t, m, "type")
+	assert.Contains(t, m, "parent_id")
+	assert.Contains(t, m, "currency")
+	assert.Contains(t, m, "description")
+	assert.Contains(t, m, "is_hidden")
+
+	assert.NotContains(t, m, "ID")
+	assert.NotContains(t, m, "ParentID")
+	assert.NotContains(t, m, "IsHidden")
+}
+
+func TestAccount_JSON_OmitsNullParentID(t *testing.T) {
+	acc := model.Account{
+		ID:       1,
+		Name:     "Assets:Cash",
+		Type:     model.AccountTypeAsset,
+		Currency: "USD",
+	}
+
+	data, err := json.Marshal(acc)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	_, exists := m["parent_id"]
+	assert.False(t, exists, "parent_id should be omitted when nil")
+}

--- a/internal/model/transaction.go
+++ b/internal/model/transaction.go
@@ -84,10 +84,10 @@ type SplitDetail struct {
 // so the TUI can display amounts and the service can compute the cleared balance
 // without issuing per-transaction queries.
 type ReconcileEntry struct {
-	ID            int64
-	Timestamp     int64
-	Description   string
-	Status        TransactionStatus
-	Amount        int64  // net split amount for the reconciled account
-	OffsetAccount string // other-side account name; "(split)" for multi-split transactions
+	ID            int64             `json:"id"`
+	Timestamp     int64             `json:"timestamp"`
+	Description   string            `json:"description"`
+	Status        TransactionStatus `json:"status"`
+	Amount        int64             `json:"amount"`
+	OffsetAccount string            `json:"offset_account"`
 }

--- a/internal/model/transaction.go
+++ b/internal/model/transaction.go
@@ -61,22 +61,22 @@ func (d *TransactionDetail) UpdateAmountPreservingBalance(newAbsAmount int64) er
 }
 
 type Split struct {
-	ID            int64
-	TransactionID int64
-	AccountID     int64
-	Amount        int64
-	Currency      string
-	Memo          string
+	ID            int64  `json:"id"`
+	TransactionID int64  `json:"transaction_id"`
+	AccountID     int64  `json:"account_id"`
+	Amount        int64  `json:"amount"`
+	Currency      string `json:"currency"`
+	Memo          string `json:"memo"`
 }
 
 type SplitDetail struct {
-	ID          int64
-	AccountID   int64
-	AccountName string
-	AccountType AccountType
-	Amount      int64
-	Currency    string
-	Memo        string
+	ID          int64       `json:"id"`
+	AccountID   int64       `json:"account_id"`
+	AccountName string      `json:"account_name"`
+	AccountType AccountType `json:"account_type"`
+	Amount      int64       `json:"amount"`
+	Currency    string      `json:"currency"`
+	Memo        string      `json:"memo"`
 }
 
 // ReconcileEntry is a read-only projection used by the reconciliation workflow.

--- a/internal/model/transaction.go
+++ b/internal/model/transaction.go
@@ -6,21 +6,21 @@ package model
 import "errors"
 
 type Transaction struct {
-	ID          int64
-	Timestamp   int64
-	Description string
-	Status      TransactionStatus
-	Type        TransactionType
-	ExternalID  *string
+	ID          int64             `json:"id"`
+	Timestamp   int64             `json:"timestamp"`
+	Description string            `json:"description"`
+	Status      TransactionStatus `json:"status"`
+	Type        TransactionType   `json:"type"`
+	ExternalID  *string           `json:"external_id,omitempty"`
 }
 
 type TransactionDetail struct {
-	ID          int64
-	Timestamp   int64
-	Description string
-	Status      TransactionStatus
-	Type        TransactionType
-	Splits      []SplitDetail
+	ID          int64             `json:"id"`
+	Timestamp   int64             `json:"timestamp"`
+	Description string            `json:"description"`
+	Status      TransactionStatus `json:"status"`
+	Type        TransactionType   `json:"type"`
+	Splits      []SplitDetail     `json:"splits"`
 }
 
 type TransactionRule struct {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -4,6 +4,7 @@
 package model
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -85,6 +86,33 @@ func (s TransactionStatus) String() string {
 	default:
 		return "Unknown"
 	}
+}
+
+func (s TransactionStatus) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+func (s *TransactionStatus) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		var num int
+		if err2 := json.Unmarshal(data, &num); err2 != nil {
+			return err
+		}
+		*s = TransactionStatus(num)
+		return nil
+	}
+	switch str {
+	case "Pending":
+		*s = StatusPending
+	case "Cleared":
+		*s = StatusCleared
+	case "Reconciled":
+		*s = StatusReconciled
+	default:
+		return fmt.Errorf("unknown transaction status %q", str)
+	}
+	return nil
 }
 
 const (

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -89,7 +89,11 @@ func (s TransactionStatus) String() string {
 }
 
 func (s TransactionStatus) MarshalJSON() ([]byte, error) {
-	return json.Marshal(s.String())
+	str := s.String()
+	if str == "Unknown" {
+		return nil, fmt.Errorf("cannot marshal invalid transaction status %d", int(s))
+	}
+	return json.Marshal(str)
 }
 
 func (s *TransactionStatus) UnmarshalJSON(data []byte) error {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -99,7 +99,11 @@ func (s *TransactionStatus) UnmarshalJSON(data []byte) error {
 		if err2 := json.Unmarshal(data, &num); err2 != nil {
 			return err
 		}
-		*s = TransactionStatus(num)
+		ts := TransactionStatus(num)
+		if ts != StatusPending && ts != StatusCleared && ts != StatusReconciled {
+			return fmt.Errorf("unknown transaction status %d", num)
+		}
+		*s = ts
 		return nil
 	}
 	switch str {


### PR DESCRIPTION
## Summary

- Added `json:"snake_case"` tags to 6 core model structs: `Account`, `Transaction`, `TransactionDetail`, `Split`, `SplitDetail`, `ReconcileEntry`
- Added `MarshalJSON`/`UnmarshalJSON` for `TransactionStatus` so it serializes as `"Pending"`/`"Cleared"`/`"Reconciled"` instead of raw integers, with bounds validation on deserialization
- `omitempty` applied only to pointer fields (`ParentID`, `ExternalID`)
- Custom time type deferred — existing DTO layer in `ui/views/json_types.go` handles timestamp formatting

Closes #74

## Test plan

- [x] 12 new tests in `internal/model/json_test.go` covering all tagged structs
- [x] Round-trip marshal/unmarshal for `TransactionStatus`
- [x] Negative tests for invalid status values (unknown strings, out-of-range ints)
- [x] Full test suite passes (`go test ./...`)
- [x] Binary builds successfully (`make build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)