### PR TITLE
refactor: replace positional params with input structs in service layer

### DIFF
--- a/cmd/account/create_actions.go
+++ b/cmd/account/create_actions.go
@@ -13,15 +13,14 @@ import (
 )
 
 func (r *createRunner) createAccount(ctx context.Context, input createInput) (*model.Account, error) {
-	return r.accSvc.CreateAccountWithBalance(
-		ctx,
-		input.fullName,
-		input.accountType,
-		input.currency,
-		input.description,
-		input.parentID,
-		input.balanceCents,
-	)
+	return r.accSvc.CreateAccountWithBalance(ctx, model.CreateAccountInput{
+		Name:        input.fullName,
+		Type:        input.accountType,
+		Currency:    input.currency,
+		Description: input.description,
+		ParentID:    input.parentID,
+		Balance:     input.balanceCents,
+	})
 }
 
 func (r *createRunner) applyTypeSettings(accType, currencyOverride string, input *createInput) error {

--- a/cmd/account/create_types.go
+++ b/cmd/account/create_types.go
@@ -21,7 +21,7 @@ type CreateProvider interface {
 	GetRootNameByType(accType string) (string, error)
 	CheckAccountExists(ctx context.Context, name string) (bool, error)
 	FormatAccountName(prefix string, name string) string
-	CreateAccountWithBalance(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64, balance int64) (*model.Account, error)
+	CreateAccountWithBalance(ctx context.Context, input model.CreateAccountInput) (*model.Account, error)
 	ValidateAccountName(name string) error
 	ValidateFullAccountName(name string) error
 	ValidateCurrency(currency string) error

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -88,18 +88,25 @@ func (r *addRunner) Run(ctx context.Context, flags *addFlags, cmd *cobra.Command
 	var result model.TransactionDetail
 	if len(input.Splits) > 0 {
 		result, err = r.txSvc.CreateTransactionFromSplits(
-			ctx, input.Splits, input.Description, input.Timestamp, input.Status, input.Type,
+			ctx, model.CreateTransactionFromSplitsInput{
+				Splits:      input.Splits,
+				Description: input.Description,
+				Timestamp:   input.Timestamp,
+				Status:      input.Status,
+				Type:        input.Type,
+			},
 		)
 	} else {
 		result, err = r.txSvc.CreateSimpleTransaction(
-			ctx,
-			input.FromAccountID,
-			input.ToAccountID,
-			input.AmountCents,
-			input.Description,
-			input.Timestamp,
-			input.Status,
-			input.Type,
+			ctx, model.CreateSimpleTransactionInput{
+				FromAccount: input.FromAccountID,
+				ToAccount:   input.ToAccountID,
+				Amount:      input.AmountCents,
+				Description: input.Description,
+				Timestamp:   input.Timestamp,
+				Status:      input.Status,
+				Type:        input.Type,
+			},
 		)
 	}
 	if err != nil {

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -28,15 +28,15 @@ func (m *mockTransactionProvider) GetTransactionRule(mode model.TransactionType)
 	return model.TransactionRule{}, nil
 }
 
-func (m *mockTransactionProvider) CreateSimpleTransaction(_ context.Context, fromAccount, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error) {
+func (m *mockTransactionProvider) CreateSimpleTransaction(_ context.Context, input model.CreateSimpleTransactionInput) (model.TransactionDetail, error) {
 	if m.createSimpleErr != nil {
 		return model.TransactionDetail{}, m.createSimpleErr
 	}
 	return model.TransactionDetail{}, nil
 }
 
-func (m *mockTransactionProvider) CreateTransactionFromSplits(_ context.Context, splits []model.SplitDetail, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error) {
-	m.lastSplitsInput = splits
+func (m *mockTransactionProvider) CreateTransactionFromSplits(_ context.Context, input model.CreateTransactionFromSplitsInput) (model.TransactionDetail, error) {
+	m.lastSplitsInput = input.Splits
 	if m.createSplitsErr != nil {
 		return model.TransactionDetail{}, m.createSplitsErr
 	}

--- a/cmd/add_types.go
+++ b/cmd/add_types.go
@@ -22,8 +22,8 @@ type AddProvider interface {
 
 type TransactionProvider interface {
 	GetTransactionRule(mode model.TransactionType) (model.TransactionRule, error)
-	CreateSimpleTransaction(ctx context.Context, fromAccount string, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error)
-	CreateTransactionFromSplits(ctx context.Context, splits []model.SplitDetail, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error)
+	CreateSimpleTransaction(ctx context.Context, input model.CreateSimpleTransactionInput) (model.TransactionDetail, error)
+	CreateTransactionFromSplits(ctx context.Context, input model.CreateTransactionFromSplitsInput) (model.TransactionDetail, error)
 	ParseTransactionDate(dateStr string) (int64, error)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -159,11 +159,12 @@ func initSysAcc(svc *service.Service, cfg *config.Config) error {
 
 	_, err = svc.Account().CreateAccount(
 		context.Background(),
-		targetName,
-		model.AccountTypeEquity,
-		cfg.Defaults.Currency,
-		"Opening Balances (System Account)",
-		nil,
+		model.CreateAccountInput{
+			Name:        targetName,
+			Type:        model.AccountTypeEquity,
+			Currency:    cfg.Defaults.Currency,
+			Description: "Opening Balances (System Account)",
+		},
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create system account: %w", err)

--- a/cmd/transaction/edit_actions.go
+++ b/cmd/transaction/edit_actions.go
@@ -285,7 +285,14 @@ func (r *editRunner) actionSave(ctx context.Context, detail *model.TransactionDe
 
 	// Execute Update
 	if err := r.txSvc.UpdateTransactionComplete(
-		ctx, r.txID, detail.Description, detail.Timestamp, detail.Status, detail.Type, splits,
+		ctx, model.UpdateTransactionInput{
+			ID:          r.txID,
+			Description: detail.Description,
+			Timestamp:   detail.Timestamp,
+			Status:      detail.Status,
+			Type:        detail.Type,
+			Splits:      splits,
+		},
 	); err != nil {
 		return err
 	}

--- a/cmd/transaction/edit_types.go
+++ b/cmd/transaction/edit_types.go
@@ -37,7 +37,7 @@ type EditProvider interface {
 	GetAllowedAccounts(txType model.TransactionType, currentAccountType model.AccountType, allAccounts []*model.Account) []*model.Account
 	ValidateTransactionEdit(ctx context.Context, splits []model.SplitDetail) error
 	ValidateSplitsMatchType(ctx context.Context, txType model.TransactionType, splits []model.SplitDetail) error
-	UpdateTransactionComplete(ctx context.Context, txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType, splits []model.SplitDetail) error
+	UpdateTransactionComplete(ctx context.Context, input model.UpdateTransactionInput) error
 }
 
 type AccountProvider interface {

--- a/internal/model/input.go
+++ b/internal/model/input.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package model
+
+type CreateAccountInput struct {
+	Name        string
+	Type        AccountType
+	Currency    string
+	Description string
+	ParentID    *int64
+	Balance     int64
+}
+
+type CreateSimpleTransactionInput struct {
+	FromAccount string
+	ToAccount   string
+	Amount      int64
+	Description string
+	Timestamp   int64
+	Status      TransactionStatus
+	Type        TransactionType
+}
+
+type CreateTransactionFromSplitsInput struct {
+	Splits      []SplitDetail
+	Description string
+	Timestamp   int64
+	Status      TransactionStatus
+	Type        TransactionType
+}
+
+type UpdateTransactionInput struct {
+	ID          int64
+	Description string
+	Timestamp   int64
+	Status      TransactionStatus
+	Type        TransactionType
+	Splits      []SplitDetail
+}

--- a/internal/service/account_ops.go
+++ b/internal/service/account_ops.go
@@ -46,32 +46,32 @@ func (as *AccountService) validateParentChain(ctx context.Context, accountID int
 	return fmt.Errorf("parent chain exceeds maximum depth (%d): %w", maxParentDepth, ErrCircularParent)
 }
 
-func (as *AccountService) CreateAccount(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64) (*model.Account, error) {
-	currency = strings.ToUpper(strings.TrimSpace(currency))
-	if err := as.validateAccountFields(ctx, name, accType, currency, parentID); err != nil {
+func (as *AccountService) CreateAccount(ctx context.Context, input model.CreateAccountInput) (*model.Account, error) {
+	input.Currency = strings.ToUpper(strings.TrimSpace(input.Currency))
+	if err := as.validateAccountFields(ctx, input.Name, input.Type, input.Currency, input.ParentID); err != nil {
 		return nil, err
 	}
-	return as.createAccountViaRepo(ctx, as.repo, name, accType, currency, description, parentID)
+	return as.createAccountViaRepo(ctx, as.repo, input)
 }
 
-func (as *AccountService) CreateAccountWithBalance(ctx context.Context, name string, accType model.AccountType, currency, description string, parentID *int64, balance int64) (*model.Account, error) {
-	currency = strings.ToUpper(strings.TrimSpace(currency))
-	if err := as.validateAccountFields(ctx, name, accType, currency, parentID); err != nil {
+func (as *AccountService) CreateAccountWithBalance(ctx context.Context, input model.CreateAccountInput) (*model.Account, error) {
+	input.Currency = strings.ToUpper(strings.TrimSpace(input.Currency))
+	if err := as.validateAccountFields(ctx, input.Name, input.Type, input.Currency, input.ParentID); err != nil {
 		return nil, err
 	}
 
-	if balance == 0 {
-		return as.createAccountViaRepo(ctx, as.repo, name, accType, currency, description, parentID)
+	if input.Balance == 0 {
+		return as.createAccountViaRepo(ctx, as.repo, input)
 	}
 
 	var account *model.Account
 	err := as.tm.ExecTx(ctx, func(repo repository.Repository) error {
-		acc, createErr := as.createAccountViaRepo(ctx, repo, name, accType, currency, description, parentID)
+		acc, createErr := as.createAccountViaRepo(ctx, repo, input)
 		if createErr != nil {
 			return createErr
 		}
 		account = acc
-		return as.createOpeningBalanceInRepo(ctx, repo, account, balance)
+		return as.createOpeningBalanceInRepo(ctx, repo, account, input.Balance)
 	})
 	if err != nil {
 		return nil, err
@@ -97,21 +97,21 @@ func (as *AccountService) validateAccountFields(ctx context.Context, name string
 	return nil
 }
 
-func (as *AccountService) createAccountViaRepo(ctx context.Context, repo repository.AccountRepository, name string, accType model.AccountType, currency, description string, parentID *int64) (*model.Account, error) {
-	newID, err := repo.CreateAccount(ctx, name, accType, currency, description, parentID)
+func (as *AccountService) createAccountViaRepo(ctx context.Context, repo repository.AccountRepository, input model.CreateAccountInput) (*model.Account, error) {
+	newID, err := repo.CreateAccount(ctx, input.Name, input.Type, input.Currency, input.Description, input.ParentID)
 	if err != nil {
 		if errors.Is(err, repository.ErrAlreadyExists) {
-			return nil, fmt.Errorf("account %q: %w", name, ErrAlreadyExists)
+			return nil, fmt.Errorf("account %q: %w", input.Name, ErrAlreadyExists)
 		}
 		return nil, err
 	}
 	return &model.Account{
 		ID:          newID,
-		Name:        name,
-		Type:        accType,
-		Currency:    currency,
-		Description: description,
-		ParentID:    parentID,
+		Name:        input.Name,
+		Type:        input.Type,
+		Currency:    input.Currency,
+		Description: input.Description,
+		ParentID:    input.ParentID,
 		IsHidden:    false,
 	}, nil
 }

--- a/internal/service/account_ops_test.go
+++ b/internal/service/account_ops_test.go
@@ -172,7 +172,7 @@ func TestCreateAccount(t *testing.T) {
 		accRepo := newMockAccountRepo()
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		acc, err := svc.CreateAccount(context.Background(), "Assets:Bank", model.AccountTypeAsset, "USD", "My bank", nil)
+		acc, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD", Description: "My bank"})
 		require.NoError(t, err)
 		require.NotNil(t, acc)
 		assert.Greater(t, acc.ID, int64(0))
@@ -185,21 +185,21 @@ func TestCreateAccount(t *testing.T) {
 
 	t.Run("invalid account name (non-reserved root) rejected", func(t *testing.T) {
 		svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
-		_, err := svc.CreateAccount(context.Background(), "Money:Bank", model.AccountTypeAsset, "USD", "", nil)
+		_, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{Name: "Money:Bank", Type: model.AccountTypeAsset, Currency: "USD"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid account name")
 	})
 
 	t.Run("invalid currency code rejected", func(t *testing.T) {
 		svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
-		_, err := svc.CreateAccount(context.Background(), "Assets:Bank", model.AccountTypeAsset, "US", "", nil)
+		_, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "US"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid currency")
 	})
 
 	t.Run("invalid account type rejected", func(t *testing.T) {
 		svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
-		_, err := svc.CreateAccount(context.Background(), "Assets:Bank", model.AccountType("X"), "USD", "", nil)
+		_, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{Name: "Assets:Bank", Type: model.AccountType("X"), Currency: "USD"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid account type")
 	})
@@ -209,7 +209,7 @@ func TestCreateAccount(t *testing.T) {
 		accRepo.createErr = errors.New("db error")
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		_, err := svc.CreateAccount(context.Background(), "Assets:Bank", model.AccountTypeAsset, "USD", "", nil)
+		_, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD"})
 		require.Error(t, err)
 	})
 
@@ -218,7 +218,7 @@ func TestCreateAccount(t *testing.T) {
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD"})
 
-		_, err := svc.CreateAccount(context.Background(), "Assets:Bank", model.AccountTypeAsset, "USD", "", nil)
+		_, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD"})
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrAlreadyExists), "expected ErrAlreadyExists, got: %v", err)
 	})
@@ -227,7 +227,7 @@ func TestCreateAccount(t *testing.T) {
 		accRepo := newMockAccountRepo()
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		acc, err := svc.CreateAccount(context.Background(), "Assets:Bank", model.AccountTypeAsset, "usd", "My bank", nil)
+		acc, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "usd", Description: "My bank"})
 		require.NoError(t, err)
 		assert.Equal(t, "USD", acc.Currency)
 	})
@@ -236,7 +236,7 @@ func TestCreateAccount(t *testing.T) {
 		accRepo := newMockAccountRepo()
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		acc, err := svc.CreateAccount(context.Background(), "Assets:Bank", model.AccountTypeAsset, " eur ", "My bank", nil)
+		acc, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: " eur ", Description: "My bank"})
 		require.NoError(t, err)
 		assert.Equal(t, "EUR", acc.Currency)
 	})
@@ -254,7 +254,7 @@ func TestCreateAccountWithBalance_SplitDirection(t *testing.T) {
 		addOpeningBalanceAccount(accRepo)
 		svc := newTestAccountService(accRepo, txRepo)
 
-		acc, err := svc.CreateAccountWithBalance(context.Background(), "Assets:Bank", model.AccountTypeAsset, "USD", "", nil, 5000)
+		acc, err := svc.CreateAccountWithBalance(context.Background(), model.CreateAccountInput{Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD", Balance: 5000})
 		require.NoError(t, err)
 
 		splits := txRepo.splits[1] // first transaction ID=1
@@ -283,7 +283,7 @@ func TestCreateAccountWithBalance_SplitDirection(t *testing.T) {
 		addOpeningBalanceAccount(accRepo)
 		svc := newTestAccountService(accRepo, txRepo)
 
-		acc, err := svc.CreateAccountWithBalance(context.Background(), "Assets:Loan", model.AccountTypeAsset, "USD", "", nil, -3000)
+		acc, err := svc.CreateAccountWithBalance(context.Background(), model.CreateAccountInput{Name: "Assets:Loan", Type: model.AccountTypeAsset, Currency: "USD", Balance: -3000})
 		require.NoError(t, err)
 
 		splits := txRepo.splits[1]
@@ -307,7 +307,7 @@ func TestCreateAccountWithBalance_SplitDirection(t *testing.T) {
 		addOpeningBalanceAccount(accRepo)
 		svc := newTestAccountService(accRepo, txRepo)
 
-		acc, err := svc.CreateAccountWithBalance(context.Background(), "Liabilities:CreditCard", model.AccountTypeLiability, "USD", "", nil, 2000)
+		acc, err := svc.CreateAccountWithBalance(context.Background(), model.CreateAccountInput{Name: "Liabilities:CreditCard", Type: model.AccountTypeLiability, Currency: "USD", Balance: 2000})
 		require.NoError(t, err)
 
 		splits := txRepo.splits[1]
@@ -331,7 +331,7 @@ func TestCreateAccountWithBalance_SplitDirection(t *testing.T) {
 		addOpeningBalanceAccount(accRepo)
 		svc := newTestAccountService(accRepo, txRepo)
 
-		_, err := svc.CreateAccountWithBalance(context.Background(), "Assets:Bank", model.AccountTypeAsset, "USD", "", nil, 0)
+		_, err := svc.CreateAccountWithBalance(context.Background(), model.CreateAccountInput{Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD", Balance: 0})
 		require.NoError(t, err)
 		assert.Empty(t, txRepo.transactions, "no transaction should be created for zero balance")
 	})
@@ -342,7 +342,7 @@ func TestCreateAccountWithBalance_SplitDirection(t *testing.T) {
 		addOpeningBalanceAccount(accRepo)
 		svc := newTestAccountService(accRepo, txRepo)
 
-		acc, err := svc.CreateAccountWithBalance(context.Background(), "Expenses:Food", model.AccountTypeExpense, "USD", "", nil, 500)
+		acc, err := svc.CreateAccountWithBalance(context.Background(), model.CreateAccountInput{Name: "Expenses:Food", Type: model.AccountTypeExpense, Currency: "USD", Balance: 500})
 		require.Error(t, err)
 		assert.Nil(t, acc, "account should be nil on unsupported type")
 		assert.Contains(t, err.Error(), "opening balance")
@@ -356,7 +356,7 @@ func TestCreateAccountWithBalance_SplitDirection(t *testing.T) {
 		// intentionally omit the opening balance account
 		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-		_, err := svc.CreateAccountWithBalance(context.Background(), "Assets:Bank", model.AccountTypeAsset, "USD", "", nil, 1000)
+		_, err := svc.CreateAccountWithBalance(context.Background(), model.CreateAccountInput{Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD", Balance: 1000})
 		require.NoError(t, err)
 
 		equityName := model.OpeningBalancesAccountName("USD")
@@ -373,7 +373,7 @@ func TestCreateAccountWithBalance_SplitDirection(t *testing.T) {
 		txRepo.createErr = errors.New("forced DB error")
 		svc := newTestAccountService(accRepo, txRepo)
 
-		acc, err := svc.CreateAccountWithBalance(context.Background(), "Assets:Bank", model.AccountTypeAsset, "USD", "", nil, 5000)
+		acc, err := svc.CreateAccountWithBalance(context.Background(), model.CreateAccountInput{Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD", Balance: 5000})
 		require.Error(t, err)
 		assert.Nil(t, acc, "account should be nil on rollback")
 
@@ -389,7 +389,7 @@ func TestCreateAccountWithBalance_CurrencyRouting(t *testing.T) {
 		addOpeningBalancesForCurrency(accRepo, "TWD")
 		svc := newTestAccountService(accRepo, txRepo)
 
-		acc, err := svc.CreateAccountWithBalance(context.Background(), "Assets:TWDBank", model.AccountTypeAsset, "TWD", "", nil, 30000)
+		acc, err := svc.CreateAccountWithBalance(context.Background(), model.CreateAccountInput{Name: "Assets:TWDBank", Type: model.AccountTypeAsset, Currency: "TWD", Balance: 30000})
 		require.NoError(t, err)
 
 		splits := txRepo.splits[1]
@@ -415,7 +415,7 @@ func TestCreateAccountWithBalance_CurrencyRouting(t *testing.T) {
 		addOpeningBalancesForCurrency(accRepo, "USD")
 		svc := newTestAccountService(accRepo, txRepo)
 
-		_, err := svc.CreateAccountWithBalance(context.Background(), "Assets:Bank", model.AccountTypeAsset, "", "", nil, 5000)
+		_, err := svc.CreateAccountWithBalance(context.Background(), model.CreateAccountInput{Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "", Balance: 5000})
 		require.NoError(t, err)
 
 		splits := txRepo.splits[1]
@@ -431,7 +431,7 @@ func TestCreateAccountWithBalance_CurrencyRouting(t *testing.T) {
 		// no TWD equity account pre-seeded
 		svc := newTestAccountService(accRepo, txRepo)
 
-		_, err := svc.CreateAccountWithBalance(context.Background(), "Assets:TWDBank", model.AccountTypeAsset, "TWD", "", nil, 30000)
+		_, err := svc.CreateAccountWithBalance(context.Background(), model.CreateAccountInput{Name: "Assets:TWDBank", Type: model.AccountTypeAsset, Currency: "TWD", Balance: 30000})
 		require.NoError(t, err)
 
 		// equity account should now exist
@@ -733,7 +733,7 @@ func TestCreateAccount_ParentValidation(t *testing.T) {
 		parent := &model.Account{ID: 10, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD"}
 		accRepo.addAccount(parent)
 
-		acc, err := svc.CreateAccount(context.Background(), "Assets:Bank:Checking", model.AccountTypeAsset, "USD", "", int64Ptr(10))
+		acc, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{Name: "Assets:Bank:Checking", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(10)})
 		require.NoError(t, err)
 		require.NotNil(t, acc.ParentID)
 		assert.Equal(t, int64(10), *acc.ParentID)
@@ -742,7 +742,7 @@ func TestCreateAccount_ParentValidation(t *testing.T) {
 	t.Run("non-existent parent rejected", func(t *testing.T) {
 		svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
 
-		_, err := svc.CreateAccount(context.Background(), "Assets:Bank:Checking", model.AccountTypeAsset, "USD", "", int64Ptr(999))
+		_, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{Name: "Assets:Bank:Checking", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(999)})
 		require.Error(t, err)
 	})
 
@@ -754,7 +754,7 @@ func TestCreateAccount_ParentValidation(t *testing.T) {
 		accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(1)})
 		accRepo.addAccount(&model.Account{ID: 3, Name: "Assets:Bank:Savings", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(2)})
 
-		acc, err := svc.CreateAccount(context.Background(), "Assets:Bank:Savings:Sub", model.AccountTypeAsset, "USD", "", int64Ptr(3))
+		acc, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{Name: "Assets:Bank:Savings:Sub", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(3)})
 		require.NoError(t, err)
 		require.NotNil(t, acc.ParentID)
 		assert.Equal(t, int64(3), *acc.ParentID)
@@ -769,7 +769,7 @@ func TestCreateAccount_ParentValidation(t *testing.T) {
 		accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:B", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(1)})
 		accRepo.addAccount(&model.Account{ID: 3, Name: "Assets:C", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(2)})
 
-		_, err := svc.CreateAccount(context.Background(), "Assets:C:Child", model.AccountTypeAsset, "USD", "", int64Ptr(3))
+		_, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{Name: "Assets:C:Child", Type: model.AccountTypeAsset, Currency: "USD", ParentID: int64Ptr(3)})
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrCircularParent), "expected ErrCircularParent, got: %v", err)
 	})

--- a/internal/service/errors_test.go
+++ b/internal/service/errors_test.go
@@ -168,7 +168,7 @@ func TestCreateAccount_ValidationErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := svc.CreateAccount(context.Background(), tt.accName, tt.accType, "USD", "", nil)
+			_, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{Name: tt.accName, Type: tt.accType, Currency: "USD"})
 			assert.Error(t, err)
 
 			var ve *ValidationError
@@ -220,7 +220,7 @@ func TestCreateAccountWithBalance_NonAL_ReturnsValidationError(t *testing.T) {
 	accRepo := newMockAccountRepo()
 	svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-	_, err := svc.CreateAccountWithBalance(context.Background(), "Revenue:Sales", model.AccountTypeRevenue, "USD", "", nil, 1000)
+	_, err := svc.CreateAccountWithBalance(context.Background(), model.CreateAccountInput{Name: "Revenue:Sales", Type: model.AccountTypeRevenue, Currency: "USD", Balance: 1000})
 	assert.Error(t, err)
 
 	var ve *ValidationError

--- a/internal/service/errors_test.go
+++ b/internal/service/errors_test.go
@@ -268,7 +268,7 @@ func TestCreateSimpleTransaction_SameAccount_ReturnsValidationError(t *testing.T
 	txRepo := newMockTransactionRepo()
 	svc := newTestTransactionService(accRepo, txRepo)
 
-	_, err := svc.CreateSimpleTransaction(context.Background(), "Assets:Cash", "Assets:Cash", 100, "test", 0, 0, model.TxTypeTransfer)
+	_, err := svc.CreateSimpleTransaction(context.Background(), model.CreateSimpleTransactionInput{FromAccount: "Assets:Cash", ToAccount: "Assets:Cash", Amount: 100, Description: "test", Timestamp: 0, Status: 0, Type: model.TxTypeTransfer})
 	assert.Error(t, err)
 
 	var ve *ValidationError
@@ -280,7 +280,7 @@ func TestCreateSimpleTransaction_NegativeAmount_ReturnsValidationError(t *testin
 	txRepo := newMockTransactionRepo()
 	svc := newTestTransactionService(accRepo, txRepo)
 
-	_, err := svc.CreateSimpleTransaction(context.Background(), "A", "B", -5, "test", 0, 0, model.TxTypeTransfer)
+	_, err := svc.CreateSimpleTransaction(context.Background(), model.CreateSimpleTransactionInput{FromAccount: "A", ToAccount: "B", Amount: -5, Description: "test", Timestamp: 0, Status: 0, Type: model.TxTypeTransfer})
 	assert.Error(t, err)
 
 	var ve *ValidationError

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -129,29 +129,32 @@ func (ts *TransactionService) checkAccountSelectable(ctx context.Context, accRep
 //   - A Credit (negative) to the fromAccount (Source).
 //   - A Debit (positive) to the toAccount (Destination).
 //
-// If txType is empty, it is inferred from the account types via DetermineType.
+// If input.Type is empty, it is inferred from the account types via DetermineType.
 // Returns the constructed TransactionDetail (useful for UI rendering).
-func (ts *TransactionService) CreateSimpleTransaction(ctx context.Context, fromAccount, toAccount string, amount int64, desc string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) (model.TransactionDetail, error) {
-	if fromAccount == toAccount {
+func (ts *TransactionService) CreateSimpleTransaction(ctx context.Context, input model.CreateSimpleTransactionInput) (model.TransactionDetail, error) {
+	if input.FromAccount == input.ToAccount {
 		return model.TransactionDetail{}, validationErrorf("account", "source and destination accounts cannot be the same")
 	}
-	if amount <= 0 {
+	if input.Amount <= 0 {
 		return model.TransactionDetail{}, validationErrorf("amount", "amount must be positive")
 	}
 
+	// The local txType may be overwritten by type inference.
+	txType := input.Type
+
 	// If no type provided, infer from account types.
 	if txType == "" {
-		fromAcc, err := ts.accRepo.GetAccountByName(ctx, fromAccount)
+		fromAcc, err := ts.accRepo.GetAccountByName(ctx, input.FromAccount)
 		if err != nil {
 			return model.TransactionDetail{}, fmt.Errorf("failed to resolve from account: %w", err)
 		}
-		toAcc, err := ts.accRepo.GetAccountByName(ctx, toAccount)
+		toAcc, err := ts.accRepo.GetAccountByName(ctx, input.ToAccount)
 		if err != nil {
 			return model.TransactionDetail{}, fmt.Errorf("failed to resolve to account: %w", err)
 		}
 		inferred, err := ts.DetermineType(ctx, []model.SplitDetail{
-			{AccountType: toAcc.Type, Amount: amount},
-			{AccountType: fromAcc.Type, Amount: -amount},
+			{AccountType: toAcc.Type, Amount: input.Amount},
+			{AccountType: fromAcc.Type, Amount: -input.Amount},
 		})
 		if err != nil {
 			return model.TransactionDetail{}, err
@@ -160,22 +163,22 @@ func (ts *TransactionService) CreateSimpleTransaction(ctx context.Context, fromA
 	}
 
 	splits := []model.SplitDetail{
-		{AccountName: toAccount, Amount: amount},
-		{AccountName: fromAccount, Amount: -amount},
+		{AccountName: input.ToAccount, Amount: input.Amount},
+		{AccountName: input.FromAccount, Amount: -input.Amount},
 	}
-	input := model.TransactionDetail{
-		Timestamp:   timestamp,
-		Description: desc,
-		Status:      status,
+	txDetail := model.TransactionDetail{
+		Timestamp:   input.Timestamp,
+		Description: input.Description,
+		Status:      input.Status,
 		Type:        txType,
 		Splits:      splits,
 	}
-	id, err := ts.CreateTransaction(ctx, input)
+	id, err := ts.CreateTransaction(ctx, txDetail)
 	if err != nil {
 		return model.TransactionDetail{}, err
 	}
-	input.ID = id
-	return input, nil
+	txDetail.ID = id
+	return txDetail, nil
 }
 
 // CreateTransactionFromSplits creates a transaction from an explicit slice of splits.
@@ -183,25 +186,21 @@ func (ts *TransactionService) CreateSimpleTransaction(ctx context.Context, fromA
 // by CreateTransaction.
 func (ts *TransactionService) CreateTransactionFromSplits(
 	ctx context.Context,
-	splits []model.SplitDetail,
-	desc string,
-	timestamp int64,
-	status model.TransactionStatus,
-	txType model.TransactionType,
+	input model.CreateTransactionFromSplitsInput,
 ) (model.TransactionDetail, error) {
-	input := model.TransactionDetail{
-		Timestamp:   timestamp,
-		Description: desc,
-		Status:      status,
-		Type:        txType,
-		Splits:      splits,
+	txDetail := model.TransactionDetail{
+		Timestamp:   input.Timestamp,
+		Description: input.Description,
+		Status:      input.Status,
+		Type:        input.Type,
+		Splits:      input.Splits,
 	}
-	id, err := ts.CreateTransaction(ctx, input)
+	id, err := ts.CreateTransaction(ctx, txDetail)
 	if err != nil {
 		return model.TransactionDetail{}, err
 	}
-	input.ID = id
-	return input, nil
+	txDetail.ID = id
+	return txDetail, nil
 }
 
 // DeleteTransaction deletes a transaction

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -247,44 +247,44 @@ func (ts *TransactionService) UpdateTransactionStatus(ctx context.Context, txID 
 
 // UpdateTransactionComplete performs a complete update of a transaction including splits
 // This operation is atomic - either all changes succeed or all fail
-func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType, splits []model.SplitDetail) error {
+func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, input model.UpdateTransactionInput) error {
 	// Validate status
-	if status != model.StatusPending && status != model.StatusCleared && status != model.StatusReconciled {
+	if input.Status != model.StatusPending && input.Status != model.StatusCleared && input.Status != model.StatusReconciled {
 		return validationErrorf("status", "invalid status: must be 0 (Pending), 1 (Cleared) or 2 (Reconciled)")
 	}
 
-	if txID == model.SystemTransactionID {
+	if input.ID == model.SystemTransactionID {
 		return fmt.Errorf("cannot modify the initial opening transaction: %w", ErrNotEditable)
 	}
 
-	oldTx, err := ts.txRepo.GetTransactionByID(ctx, txID)
+	oldTx, err := ts.txRepo.GetTransactionByID(ctx, input.ID)
 	if err != nil {
 		return fmt.Errorf("transaction not found: %w", err)
 	}
 
 	if oldTx.Status == model.StatusReconciled {
-		return fmt.Errorf("transaction #%d cannot be modified: %w", txID, ErrReconciled)
+		return fmt.Errorf("transaction #%d cannot be modified: %w", input.ID, ErrReconciled)
 	}
 
 	// Validate that we have at least 2 splits
-	if len(splits) < 2 {
+	if len(input.Splits) < 2 {
 		return validationErrorf("splits", "transaction must have at least 2 splits for double-entry bookkeeping")
 	}
 
-	if err := ts.ValidateSplitDetailsBalance(splits); err != nil {
+	if err := ts.ValidateSplitDetailsBalance(input.Splits); err != nil {
 		return err
 	}
 
-	if err := ts.ValidateSplitsMatchType(ctx, txType, splits); err != nil {
-		return fmt.Errorf("splits do not match transaction type %q: %w", txType, err)
+	if err := ts.ValidateSplitsMatchType(ctx, input.Type, input.Splits); err != nil {
+		return fmt.Errorf("splits do not match transaction type %q: %w", input.Type, err)
 	}
 
 	return ts.tm.ExecTx(ctx, func(repo repository.Repository) error {
-		if err := repo.UpdateTransactionBasic(ctx, txID, description, timestamp, status, txType); err != nil {
+		if err := repo.UpdateTransactionBasic(ctx, input.ID, input.Description, input.Timestamp, input.Status, input.Type); err != nil {
 			return err
 		}
 
-		existingSplits, err := repo.GetSplitsByTransaction(ctx, txID)
+		existingSplits, err := repo.GetSplitsByTransaction(ctx, input.ID)
 		if err != nil {
 			return err
 		}
@@ -298,8 +298,8 @@ func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, txI
 		}
 
 		// Reject duplicate or foreign split IDs.
-		seenSplitIDs := make(map[int64]bool, len(splits))
-		for _, split := range splits {
+		seenSplitIDs := make(map[int64]bool, len(input.Splits))
+		for _, split := range input.Splits {
 			if split.ID == 0 {
 				continue
 			}
@@ -308,12 +308,12 @@ func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, txI
 			}
 			seenSplitIDs[split.ID] = true
 			if _, ok := existingAccountByID[split.ID]; !ok {
-				return validationErrorf("splits", "split ID %d does not belong to transaction %d", split.ID, txID)
+				return validationErrorf("splits", "split ID %d does not belong to transaction %d", split.ID, input.ID)
 			}
 		}
 
 		// Validate accounts; enforce selectability only for new or changed splits.
-		for _, split := range splits {
+		for _, split := range input.Splits {
 			account, err := repo.GetAccountByID(ctx, split.AccountID)
 			if err != nil {
 				if errors.Is(err, repository.ErrNotFound) {
@@ -331,7 +331,7 @@ func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, txI
 		}
 
 		newSplitMap := make(map[int64]bool)
-		for _, split := range splits {
+		for _, split := range input.Splits {
 			if split.ID != 0 {
 				newSplitMap[split.ID] = true
 			}
@@ -347,16 +347,16 @@ func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, txI
 		}
 
 		// Update existing splits or create new ones
-		for _, split := range splits {
+		for _, split := range input.Splits {
 			if split.ID == 0 {
 				newSplit := &model.Split{
-					TransactionID: txID,
+					TransactionID: input.ID,
 					AccountID:     split.AccountID,
 					Amount:        split.Amount,
 					Currency:      split.Currency,
 					Memo:          split.Memo,
 				}
-				_, err := repo.CreateSplit(ctx, txID, newSplit)
+				_, err := repo.CreateSplit(ctx, input.ID, newSplit)
 				if err != nil {
 					return err
 				}

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -281,7 +281,7 @@ func TestCreateSimpleTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		detail, err := svc.CreateSimpleTransaction(
-			context.Background(), "Assets:Bank", "Expenses:Food", 1000, "Dinner", 0, model.StatusPending, model.TxTypeExpense,
+			context.Background(), model.CreateSimpleTransactionInput{FromAccount: "Assets:Bank", ToAccount: "Expenses:Food", Amount: 1000, Description: "Dinner", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense},
 		)
 		require.NoError(t, err)
 		assert.Greater(t, detail.ID, int64(0))
@@ -303,7 +303,7 @@ func TestCreateSimpleTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		detail, err := svc.CreateSimpleTransaction(
-			context.Background(), "Assets:Bank", "Expenses:Food", 750, "Coffee", 0, model.StatusPending, model.TxTypeExpense,
+			context.Background(), model.CreateSimpleTransactionInput{FromAccount: "Assets:Bank", ToAccount: "Expenses:Food", Amount: 750, Description: "Coffee", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense},
 		)
 		require.NoError(t, err)
 
@@ -317,7 +317,7 @@ func TestCreateSimpleTransaction(t *testing.T) {
 	t.Run("same account rejected", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
 		_, err := svc.CreateSimpleTransaction(
-			context.Background(), "Assets:Bank", "Assets:Bank", 1000, "Self", 0, model.StatusPending, model.TxTypeExpense,
+			context.Background(), model.CreateSimpleTransactionInput{FromAccount: "Assets:Bank", ToAccount: "Assets:Bank", Amount: 1000, Description: "Self", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense},
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "same")
@@ -326,7 +326,7 @@ func TestCreateSimpleTransaction(t *testing.T) {
 	t.Run("zero amount rejected", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
 		_, err := svc.CreateSimpleTransaction(
-			context.Background(), "Assets:Bank", "Expenses:Food", 0, "Zero", 0, model.StatusPending, model.TxTypeExpense,
+			context.Background(), model.CreateSimpleTransactionInput{FromAccount: "Assets:Bank", ToAccount: "Expenses:Food", Amount: 0, Description: "Zero", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense},
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "positive")
@@ -335,7 +335,7 @@ func TestCreateSimpleTransaction(t *testing.T) {
 	t.Run("negative amount rejected", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
 		_, err := svc.CreateSimpleTransaction(
-			context.Background(), "Assets:Bank", "Expenses:Food", -100, "Negative", 0, model.StatusPending, model.TxTypeExpense,
+			context.Background(), model.CreateSimpleTransactionInput{FromAccount: "Assets:Bank", ToAccount: "Expenses:Food", Amount: -100, Description: "Negative", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense},
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "positive")
@@ -348,7 +348,7 @@ func TestCreateSimpleTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		detail, err := svc.CreateSimpleTransaction(
-			context.Background(), "Assets:Bank", "Expenses:Food", 500, "Inferred", 0, model.StatusPending, "",
+			context.Background(), model.CreateSimpleTransactionInput{FromAccount: "Assets:Bank", ToAccount: "Expenses:Food", Amount: 500, Description: "Inferred", Timestamp: 0, Status: model.StatusPending, Type: ""},
 		)
 		require.NoError(t, err)
 		assert.Equal(t, model.TxTypeExpense, detail.Type)
@@ -864,7 +864,7 @@ func TestCreateTransactionFromSplits(t *testing.T) {
 			{AccountName: "Assets:Bank", Amount: -200000},
 			{AccountName: "Expenses:Food", Amount: 200000},
 		}
-		result, err := svc.CreateTransactionFromSplits(context.Background(), splits, "team lunch", 0, model.StatusCleared, model.TxTypeExpense)
+		result, err := svc.CreateTransactionFromSplits(context.Background(), model.CreateTransactionFromSplitsInput{Splits: splits, Description: "team lunch", Timestamp: 0, Status: model.StatusCleared, Type: model.TxTypeExpense})
 		require.NoError(t, err)
 		assert.Greater(t, result.ID, int64(0))
 		assert.Equal(t, "team lunch", result.Description)
@@ -883,7 +883,7 @@ func TestCreateTransactionFromSplits(t *testing.T) {
 			{AccountName: "Assets:Bank", Amount: -200000},
 			{AccountName: "Expenses:Food", Amount: 200000},
 		}
-		_, err := svc.CreateTransactionFromSplits(context.Background(), splits, "team lunch", 0, model.StatusCleared, model.TxTypeExpense)
+		_, err := svc.CreateTransactionFromSplits(context.Background(), model.CreateTransactionFromSplitsInput{Splits: splits, Description: "team lunch", Timestamp: 0, Status: model.StatusCleared, Type: model.TxTypeExpense})
 		require.Error(t, err)
 	})
 }

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -511,7 +511,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -800, Currency: "USD"},
 			{ID: 11, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 800, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "Updated desc", 0, model.StatusCleared, model.TxTypeExpense, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "Updated desc", Timestamp: 0, Status: model.StatusCleared, Type: model.TxTypeExpense, Splits: splits})
 		require.NoError(t, err)
 	})
 
@@ -520,15 +520,15 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.TransactionStatus(99), model.TxTypeExpense, nil)
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.TransactionStatus(99), Type: model.TxTypeExpense, Splits: nil})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid status")
 	})
 
 	t.Run("non-existent transaction returns error", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		err := svc.UpdateTransactionComplete(context.Background(), 999, "", 0, model.StatusPending, model.TxTypeExpense,
-			[]model.SplitDetail{{AccountID: 1, Amount: 0}, {AccountID: 2, Amount: 0}})
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 999, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense,
+			Splits: []model.SplitDetail{{AccountID: 1, Amount: 0}, {AccountID: 2, Amount: 0}}})
 		require.Error(t, err)
 	})
 
@@ -537,8 +537,8 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusReconciled}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusCleared, model.TxTypeExpense,
-			[]model.SplitDetail{{AccountID: 1, Amount: 500}, {AccountID: 2, Amount: -500}})
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusCleared, Type: model.TxTypeExpense,
+			Splits: []model.SplitDetail{{AccountID: 1, Amount: 500}, {AccountID: 2, Amount: -500}}})
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrReconciled))
 	})
@@ -548,8 +548,8 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeExpense,
-			[]model.SplitDetail{{AccountID: 1, Amount: 0}})
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense,
+			Splits: []model.SplitDetail{{AccountID: 1, Amount: 0}}})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "at least 2")
 	})
@@ -561,11 +561,11 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(accRepo, txRepo)
 
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeExpense,
-			[]model.SplitDetail{
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense,
+			Splits: []model.SplitDetail{
 				{AccountID: 1, Amount: -500},
 				{AccountID: 2, Amount: 400}, // off by 100
-			})
+			}})
 		require.Error(t, err)
 	})
 
@@ -583,7 +583,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -1000, Currency: "USD"},
 			{ID: 11, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 1000, Currency: "TWD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "Mixed", 0, model.StatusPending, model.TxTypeExpense, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "Mixed", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "currency")
 	})
@@ -595,11 +595,11 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(accRepo, txRepo)
 
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeExpense,
-			[]model.SplitDetail{
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense,
+			Splits: []model.SplitDetail{
 				{AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -500},
 				{AccountID: 99, AccountType: model.AccountTypeExpense, Amount: 500}, // does not exist
-			})
+			}})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "99")
 	})
@@ -623,7 +623,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -1000, Currency: "USD"},
 			{ID: 11, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 1000, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeExpense, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
 		require.NoError(t, err)
 		assert.Contains(t, txRepo.deleteSplitCalls, int64(12), "split ID 12 should be deleted")
 	})
@@ -642,7 +642,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -1000, Currency: "USD"},
 			{ID: 0, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 1000, Currency: "USD"}, // new split
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeExpense, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
 		require.NoError(t, err)
 		assert.Len(t, txRepo.createSplitCalls, 1, "CreateSplit should be called once")
 	})
@@ -664,7 +664,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -800, Currency: "USD"},
 			{ID: 11, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 800, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeExpense, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
 		require.NoError(t, err)
 		assert.Contains(t, txRepo.updateSplitCalls, int64(10))
 		assert.Contains(t, txRepo.updateSplitCalls, int64(11))
@@ -682,7 +682,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{AccountID: 10, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"},
 			{AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeExpense, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "hidden")
 	})
@@ -700,7 +700,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{AccountID: 11, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"},
 			{AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeExpense, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "parent account")
 	})
@@ -720,7 +720,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 20, AccountID: 10, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"},
 			{ID: 21, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "updated desc", 0, model.StatusPending, model.TxTypeExpense, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "updated desc", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
 		require.NoError(t, err)
 	})
 
@@ -739,7 +739,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 20, AccountID: 10, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"}, // moved to hidden account
 			{ID: 21, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeExpense, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "hidden")
 	})
@@ -759,7 +759,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
 			{AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "", 0, model.StatusPending, model.TxTypeTransfer, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeTransfer, Splits: splits})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "splits do not match transaction type")
 	})
@@ -782,7 +782,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 20, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"},
 			{ID: 11, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "cross-tx", 0, model.StatusPending, model.TxTypeExpense, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "cross-tx", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not belong to transaction")
 		assert.Empty(t, txRepo.deleteSplitCalls, "no splits should be deleted")
@@ -804,7 +804,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"},
 			{ID: 10, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), 5, "dup", 0, model.StatusPending, model.TxTypeExpense, splits)
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "dup", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "duplicate split ID")
 		assert.Empty(t, txRepo.deleteSplitCalls)


### PR DESCRIPTION
## Summary

Closes #79

- Define `CreateAccountInput`, `CreateSimpleTransactionInput`, `CreateTransactionFromSplitsInput`, and `UpdateTransactionInput` structs in `internal/model/input.go`
- Refactor `AccountService.CreateAccount`, `CreateAccountWithBalance`, `TransactionService.CreateSimpleTransaction`, `CreateTransactionFromSplits`, and `UpdateTransactionComplete` to accept input structs instead of long positional parameter lists
- Update all callers in `cmd/` layer (interfaces, call sites, test mocks) to construct and pass input structs

## Test plan

- [x] All existing service-layer tests pass (`go test ./internal/service/...`)
- [x] All cmd-layer tests pass (`go test ./cmd/...`)
- [x] Full test suite passes (`go test ./...`)
- [x] Binary builds successfully (`make build`)
- [x] No remaining positional call sites (verified via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)