### PR TITLE
feat: add structured ValidationError for HTTP status mapping (issue #77)

### DIFF
--- a/internal/service/account_ops.go
+++ b/internal/service/account_ops.go
@@ -81,13 +81,13 @@ func (as *AccountService) CreateAccountWithBalance(ctx context.Context, name str
 
 func (as *AccountService) validateAccountFields(ctx context.Context, name string, accType model.AccountType, currency string, parentID *int64) error {
 	if err := as.ValidateFullAccountName(name); err != nil {
-		return fmt.Errorf("invalid account name: %w", err)
+		return validationWrap("name", "invalid account name", err)
 	}
 	if err := as.ValidateCurrency(currency); err != nil {
-		return fmt.Errorf("invalid currency: %w", err)
+		return validationWrap("currency", "invalid currency", err)
 	}
 	if !accType.IsValid() {
-		return fmt.Errorf("invalid account type: %s", accType)
+		return validationErrorf("type", "invalid account type: %s", accType)
 	}
 	if parentID != nil {
 		if err := as.validateParentChain(ctx, 0, parentID); err != nil {
@@ -133,7 +133,7 @@ func (as *AccountService) createOpeningBalanceInRepo(ctx context.Context, repo r
 		balanceAmount = -amountInCents
 		equityAmount = amountInCents
 	default:
-		return fmt.Errorf("only Assets(A) and Liabilities(L) accounts can set an opening balance")
+		return validationErrorf("type", "only Assets(A) and Liabilities(L) accounts can set an opening balance")
 	}
 
 	tx := model.Transaction{
@@ -185,7 +185,7 @@ func (as *AccountService) DeleteAccountByName(ctx context.Context, name string) 
 		return err
 	}
 	if hasChildren {
-		return fmt.Errorf("account %q has child accounts; delete or move them first", acc.Name)
+		return validationErrorf("", "account %q has child accounts; delete or move them first", acc.Name)
 	}
 
 	hasTransactions, err := as.repo.AccountHasTransactions(ctx, acc.ID)
@@ -193,7 +193,7 @@ func (as *AccountService) DeleteAccountByName(ctx context.Context, name string) 
 		return err
 	}
 	if hasTransactions {
-		return fmt.Errorf("account %q has transactions and cannot be deleted", acc.Name)
+		return validationErrorf("", "account %q has transactions and cannot be deleted", acc.Name)
 	}
 
 	return as.repo.DeleteAccount(ctx, acc.ID)
@@ -217,7 +217,7 @@ func (as *AccountService) RenameAccount(ctx context.Context, oldName, newSegment
 	}
 
 	if err := as.ValidateAccountName(newSegment); err != nil {
-		return fmt.Errorf("invalid account name: %w", err)
+		return validationWrap("name", "invalid account name", err)
 	}
 
 	var newFullName string
@@ -232,7 +232,7 @@ func (as *AccountService) RenameAccount(ctx context.Context, oldName, newSegment
 		return err
 	}
 	if exists {
-		return fmt.Errorf("account %q already exists", newFullName)
+		return validationErrorf("name", "account %q already exists", newFullName)
 	}
 
 	return as.repo.RenameAccount(ctx, acc.Name, newFullName)

--- a/internal/service/account_service.go
+++ b/internal/service/account_service.go
@@ -60,7 +60,7 @@ func (as *AccountService) GetRootNameByType(accType string) (string, error) {
 	at := model.AccountType(strings.ToUpper(accType))
 	name, ok := at.RootName()
 	if !ok {
-		return "", fmt.Errorf("invalid account type '%s' (must be A, L, C, R, E)", accType)
+		return "", validationErrorf("type", "invalid account type '%s' (must be A, L, C, R, E)", accType)
 	}
 	return name, nil
 }
@@ -89,7 +89,7 @@ func (as *AccountService) ValidateSelectableAccount(ctx context.Context, name st
 	}
 
 	if acc.IsHidden {
-		return fmt.Errorf("account %q is hidden", name)
+		return validationErrorf("account", "account %q is hidden", name)
 	}
 
 	hasChildren, err := as.repo.HasChildAccounts(ctx, acc.ID)
@@ -97,7 +97,7 @@ func (as *AccountService) ValidateSelectableAccount(ctx context.Context, name st
 		return err
 	}
 	if hasChildren {
-		return fmt.Errorf("account %q is a parent account; select a leaf account instead", name)
+		return validationErrorf("account", "account %q is a parent account; select a leaf account instead", name)
 	}
 
 	return nil

--- a/internal/service/account_service.go
+++ b/internal/service/account_service.go
@@ -84,7 +84,7 @@ func (as *AccountService) ValidateSelectableAccount(ctx context.Context, name st
 			}
 		}
 		if !allowed {
-			return fmt.Errorf("account %q has type %q, not allowed for this transaction type (allowed: %v)", name, acc.Type, allowedTypes)
+			return validationErrorf("type", "account %q has type %q, not allowed for this transaction type (allowed: %v)", name, acc.Type, allowedTypes)
 		}
 	}
 

--- a/internal/service/account_validation.go
+++ b/internal/service/account_validation.go
@@ -4,7 +4,6 @@
 package service
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/hance08/kea/internal/model"
@@ -13,21 +12,21 @@ import (
 // ValidateAccountName validates a basic account name segment (without path prefix)
 func (as *AccountService) ValidateAccountName(name string) error {
 	if name != strings.TrimSpace(name) {
-		return fmt.Errorf("account name cannot start or end with spaces")
+		return validationErrorf("name", "account name cannot start or end with spaces")
 	}
 	name = strings.TrimSpace(name)
 
 	if name == "" {
-		return fmt.Errorf("account name can't be empty")
+		return validationErrorf("name", "account name can't be empty")
 	}
 	if strings.Contains(name, ":") {
-		return fmt.Errorf("account name cannot contain ':' character")
+		return validationErrorf("name", "account name cannot contain ':' character")
 	}
 	if model.ReservedNames[strings.ToLower(name)] {
-		return fmt.Errorf("'%s' is a reserved root account name", name)
+		return validationErrorf("name", "'%s' is a reserved root account name", name)
 	}
 	if len(name) > model.AccountNameMaxLength {
-		return fmt.Errorf("account name too long (max %d characters)", model.AccountNameMaxLength)
+		return validationErrorf("name", "account name too long (max %d characters)", model.AccountNameMaxLength)
 	}
 	return nil
 }
@@ -35,42 +34,42 @@ func (as *AccountService) ValidateAccountName(name string) error {
 // ValidateFullAccountName validates the full hierarchical account name (e.g. "Assets:Bank:Checking")
 func (as *AccountService) ValidateFullAccountName(fullName string) error {
 	if fullName != strings.TrimSpace(fullName) {
-		return fmt.Errorf("account name cannot start or end with spaces")
+		return validationErrorf("name", "account name cannot start or end with spaces")
 	}
 	fullName = strings.TrimSpace(fullName)
 	if fullName == "" {
-		return fmt.Errorf("account name can't be empty")
+		return validationErrorf("name", "account name can't be empty")
 	}
 	if len(fullName) > model.AccountNameMaxLength {
-		return fmt.Errorf("account name too long (max %d characters)", model.AccountNameMaxLength)
+		return validationErrorf("name", "account name too long (max %d characters)", model.AccountNameMaxLength)
 	}
 
 	parts := strings.Split(fullName, ":")
 	if len(parts) == 0 {
-		return fmt.Errorf("invalid account name")
+		return validationErrorf("name", "invalid account name")
 	}
 
 	root := strings.ToLower(strings.TrimSpace(parts[0]))
 	if !model.ReservedNames[root] {
-		return fmt.Errorf("account root must be one of: Assets, Liabilities, Equity, Revenue, Expenses")
+		return validationErrorf("name", "account root must be one of: Assets, Liabilities, Equity, Revenue, Expenses")
 	}
 
 	for i, part := range parts {
 		if part != strings.TrimSpace(part) {
-			return fmt.Errorf("account segment at level %d cannot start or end with spaces", i+1)
+			return validationErrorf("name", "account segment at level %d cannot start or end with spaces", i+1)
 		}
 		segment := strings.TrimSpace(part)
 		if segment == "" {
-			return fmt.Errorf("account name has empty segment at level %d", i+1)
+			return validationErrorf("name", "account name has empty segment at level %d", i+1)
 		}
 		if strings.Contains(segment, ":") {
-			return fmt.Errorf("account segment '%s' cannot contain ':'", segment)
+			return validationErrorf("name", "account segment '%s' cannot contain ':'", segment)
 		}
 		if len(segment) > model.AccountNameMaxLength {
-			return fmt.Errorf("account segment too long (max %d characters)", model.AccountNameMaxLength)
+			return validationErrorf("name", "account segment too long (max %d characters)", model.AccountNameMaxLength)
 		}
 		if i > 0 && model.ReservedNames[strings.ToLower(segment)] {
-			return fmt.Errorf("account segment '%s' cannot use reserved root account name", segment)
+			return validationErrorf("name", "account segment '%s' cannot use reserved root account name", segment)
 		}
 	}
 
@@ -85,11 +84,11 @@ func (as *AccountService) ValidateCurrency(currency string) error {
 		return nil // empty is allowed, will use default
 	}
 	if len(currency) != 3 {
-		return fmt.Errorf("currency code must be 3 characters (e.g. USD)")
+		return validationErrorf("currency", "currency code must be 3 characters (e.g. USD)")
 	}
 	for _, c := range currency {
 		if c < 'A' || c > 'Z' {
-			return fmt.Errorf("currency code must contain only letters")
+			return validationErrorf("currency", "currency code must contain only letters")
 		}
 	}
 	return nil

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -3,7 +3,10 @@
 
 package service
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	ErrReconciled     = errors.New("transaction has been reconciled")
@@ -12,3 +15,26 @@ var (
 	ErrAlreadyExists  = errors.New("record already exists")
 	ErrCircularParent = errors.New("circular parent reference detected")
 )
+
+// ValidationError represents a user-input validation failure.
+type ValidationError struct {
+	Field   string // which field failed (empty for cross-field validations)
+	Message string
+	Err     error // optional wrapped error
+}
+
+func (e *ValidationError) Error() string { return e.Message }
+
+func (e *ValidationError) Unwrap() error { return e.Err }
+
+func validationErrorf(field, format string, args ...any) *ValidationError {
+	return &ValidationError{Field: field, Message: fmt.Sprintf(format, args...)}
+}
+
+func validationWrap(field, prefix string, err error) *ValidationError {
+	return &ValidationError{
+		Field:   field,
+		Message: prefix + ": " + err.Error(),
+		Err:     err,
+	}
+}

--- a/internal/service/errors_test.go
+++ b/internal/service/errors_test.go
@@ -313,3 +313,55 @@ func TestParseTransactionDate_InvalidFormat_ReturnsValidationError(t *testing.T)
 	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
 	assert.Equal(t, "date", ve.Field)
 }
+
+func TestValidateSplitsBalance_ReturnsValidationError(t *testing.T) {
+	txRepo := newMockTransactionRepo()
+	accRepo := newMockAccountRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	splits := []model.Split{
+		{AccountID: 1, Amount: 100, Currency: "USD"},
+		{AccountID: 2, Amount: -50, Currency: "USD"},
+	}
+	err := svc.ValidateSplitsBalance(splits)
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+	assert.Equal(t, "splits", ve.Field)
+}
+
+func TestValidateSplitsBalance_MixedCurrency_ReturnsValidationError(t *testing.T) {
+	txRepo := newMockTransactionRepo()
+	accRepo := newMockAccountRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	splits := []model.Split{
+		{AccountID: 1, Amount: 100, Currency: "USD"},
+		{AccountID: 2, Amount: -100, Currency: "EUR"},
+	}
+	err := svc.ValidateSplitsBalance(splits)
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+	assert.Equal(t, "splits", ve.Field)
+}
+
+func TestValidateSplitsMatchType_BadExpense_ReturnsValidationError(t *testing.T) {
+	txRepo := newMockTransactionRepo()
+	accRepo := newMockAccountRepo()
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Cash", Type: model.AccountTypeAsset})
+	accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Bank", Type: model.AccountTypeAsset})
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	splits := []model.SplitDetail{
+		{AccountName: "Assets:Cash", AccountID: 1, Amount: 100},
+		{AccountName: "Assets:Bank", AccountID: 2, Amount: -100},
+	}
+	err := svc.ValidateSplitsMatchType(context.Background(), model.TxTypeExpense, splits)
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+}

--- a/internal/service/errors_test.go
+++ b/internal/service/errors_test.go
@@ -226,3 +226,90 @@ func TestCreateAccountWithBalance_NonAL_ReturnsValidationError(t *testing.T) {
 	var ve *ValidationError
 	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
 }
+
+func TestCreateTransaction_TooFewSplits_ReturnsValidationError(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	input := model.TransactionDetail{
+		Type:   model.TxTypeExpense,
+		Splits: []model.SplitDetail{{AccountName: "A", Amount: 100}},
+	}
+	_, err := svc.CreateTransaction(context.Background(), input)
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+	assert.Equal(t, "splits", ve.Field)
+}
+
+func TestCreateTransaction_EmptyType_ReturnsValidationError(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	input := model.TransactionDetail{
+		Splits: []model.SplitDetail{
+			{AccountName: "A", Amount: 100},
+			{AccountName: "B", Amount: -100},
+		},
+	}
+	_, err := svc.CreateTransaction(context.Background(), input)
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+	assert.Equal(t, "type", ve.Field)
+}
+
+func TestCreateSimpleTransaction_SameAccount_ReturnsValidationError(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	_, err := svc.CreateSimpleTransaction(context.Background(), "Assets:Cash", "Assets:Cash", 100, "test", 0, 0, model.TxTypeTransfer)
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve))
+}
+
+func TestCreateSimpleTransaction_NegativeAmount_ReturnsValidationError(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	_, err := svc.CreateSimpleTransaction(context.Background(), "A", "B", -5, "test", 0, 0, model.TxTypeTransfer)
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve))
+	assert.Equal(t, "amount", ve.Field)
+}
+
+func TestUpdateTransactionStatus_InvalidStatus_ReturnsValidationError(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	err := svc.UpdateTransactionStatus(context.Background(), 5, model.TransactionStatus(99))
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+	assert.Equal(t, "status", ve.Field)
+}
+
+func TestParseTransactionDate_InvalidFormat_ReturnsValidationError(t *testing.T) {
+	txRepo := newMockTransactionRepo()
+	accRepo := newMockAccountRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	_, err := svc.ParseTransactionDate("not-a-date")
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+	assert.Equal(t, "date", ve.Field)
+}

--- a/internal/service/errors_test.go
+++ b/internal/service/errors_test.go
@@ -72,3 +72,80 @@ func TestValidationError_NotMatchSentinels(t *testing.T) {
 	assert.False(t, errors.Is(ve, ErrNotFound))
 	assert.False(t, errors.Is(ve, ErrNotEditable))
 }
+
+func TestValidateAccountName_ReturnsValidationError(t *testing.T) {
+	svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
+
+	tests := []struct {
+		name  string
+		input string
+		field string
+	}{
+		{"empty name", "", "name"},
+		{"has colon", "foo:bar", "name"},
+		{"too long", string(make([]byte, 256)), "name"},
+		{"leading space", " foo", "name"},
+		{"reserved name", "assets", "name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := svc.ValidateAccountName(tt.input)
+			assert.Error(t, err)
+
+			var ve *ValidationError
+			assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+			assert.Equal(t, tt.field, ve.Field)
+		})
+	}
+}
+
+func TestValidateCurrency_ReturnsValidationError(t *testing.T) {
+	svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
+
+	tests := []struct {
+		name  string
+		input string
+		field string
+	}{
+		{"too short", "US", "currency"},
+		{"has digits", "U2D", "currency"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := svc.ValidateCurrency(tt.input)
+			assert.Error(t, err)
+
+			var ve *ValidationError
+			assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+			assert.Equal(t, tt.field, ve.Field)
+		})
+	}
+}
+
+func TestValidateFullAccountName_ReturnsValidationError(t *testing.T) {
+	svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
+
+	tests := []struct {
+		name  string
+		input string
+		field string
+	}{
+		{"empty", "", "name"},
+		{"bad root", "Foo:Bar", "name"},
+		{"empty segment", "Assets::Checking", "name"},
+		{"reserved in segment", "Assets:Equity", "name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := svc.ValidateFullAccountName(tt.input)
+			assert.Error(t, err)
+
+			var ve *ValidationError
+			assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+			assert.Equal(t, tt.field, ve.Field)
+		})
+	}
+}

--- a/internal/service/errors_test.go
+++ b/internal/service/errors_test.go
@@ -4,10 +4,12 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/hance08/kea/internal/model"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -148,4 +150,79 @@ func TestValidateFullAccountName_ReturnsValidationError(t *testing.T) {
 			assert.Equal(t, tt.field, ve.Field)
 		})
 	}
+}
+
+func TestCreateAccount_ValidationErrors(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+	tests := []struct {
+		name    string
+		accName string
+		accType model.AccountType
+		field   string
+	}{
+		{"invalid name", "", model.AccountTypeAsset, "name"},
+		{"invalid type", "Assets:Cash", model.AccountType("X"), "type"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := svc.CreateAccount(context.Background(), tt.accName, tt.accType, "USD", "", nil)
+			assert.Error(t, err)
+
+			var ve *ValidationError
+			assert.True(t, errors.As(err, &ve), "expected ValidationError for %s, got: %T: %v", tt.name, err, err)
+		})
+	}
+}
+
+func TestDeleteAccount_HasChildren_ReturnsValidationError(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank", Type: model.AccountTypeAsset})
+	accRepo.childMap[1] = true
+
+	svc := newTestAccountService(accRepo, newMockTransactionRepo())
+	err := svc.DeleteAccountByName(context.Background(), "Assets:Bank")
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+}
+
+func TestDeleteAccount_HasTransactions_ReturnsValidationError(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank", Type: model.AccountTypeAsset})
+	accRepo.txExistsMap[1] = true
+
+	svc := newTestAccountService(accRepo, newMockTransactionRepo())
+	err := svc.DeleteAccountByName(context.Background(), "Assets:Bank")
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+}
+
+func TestRenameAccount_DuplicateName_ReturnsValidationError(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Old", Type: model.AccountTypeAsset})
+	accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Existing", Type: model.AccountTypeAsset})
+
+	svc := newTestAccountService(accRepo, newMockTransactionRepo())
+	err := svc.RenameAccount(context.Background(), "Assets:Old", "Existing")
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+}
+
+func TestCreateAccountWithBalance_NonAL_ReturnsValidationError(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+	_, err := svc.CreateAccountWithBalance(context.Background(), "Revenue:Sales", model.AccountTypeRevenue, "USD", "", nil, 1000)
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
 }

--- a/internal/service/errors_test.go
+++ b/internal/service/errors_test.go
@@ -365,3 +365,55 @@ func TestValidateSplitsMatchType_BadExpense_ReturnsValidationError(t *testing.T)
 	var ve *ValidationError
 	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
 }
+
+func TestPreviewReconcile_EmptyTxIDs_ReturnsValidationError(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	_, err := svc.PreviewReconcile(context.Background(), 1, 0, nil)
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+	assert.Equal(t, "transactions", ve.Field)
+}
+
+func TestReconcile_InvalidTxID_ReturnsValidationError(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank", Type: model.AccountTypeAsset})
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	_, err := svc.ReconcileTransactions(context.Background(), 1, 0, []int64{999})
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+	assert.Equal(t, "transactions", ve.Field)
+}
+
+func TestParseMonth_Invalid_ReturnsValidationError(t *testing.T) {
+	_, _, _, err := parseMonth("bad")
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+	assert.Equal(t, "month", ve.Field)
+}
+
+func TestParseDateRange_Invalid_ReturnsValidationError(t *testing.T) {
+	_, _, _, err := parseDateRange("bad", "")
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+}
+
+func TestParseDateRange_EndBeforeStart_ReturnsValidationError(t *testing.T) {
+	_, _, _, err := parseDateRange("2026-01-15", "2026-01-01")
+	assert.Error(t, err)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve), "expected ValidationError, got: %T: %v", err, err)
+}

--- a/internal/service/errors_test.go
+++ b/internal/service/errors_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package service
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidationError_Error(t *testing.T) {
+	ve := &ValidationError{Field: "name", Message: "name is required"}
+	assert.Equal(t, "name is required", ve.Error())
+}
+
+func TestValidationError_ErrorsAs(t *testing.T) {
+	ve := &ValidationError{Field: "amount", Message: "amount must be positive"}
+	wrapped := fmt.Errorf("split #1: %w", ve)
+
+	var target *ValidationError
+	assert.True(t, errors.As(wrapped, &target))
+	assert.Equal(t, "amount", target.Field)
+	assert.Equal(t, "amount must be positive", target.Message)
+}
+
+func TestValidationError_Unwrap(t *testing.T) {
+	inner := errors.New("parse error")
+	ve := &ValidationError{Field: "date", Message: "invalid date", Err: inner}
+
+	assert.True(t, errors.Is(ve, inner))
+}
+
+func TestValidationError_NilUnwrap(t *testing.T) {
+	ve := &ValidationError{Field: "name", Message: "name is required"}
+	assert.Nil(t, ve.Unwrap())
+}
+
+func TestValidationErrorf(t *testing.T) {
+	err := validationErrorf("splits", "must have at least %d splits (got %d)", 2, 1)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve))
+	assert.Equal(t, "splits", ve.Field)
+	assert.Equal(t, "must have at least 2 splits (got 1)", ve.Message)
+}
+
+func TestValidationErrorf_EmptyField(t *testing.T) {
+	err := validationErrorf("", "source and destination cannot be the same")
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve))
+	assert.Equal(t, "", ve.Field)
+}
+
+func TestValidationWrap(t *testing.T) {
+	inner := &ValidationError{Field: "", Message: "can't be empty"}
+	err := validationWrap("name", "invalid account name", inner)
+
+	var ve *ValidationError
+	assert.True(t, errors.As(err, &ve))
+	assert.Equal(t, "name", ve.Field)
+	assert.Contains(t, ve.Message, "invalid account name")
+	assert.Contains(t, ve.Message, "can't be empty")
+	assert.True(t, errors.Is(err, inner))
+}
+
+func TestValidationError_NotMatchSentinels(t *testing.T) {
+	ve := &ValidationError{Field: "name", Message: "bad name"}
+	assert.False(t, errors.Is(ve, ErrNotFound))
+	assert.False(t, errors.Is(ve, ErrNotEditable))
+}

--- a/internal/service/reconcile_ops.go
+++ b/internal/service/reconcile_ops.go
@@ -38,7 +38,7 @@ func (ts *TransactionService) GetUnreconciledByAccount(ctx context.Context, acco
 //	statementBalance − (lastReconciledBalance + clearedBalance)
 func (ts *TransactionService) PreviewReconcile(ctx context.Context, accountID int64, statementBalance int64, txIDs []int64) (int64, error) {
 	if len(txIDs) == 0 {
-		return 0, fmt.Errorf("no transactions selected for reconciliation")
+		return 0, validationErrorf("transactions", "no transactions selected for reconciliation")
 	}
 
 	if _, err := ts.accRepo.GetAccountByID(ctx, accountID); err != nil {
@@ -64,7 +64,7 @@ func (ts *TransactionService) PreviewReconcile(ctx context.Context, accountID in
 	for _, id := range txIDs {
 		amount, ok := validAmounts[id]
 		if !ok {
-			return 0, fmt.Errorf("transaction ID %d is not in the unreconciled set for this account", id)
+			return 0, validationErrorf("transactions", "transaction ID %d is not in the unreconciled set for this account", id)
 		}
 		clearedBalance += amount
 	}
@@ -89,7 +89,7 @@ func (ts *TransactionService) PreviewReconcile(ctx context.Context, accountID in
 // difference is zero. The caller decides whether to warn on a non-zero diff.
 func (ts *TransactionService) ReconcileTransactions(ctx context.Context, accountID int64, statementBalance int64, txIDs []int64) (int64, error) {
 	if len(txIDs) == 0 {
-		return 0, fmt.Errorf("no transactions selected for reconciliation")
+		return 0, validationErrorf("transactions", "no transactions selected for reconciliation")
 	}
 
 	// 1. Verify account exists.
@@ -119,7 +119,7 @@ func (ts *TransactionService) ReconcileTransactions(ctx context.Context, account
 	for _, id := range txIDs {
 		amount, ok := validAmounts[id]
 		if !ok {
-			return 0, fmt.Errorf("transaction ID %d is not in the unreconciled set for this account", id)
+			return 0, validationErrorf("transactions", "transaction ID %d is not in the unreconciled set for this account", id)
 		}
 		clearedBalance += amount
 	}

--- a/internal/service/report_service.go
+++ b/internal/service/report_service.go
@@ -386,7 +386,7 @@ func parseMonth(month string) (startTime, endTime int64, period string, err erro
 	loc := time.Local
 	t, parseErr := time.ParseInLocation("2006-01", month, loc)
 	if parseErr != nil {
-		err = fmt.Errorf("invalid month format %q, expected YYYY-MM", month)
+		err = validationErrorf("month", "invalid month format %q, expected YYYY-MM", month)
 		return
 	}
 
@@ -409,7 +409,7 @@ func parseDateRange(from, to string) (startTime, endTime int64, period string, e
 	} else {
 		startDate, err = time.ParseInLocation(model.DateFormat, from, loc)
 		if err != nil {
-			err = fmt.Errorf("invalid from-date format %q, expected YYYY-MM-DD", from)
+			err = validationErrorf("from", "invalid from-date format %q, expected YYYY-MM-DD", from)
 			return
 		}
 	}
@@ -419,14 +419,14 @@ func parseDateRange(from, to string) (startTime, endTime int64, period string, e
 	} else {
 		endDate, err = time.ParseInLocation(model.DateFormat, to, loc)
 		if err != nil {
-			err = fmt.Errorf("invalid to-date format %q, expected YYYY-MM-DD", to)
+			err = validationErrorf("to", "invalid to-date format %q, expected YYYY-MM-DD", to)
 			return
 		}
 		endDate = endDate.Add(24*time.Hour - time.Second)
 	}
 
 	if endDate.Before(startDate) {
-		err = fmt.Errorf("end date must be on or after start date")
+		err = validationErrorf("to", "end date must be on or after start date")
 		return
 	}
 

--- a/internal/service/transaction_classifier.go
+++ b/internal/service/transaction_classifier.go
@@ -5,7 +5,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/utils"
@@ -308,10 +307,10 @@ func (ts *TransactionService) ValidateSplitsMatchType(ctx context.Context, txTyp
 			}
 		}
 		if !hasExpense {
-			return fmt.Errorf("expense transaction requires at least one Expense account")
+			return validationErrorf("type", "expense transaction requires at least one Expense account")
 		}
 		if !hasAssetOrLiab {
-			return fmt.Errorf("expense transaction requires at least one Asset or Liability account")
+			return validationErrorf("type", "expense transaction requires at least one Asset or Liability account")
 		}
 
 	case model.TxTypeIncome:
@@ -329,10 +328,10 @@ func (ts *TransactionService) ValidateSplitsMatchType(ctx context.Context, txTyp
 			}
 		}
 		if !hasRevenue {
-			return fmt.Errorf("income transaction requires at least one Revenue account")
+			return validationErrorf("type", "income transaction requires at least one Revenue account")
 		}
 		if !hasAssetOrLiab {
-			return fmt.Errorf("income transaction requires at least one Asset or Liability account")
+			return validationErrorf("type", "income transaction requires at least one Asset or Liability account")
 		}
 
 	case model.TxTypeTransfer:
@@ -342,12 +341,12 @@ func (ts *TransactionService) ValidateSplitsMatchType(ctx context.Context, txTyp
 				return err
 			}
 			if accType != model.AccountTypeAsset && accType != model.AccountTypeLiability {
-				return fmt.Errorf("transfer transaction must only contain Asset and Liability accounts (found account type %q)", accType)
+				return validationErrorf("type", "transfer transaction must only contain Asset and Liability accounts (found account type %q)", accType)
 			}
 		}
 
 	default:
-		return fmt.Errorf("unknown transaction type %q", txType)
+		return validationErrorf("type", "unknown transaction type %q", txType)
 	}
 
 	return nil

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -316,7 +317,10 @@ func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, txI
 		for _, split := range splits {
 			account, err := repo.GetAccountByID(ctx, split.AccountID)
 			if err != nil {
-				return validationErrorf("splits", "account ID %d not found", split.AccountID)
+				if errors.Is(err, repository.ErrNotFound) {
+					return validationErrorf("splits", "account ID %d not found", split.AccountID)
+				}
+				return err
 			}
 			isNew := split.ID == 0
 			accountChanged := split.ID != 0 && existingAccountByID[split.ID] != split.AccountID
@@ -396,7 +400,7 @@ func (ts *TransactionService) ParseTransactionDate(dateStr string) (int64, error
 	}
 	t, err := time.ParseInLocation(model.DateFormat, dateStr, time.Local)
 	if err != nil {
-		return 0, &ValidationError{Field: "date", Message: fmt.Sprintf("invalid date format, use %s: %s", model.DateFormat, err), Err: err}
+		return 0, validationWrap("date", fmt.Sprintf("invalid date format, use %s", model.DateFormat), err)
 	}
 	return t.Unix(), nil
 }

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -316,7 +316,7 @@ func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, txI
 		for _, split := range splits {
 			account, err := repo.GetAccountByID(ctx, split.AccountID)
 			if err != nil {
-				return fmt.Errorf("account ID %d not found", split.AccountID)
+				return validationErrorf("splits", "account ID %d not found", split.AccountID)
 			}
 			isNew := split.ID == 0
 			accountChanged := split.ID != 0 && existingAccountByID[split.ID] != split.AccountID

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -26,11 +26,11 @@ func (ts *TransactionService) CreateTransaction(ctx context.Context, input model
 	// Validate: According to double-entry bookkeeping principles,
 	// a transaction must consist of at least 2 splits.
 	if len(input.Splits) < 2 {
-		return 0, fmt.Errorf("transaction must have at least 2 splits (got %d)", len(input.Splits))
+		return 0, validationErrorf("splits", "transaction must have at least 2 splits (got %d)", len(input.Splits))
 	}
 
 	if input.Type == "" {
-		return 0, fmt.Errorf("transaction type is required")
+		return 0, validationErrorf("type", "transaction type is required")
 	}
 
 	// Set default timestamp: Use current system time if not provided.
@@ -109,14 +109,14 @@ func (ts *TransactionService) CreateTransaction(ctx context.Context, input model
 // checkAccountSelectable returns an error if the account is hidden or has child accounts.
 func (ts *TransactionService) checkAccountSelectable(ctx context.Context, accRepo repository.AccountRepository, account *model.Account) error {
 	if account.IsHidden {
-		return fmt.Errorf("account %q is hidden", account.Name)
+		return validationErrorf("account", "account %q is hidden", account.Name)
 	}
 	hasChildren, err := accRepo.HasChildAccounts(ctx, account.ID)
 	if err != nil {
 		return err
 	}
 	if hasChildren {
-		return fmt.Errorf("account %q is a parent account; select a leaf account instead", account.Name)
+		return validationErrorf("account", "account %q is a parent account; select a leaf account instead", account.Name)
 	}
 	return nil
 }
@@ -132,10 +132,10 @@ func (ts *TransactionService) checkAccountSelectable(ctx context.Context, accRep
 // Returns the constructed TransactionDetail (useful for UI rendering).
 func (ts *TransactionService) CreateSimpleTransaction(ctx context.Context, fromAccount, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error) {
 	if fromAccount == toAccount {
-		return model.TransactionDetail{}, fmt.Errorf("source and destination accounts cannot be the same")
+		return model.TransactionDetail{}, validationErrorf("account", "source and destination accounts cannot be the same")
 	}
 	if amount <= 0 {
-		return model.TransactionDetail{}, fmt.Errorf("amount must be positive")
+		return model.TransactionDetail{}, validationErrorf("amount", "amount must be positive")
 	}
 
 	// If no type provided, infer from account types.
@@ -226,7 +226,7 @@ func (ts *TransactionService) UpdateTransactionStatus(ctx context.Context, txID 
 
 	// Business Rule: Restrict status updates to valid enum constant to ensure data integrity.
 	if status != model.StatusPending && status != model.StatusCleared {
-		return fmt.Errorf("invalid status: must be 0 (Pending) or 1 (Cleared)")
+		return validationErrorf("status", "invalid status: must be 0 (Pending) or 1 (Cleared)")
 	}
 
 	if txID == model.SystemTransactionID {
@@ -250,7 +250,7 @@ func (ts *TransactionService) UpdateTransactionStatus(ctx context.Context, txID 
 func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType, splits []model.SplitDetail) error {
 	// Validate status
 	if status != model.StatusPending && status != model.StatusCleared && status != model.StatusReconciled {
-		return fmt.Errorf("invalid status: must be 0 (Pending), 1 (Cleared) or 2 (Reconciled)")
+		return validationErrorf("status", "invalid status: must be 0 (Pending), 1 (Cleared) or 2 (Reconciled)")
 	}
 
 	if txID == model.SystemTransactionID {
@@ -268,7 +268,7 @@ func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, txI
 
 	// Validate that we have at least 2 splits
 	if len(splits) < 2 {
-		return fmt.Errorf("transaction must have at least 2 splits for double-entry bookkeeping")
+		return validationErrorf("splits", "transaction must have at least 2 splits for double-entry bookkeeping")
 	}
 
 	if err := ts.ValidateSplitDetailsBalance(splits); err != nil {
@@ -304,11 +304,11 @@ func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, txI
 				continue
 			}
 			if seenSplitIDs[split.ID] {
-				return fmt.Errorf("duplicate split ID %d in input", split.ID)
+				return validationErrorf("splits", "duplicate split ID %d in input", split.ID)
 			}
 			seenSplitIDs[split.ID] = true
 			if _, ok := existingAccountByID[split.ID]; !ok {
-				return fmt.Errorf("split ID %d does not belong to transaction %d", split.ID, txID)
+				return validationErrorf("splits", "split ID %d does not belong to transaction %d", split.ID, txID)
 			}
 		}
 
@@ -396,7 +396,7 @@ func (ts *TransactionService) ParseTransactionDate(dateStr string) (int64, error
 	}
 	t, err := time.ParseInLocation(model.DateFormat, dateStr, time.Local)
 	if err != nil {
-		return 0, fmt.Errorf("invalid date format, use %s: %w", model.DateFormat, err)
+		return 0, &ValidationError{Field: "date", Message: fmt.Sprintf("invalid date format, use %s: %s", model.DateFormat, err), Err: err}
 	}
 	return t.Unix(), nil
 }

--- a/internal/service/transaction_service.go
+++ b/internal/service/transaction_service.go
@@ -44,7 +44,7 @@ func (ts *TransactionService) GetTransactionRule(txType model.TransactionType) (
 			DestTypes:   []string{"A", "L"},
 		}, nil
 	default:
-		return model.TransactionRule{}, fmt.Errorf("unknown transaction mode: %s", txType)
+		return model.TransactionRule{}, validationErrorf("type", "unknown transaction mode: %s", txType)
 	}
 }
 

--- a/internal/service/transaction_validation.go
+++ b/internal/service/transaction_validation.go
@@ -5,7 +5,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hance08/kea/internal/model"
 )
@@ -20,15 +19,14 @@ func (ts *TransactionService) ValidateSplitsBalance(splits []model.Split) error 
 		if firstCurrency == "" {
 			firstCurrency = split.Currency
 		} else if split.Currency != firstCurrency {
-			return fmt.Errorf("splits must all use the same currency (got %q and %q)", firstCurrency, split.Currency)
+			return validationErrorf("splits", "splits must all use the same currency (got %q and %q)", firstCurrency, split.Currency)
 		}
 		total += split.Amount
 	}
 
 	if total != 0 {
-		return fmt.Errorf("splits do not balance: total is %d cents (%.2f), must be 0. "+
-			"In double-entry bookkeeping, debits must equal credits",
-			total, float64(total)/100.0)
+		return validationErrorf("splits", "splits do not balance: total is %d cents (%.2f), must be 0. In double-entry bookkeeping, debits must equal credits",
+			total, float64(total)/100)
 	}
 
 	return nil
@@ -46,15 +44,14 @@ func (ts *TransactionService) ValidateSplitDetailsBalance(splits []model.SplitDe
 			firstCurrency = split.Currency
 			initialized = true
 		} else if split.Currency != firstCurrency {
-			return fmt.Errorf("splits must all use the same currency (got %q and %q)", firstCurrency, split.Currency)
+			return validationErrorf("splits", "splits must all use the same currency (got %q and %q)", firstCurrency, split.Currency)
 		}
 		total += split.Amount
 	}
 
 	if total != 0 {
-		return fmt.Errorf("splits do not balance: total is %d cents (%.2f), must be 0. "+
-			"In double-entry bookkeeping, debits must equal credits",
-			total, float64(total)/100.0)
+		return validationErrorf("splits", "splits do not balance: total is %d cents (%.2f), must be 0. In double-entry bookkeeping, debits must equal credits",
+			total, float64(total)/100)
 	}
 
 	return nil
@@ -64,7 +61,7 @@ func (ts *TransactionService) ValidateSplitDetailsBalance(splits []model.SplitDe
 func (ts *TransactionService) ValidateTransactionEdit(ctx context.Context, splits []model.SplitDetail) error {
 	// Check minimum splits
 	if len(splits) < model.MinSplitsCount {
-		return fmt.Errorf("transaction must have at least 2 splits")
+		return validationErrorf("splits", "transaction must have at least 2 splits")
 	}
 
 	if err := ts.ValidateSplitDetailsBalance(splits); err != nil {
@@ -75,7 +72,7 @@ func (ts *TransactionService) ValidateTransactionEdit(ctx context.Context, split
 	for i, split := range splits {
 		_, err := ts.accRepo.GetAccountByID(ctx, split.AccountID)
 		if err != nil {
-			return fmt.Errorf("split #%d: account ID %d not found", i+1, split.AccountID)
+			return validationErrorf("splits", "split #%d: account ID %d not found", i+1, split.AccountID)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add `ValidationError` type with `Field`, `Message`, `Err` fields to `internal/service/errors.go`, enabling `errors.As(err, &ve)` for HTTP 400 mapping
- Convert ~60 unstructured `fmt.Errorf()` validation errors across 9 service files to return `*ValidationError`
- Leave sentinel errors (`ErrNotEditable`, `ErrReconciled`, etc.) and infrastructure errors (`"failed to ..."`) untouched — they already map cleanly via `errors.Is`
- Add 30 test functions asserting `errors.As` works for every error category

## Test plan
- [x] All existing tests pass (error messages unchanged, only type changes)
- [x] New `errors.As` assertions cover: name, currency, type, account, splits, amount, status, date, transactions, month, date-range fields
- [x] `errors.Is` still works through `ValidationError.Unwrap()` chain
- [x] Full suite: `go test ./...` passes
- [x] Build: `make build` succeeds

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)