### PR TITLE
feat: add pagination support to list methods (issue #78)

### DIFF
--- a/internal/model/pagination.go
+++ b/internal/model/pagination.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package model
+
+// ListOptions controls pagination for list queries.
+// IncludeCount lets callers skip the COUNT query when they don't need the total.
+// Default limit is 20 when Limit is zero or negative.
+type ListOptions struct {
+	Limit        int
+	Offset       int
+	IncludeCount bool
+}
+
+// ListResult holds a paginated slice of items alongside pagination metadata.
+type ListResult[T any] struct {
+	Items      []T
+	TotalCount int
+	Limit      int
+	Offset     int
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -73,6 +73,17 @@ type TransactionRepository interface {
 	// SetLastReconciledBalance persists the new running reconciled balance for
 	// accountID. Uses an upsert so the first call creates the row.
 	SetLastReconciledBalance(ctx context.Context, accountID int64, balance int64) error
+
+	// ListTransactions returns a paginated list of all transactions ordered by
+	// timestamp DESC, id DESC. When opts.IncludeCount is true the result also
+	// carries the total row count.
+	ListTransactions(ctx context.Context, opts model.ListOptions) (*model.ListResult[*model.Transaction], error)
+
+	// ListTransactionsByAccount returns a paginated list of transactions that
+	// have at least one split touching accountID, ordered by timestamp DESC,
+	// id DESC. When opts.IncludeCount is true the result also carries the total
+	// distinct transaction count.
+	ListTransactionsByAccount(ctx context.Context, accountID int64, opts model.ListOptions) (*model.ListResult[*model.Transaction], error)
 }
 
 type Repository interface {

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/hance08/kea/internal/config"
 	"github.com/hance08/kea/internal/model"
@@ -250,6 +251,10 @@ type mockTransactionRepo struct {
 		balance   int64
 	}
 	setLastReconciledBalErr map[int64]error
+
+	// pagination support
+	listTxErr          error
+	listTxByAccountErr error
 }
 
 func newMockTransactionRepo() *mockTransactionRepo {
@@ -473,6 +478,9 @@ func (m *mockTransactionRepo) SetLastReconciledBalance(_ context.Context, accoun
 }
 
 func (m *mockTransactionRepo) ListTransactions(_ context.Context, opts model.ListOptions) (*model.ListResult[*model.Transaction], error) {
+	if m.listTxErr != nil {
+		return nil, m.listTxErr
+	}
 	limit := opts.Limit
 	if limit <= 0 {
 		limit = 20
@@ -485,6 +493,7 @@ func (m *mockTransactionRepo) ListTransactions(_ context.Context, opts model.Lis
 	for _, tx := range m.transactions {
 		all = append(all, tx)
 	}
+	sort.Slice(all, func(i, j int) bool { return all[i].ID > all[j].ID })
 	result := &model.ListResult[*model.Transaction]{}
 	if opts.IncludeCount {
 		result.TotalCount = len(all)
@@ -503,6 +512,9 @@ func (m *mockTransactionRepo) ListTransactions(_ context.Context, opts model.Lis
 }
 
 func (m *mockTransactionRepo) ListTransactionsByAccount(_ context.Context, accountID int64, opts model.ListOptions) (*model.ListResult[*model.Transaction], error) {
+	if m.listTxByAccountErr != nil {
+		return nil, m.listTxByAccountErr
+	}
 	limit := opts.Limit
 	if limit <= 0 {
 		limit = 20
@@ -522,6 +534,7 @@ func (m *mockTransactionRepo) ListTransactionsByAccount(_ context.Context, accou
 			}
 		}
 	}
+	sort.Slice(matching, func(i, j int) bool { return matching[i].ID > matching[j].ID })
 	result := &model.ListResult[*model.Transaction]{}
 	if opts.IncludeCount {
 		result.TotalCount = len(matching)

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -485,17 +485,19 @@ func (m *mockTransactionRepo) ListTransactions(_ context.Context, opts model.Lis
 	for _, tx := range m.transactions {
 		all = append(all, tx)
 	}
-	result := &model.ListResult[*model.Transaction]{Limit: limit, Offset: offset}
+	result := &model.ListResult[*model.Transaction]{}
 	if opts.IncludeCount {
 		result.TotalCount = len(all)
 	}
-	end := offset + limit
 	if offset > len(all) {
 		offset = len(all)
 	}
+	end := offset + limit
 	if end > len(all) {
 		end = len(all)
 	}
+	result.Limit = limit
+	result.Offset = offset
 	result.Items = all[offset:end]
 	return result, nil
 }
@@ -520,17 +522,19 @@ func (m *mockTransactionRepo) ListTransactionsByAccount(_ context.Context, accou
 			}
 		}
 	}
-	result := &model.ListResult[*model.Transaction]{Limit: limit, Offset: offset}
+	result := &model.ListResult[*model.Transaction]{}
 	if opts.IncludeCount {
 		result.TotalCount = len(matching)
 	}
-	end := offset + limit
 	if offset > len(matching) {
 		offset = len(matching)
 	}
+	end := offset + limit
 	if end > len(matching) {
 		end = len(matching)
 	}
+	result.Limit = limit
+	result.Offset = offset
 	result.Items = matching[offset:end]
 	return result, nil
 }

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -472,6 +472,69 @@ func (m *mockTransactionRepo) SetLastReconciledBalance(_ context.Context, accoun
 	return nil
 }
 
+func (m *mockTransactionRepo) ListTransactions(_ context.Context, opts model.ListOptions) (*model.ListResult[*model.Transaction], error) {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	offset := opts.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	all := make([]*model.Transaction, 0, len(m.transactions))
+	for _, tx := range m.transactions {
+		all = append(all, tx)
+	}
+	result := &model.ListResult[*model.Transaction]{Limit: limit, Offset: offset}
+	if opts.IncludeCount {
+		result.TotalCount = len(all)
+	}
+	end := offset + limit
+	if offset > len(all) {
+		offset = len(all)
+	}
+	if end > len(all) {
+		end = len(all)
+	}
+	result.Items = all[offset:end]
+	return result, nil
+}
+
+func (m *mockTransactionRepo) ListTransactionsByAccount(_ context.Context, accountID int64, opts model.ListOptions) (*model.ListResult[*model.Transaction], error) {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	offset := opts.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	var matching []*model.Transaction
+	for _, splits := range m.splits {
+		for _, sp := range splits {
+			if sp.AccountID == accountID {
+				if tx, ok := m.transactions[sp.TransactionID]; ok {
+					matching = append(matching, tx)
+				}
+				break
+			}
+		}
+	}
+	result := &model.ListResult[*model.Transaction]{Limit: limit, Offset: offset}
+	if opts.IncludeCount {
+		result.TotalCount = len(matching)
+	}
+	end := offset + limit
+	if offset > len(matching) {
+		offset = len(matching)
+	}
+	if end > len(matching) {
+		end = len(matching)
+	}
+	result.Items = matching[offset:end]
+	return result, nil
+}
+
 // ──────────────────────────────────────────────
 // mockCombinedRepo (implements repository.Repository)
 // ──────────────────────────────────────────────

--- a/internal/service/transaction_pagination_test.go
+++ b/internal/service/transaction_pagination_test.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -54,6 +55,17 @@ func TestListRecentTransactions(t *testing.T) {
 		assert.NotNil(t, result.Items)
 		assert.Empty(t, result.Items)
 		assert.Equal(t, 0, result.TotalCount)
+	})
+
+	t.Run("repo error propagates", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		txRepo.listTxErr = errors.New("db connection lost")
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		_, err := svc.ListRecentTransactions(context.Background(), model.ListOptions{Limit: 10})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db connection lost")
 	})
 }
 
@@ -109,6 +121,18 @@ func TestListTransactionHistory(t *testing.T) {
 		_, err := svc.ListTransactionHistory(context.Background(), "Nonexistent:Account", model.ListOptions{Limit: 10})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "account not found")
+	})
+
+	t.Run("repo error propagates", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		txRepo.listTxByAccountErr = errors.New("db connection lost")
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		_, err := svc.ListTransactionHistory(context.Background(), "Assets:Bank", model.ListOptions{Limit: 10})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db connection lost")
 	})
 
 	t.Run("with offset", func(t *testing.T) {

--- a/internal/service/transaction_pagination_test.go
+++ b/internal/service/transaction_pagination_test.go
@@ -34,7 +34,7 @@ func TestListRecentTransactions(t *testing.T) {
 		assert.Equal(t, 3, result.TotalCount)
 	})
 
-	t.Run("default limit applied", func(t *testing.T) {
+	t.Run("zero limit uses repo default", func(t *testing.T) {
 		accRepo := newMockAccountRepo()
 		txRepo := newMockTransactionRepo()
 		svc := newTestTransactionService(accRepo, txRepo)

--- a/internal/service/transaction_pagination_test.go
+++ b/internal/service/transaction_pagination_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hance08/kea/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ──────────────────────────────────────────────
+// TestListRecentTransactions
+// ──────────────────────────────────────────────
+
+func TestListRecentTransactions(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		now := time.Now().Unix()
+		txRepo.addTransaction(&model.Transaction{ID: 1, Timestamp: now, Description: "tx1", Status: model.StatusPending, Type: model.TxTypeExpense}, nil)
+		txRepo.addTransaction(&model.Transaction{ID: 2, Timestamp: now, Description: "tx2", Status: model.StatusPending, Type: model.TxTypeExpense}, nil)
+		txRepo.addTransaction(&model.Transaction{ID: 3, Timestamp: now, Description: "tx3", Status: model.StatusPending, Type: model.TxTypeExpense}, nil)
+
+		result, err := svc.ListRecentTransactions(context.Background(), model.ListOptions{Limit: 2, IncludeCount: true})
+		require.NoError(t, err)
+		assert.Len(t, result.Items, 2)
+		assert.Equal(t, 3, result.TotalCount)
+	})
+
+	t.Run("default limit applied", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		result, err := svc.ListRecentTransactions(context.Background(), model.ListOptions{Limit: 0})
+		require.NoError(t, err)
+		assert.Equal(t, 20, result.Limit)
+	})
+
+	t.Run("empty result", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		result, err := svc.ListRecentTransactions(context.Background(), model.ListOptions{Limit: 10, IncludeCount: true})
+		require.NoError(t, err)
+		assert.NotNil(t, result.Items)
+		assert.Empty(t, result.Items)
+		assert.Equal(t, 0, result.TotalCount)
+	})
+}
+
+// ──────────────────────────────────────────────
+// TestListTransactionHistory
+// ──────────────────────────────────────────────
+
+func TestListTransactionHistory(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		now := time.Now().Unix()
+		// tx1 touches Assets:Bank (ID=1) and Expenses:Food (ID=2)
+		txRepo.addTransaction(
+			&model.Transaction{ID: 1, Timestamp: now, Description: "lunch", Status: model.StatusPending, Type: model.TxTypeExpense},
+			[]*model.Split{
+				{ID: 1, TransactionID: 1, AccountID: 1, Amount: -500, Currency: "USD"},
+				{ID: 2, TransactionID: 1, AccountID: 2, Amount: 500, Currency: "USD"},
+			},
+		)
+		// tx2 only touches Revenue:Salary (ID=3) and Assets:Bank (ID=1)
+		txRepo.addTransaction(
+			&model.Transaction{ID: 2, Timestamp: now, Description: "salary", Status: model.StatusPending, Type: model.TxTypeIncome},
+			[]*model.Split{
+				{ID: 3, TransactionID: 2, AccountID: 3, Amount: -2000, Currency: "USD"},
+				{ID: 4, TransactionID: 2, AccountID: 1, Amount: 2000, Currency: "USD"},
+			},
+		)
+		// tx3 does NOT touch Assets:Bank
+		txRepo.addTransaction(
+			&model.Transaction{ID: 3, Timestamp: now, Description: "other", Status: model.StatusPending, Type: model.TxTypeExpense},
+			[]*model.Split{
+				{ID: 5, TransactionID: 3, AccountID: 2, Amount: -100, Currency: "USD"},
+				{ID: 6, TransactionID: 3, AccountID: 3, Amount: 100, Currency: "USD"},
+			},
+		)
+
+		result, err := svc.ListTransactionHistory(context.Background(), "Assets:Bank", model.ListOptions{Limit: 10, IncludeCount: true})
+		require.NoError(t, err)
+		// tx1 and tx2 both touch Assets:Bank
+		assert.Len(t, result.Items, 2)
+		assert.Equal(t, 2, result.TotalCount)
+	})
+
+	t.Run("account not found", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		_, err := svc.ListTransactionHistory(context.Background(), "Nonexistent:Account", model.ListOptions{Limit: 10})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "account not found")
+	})
+
+	t.Run("with offset", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		now := time.Now().Unix()
+		for i := int64(1); i <= 4; i++ {
+			txRepo.addTransaction(
+				&model.Transaction{ID: i, Timestamp: now, Description: "tx", Status: model.StatusPending, Type: model.TxTypeExpense},
+				[]*model.Split{
+					{ID: i*10 + 1, TransactionID: i, AccountID: 1, Amount: -100, Currency: "USD"},
+					{ID: i*10 + 2, TransactionID: i, AccountID: 2, Amount: 100, Currency: "USD"},
+				},
+			)
+		}
+
+		// First page: offset=0, limit=2 → 2 items
+		page1, err := svc.ListTransactionHistory(context.Background(), "Assets:Bank", model.ListOptions{Limit: 2, Offset: 0, IncludeCount: true})
+		require.NoError(t, err)
+		assert.Len(t, page1.Items, 2)
+		assert.Equal(t, 4, page1.TotalCount)
+
+		// Second page: offset=2, limit=2 → 2 items
+		page2, err := svc.ListTransactionHistory(context.Background(), "Assets:Bank", model.ListOptions{Limit: 2, Offset: 2, IncludeCount: true})
+		require.NoError(t, err)
+		assert.Len(t, page2.Items, 2)
+		assert.Equal(t, 4, page2.TotalCount)
+	})
+}

--- a/internal/service/transaction_service.go
+++ b/internal/service/transaction_service.go
@@ -79,6 +79,20 @@ func (ts *TransactionService) GetRecentTransactions(ctx context.Context, limit i
 	return transactions, nil
 }
 
+// ListRecentTransactions returns a paginated list of all transactions.
+func (ts *TransactionService) ListRecentTransactions(ctx context.Context, opts model.ListOptions) (*model.ListResult[*model.Transaction], error) {
+	return ts.txRepo.ListTransactions(ctx, opts)
+}
+
+// ListTransactionHistory returns a paginated transaction history for the named account.
+func (ts *TransactionService) ListTransactionHistory(ctx context.Context, accountName string, opts model.ListOptions) (*model.ListResult[*model.Transaction], error) {
+	account, err := ts.accRepo.GetAccountByName(ctx, accountName)
+	if err != nil {
+		return nil, fmt.Errorf("account not found: %w", err)
+	}
+	return ts.txRepo.ListTransactionsByAccount(ctx, account.ID, opts)
+}
+
 // GetTransactionHistory retrieves transaction history for a specific account
 func (ts *TransactionService) GetTransactionHistory(ctx context.Context, accountName string, limit int) ([]*model.Transaction, error) {
 	// Get account by name

--- a/internal/store/sqlite_transaction.go
+++ b/internal/store/sqlite_transaction.go
@@ -405,6 +405,9 @@ func (s *Store) ListTransactions(ctx context.Context, opts model.ListOptions) (*
 	if err != nil {
 		return nil, err
 	}
+	if items == nil {
+		items = []*model.Transaction{}
+	}
 	result.Items = items
 	return result, nil
 }
@@ -444,6 +447,9 @@ func (s *Store) ListTransactionsByAccount(ctx context.Context, accountID int64, 
 	items, err := s.scanTransactions(rows)
 	if err != nil {
 		return nil, err
+	}
+	if items == nil {
+		items = []*model.Transaction{}
 	}
 	result.Items = items
 	return result, nil

--- a/internal/store/sqlite_transaction.go
+++ b/internal/store/sqlite_transaction.go
@@ -364,6 +364,91 @@ func (s *Store) GetSplitsWithAccountsByTransaction(ctx context.Context, txID int
 	return result, nil
 }
 
+// normalizeListOpts applies defaults: limit defaults to 20 when ≤0, offset is
+// clamped to 0 when negative.
+func normalizeListOpts(opts model.ListOptions) model.ListOptions {
+	if opts.Limit <= 0 {
+		opts.Limit = 20
+	}
+	if opts.Offset < 0 {
+		opts.Offset = 0
+	}
+	return opts
+}
+
+func (s *Store) ListTransactions(ctx context.Context, opts model.ListOptions) (*model.ListResult[*model.Transaction], error) {
+	opts = normalizeListOpts(opts)
+
+	result := &model.ListResult[*model.Transaction]{
+		Limit:  opts.Limit,
+		Offset: opts.Offset,
+	}
+
+	if opts.IncludeCount {
+		if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM transactions`).Scan(&result.TotalCount); err != nil {
+			return nil, fmt.Errorf("failed to count transactions: %w", err)
+		}
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+        SELECT id, timestamp, description, status, external_id, type
+        FROM transactions
+        ORDER BY timestamp DESC, id DESC
+        LIMIT ? OFFSET ?
+    `, opts.Limit, opts.Offset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query transactions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	items, err := s.scanTransactions(rows)
+	if err != nil {
+		return nil, err
+	}
+	result.Items = items
+	return result, nil
+}
+
+func (s *Store) ListTransactionsByAccount(ctx context.Context, accountID int64, opts model.ListOptions) (*model.ListResult[*model.Transaction], error) {
+	opts = normalizeListOpts(opts)
+
+	result := &model.ListResult[*model.Transaction]{
+		Limit:  opts.Limit,
+		Offset: opts.Offset,
+	}
+
+	if opts.IncludeCount {
+		if err := s.db.QueryRowContext(ctx, `
+            SELECT COUNT(DISTINCT t.id)
+            FROM transactions t
+            INNER JOIN splits s ON t.id = s.transaction_id
+            WHERE s.account_id = ?
+        `, accountID).Scan(&result.TotalCount); err != nil {
+			return nil, fmt.Errorf("failed to count transactions by account: %w", err)
+		}
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+        SELECT DISTINCT t.id, t.timestamp, t.description, t.status, t.external_id, t.type
+        FROM transactions t
+        INNER JOIN splits s ON t.id = s.transaction_id
+        WHERE s.account_id = ?
+        ORDER BY t.timestamp DESC, t.id DESC
+        LIMIT ? OFFSET ?
+    `, accountID, opts.Limit, opts.Offset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query transactions by account: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	items, err := s.scanTransactions(rows)
+	if err != nil {
+		return nil, err
+	}
+	result.Items = items
+	return result, nil
+}
+
 func (s *Store) scanTransactions(rows *sql.Rows) ([]*model.Transaction, error) {
 	var transactions []*model.Transaction
 	for rows.Next() {

--- a/internal/store/sqlite_transaction_pagination_test.go
+++ b/internal/store/sqlite_transaction_pagination_test.go
@@ -113,6 +113,7 @@ func TestListTransactions(t *testing.T) {
 
 		result, err := s.ListTransactions(ctx, model.ListOptions{Limit: 10, Offset: 100, IncludeCount: true})
 		require.NoError(t, err)
+		assert.NotNil(t, result.Items)
 		assert.Empty(t, result.Items)
 		assert.Equal(t, 5, result.TotalCount)
 	})
@@ -131,7 +132,6 @@ func TestListTransactionsByAccount(t *testing.T) {
 		// Third account not touched by any tx
 		otherID, err := s.CreateAccount(ctx, "Expenses:Other", model.AccountTypeExpense, "USD", "", nil)
 		require.NoError(t, err)
-		_ = otherID
 
 		// 3 txs touch assetID + expenseID
 		for i := 0; i < 3; i++ {

--- a/internal/store/sqlite_transaction_pagination_test.go
+++ b/internal/store/sqlite_transaction_pagination_test.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package store_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hance08/kea/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestAccounts sets up two leaf accounts used by pagination tests.
+// Returns (assetID, expenseID).
+func createTestAccounts(t *testing.T, s interface {
+	CreateAccount(ctx context.Context, name string, accountType model.AccountType, currency string, description string, parentID *int64) (int64, error)
+}) (int64, int64) {
+	t.Helper()
+	ctx := context.Background()
+	assetID, err := s.CreateAccount(ctx, "Assets:Bank", model.AccountTypeAsset, "USD", "", nil)
+	require.NoError(t, err)
+	expenseID, err := s.CreateAccount(ctx, "Expenses:Food", model.AccountTypeExpense, "USD", "", nil)
+	require.NoError(t, err)
+	return assetID, expenseID
+}
+
+// addTx is a helper to insert a balanced transaction (asset debit, expense credit).
+func addTx(t *testing.T, s interface {
+	CreateTransactionWithSplits(ctx context.Context, tx model.Transaction, splits []model.Split) (int64, error)
+}, assetID, expenseID int64, desc string) int64 {
+	t.Helper()
+	id, err := s.CreateTransactionWithSplits(context.Background(), model.Transaction{
+		Timestamp:   time.Now().Unix(),
+		Description: desc,
+		Status:      model.StatusPending,
+		Type:        model.TxTypeExpense,
+	}, []model.Split{
+		{AccountID: assetID, Amount: -1000, Currency: "USD"},
+		{AccountID: expenseID, Amount: 1000, Currency: "USD"},
+	})
+	require.NoError(t, err)
+	return id
+}
+
+// ──────────────────────────────────────────────
+// TestListTransactions
+// ──────────────────────────────────────────────
+
+func TestListTransactions(t *testing.T) {
+	t.Run("pagination", func(t *testing.T) {
+		s := setupTestDB(t)
+		ctx := context.Background()
+		assetID, expenseID := createTestAccounts(t, s)
+
+		for i := 0; i < 5; i++ {
+			addTx(t, s, assetID, expenseID, "tx")
+		}
+
+		// Page 1: offset=0, limit=2 → 2 items
+		r1, err := s.ListTransactions(ctx, model.ListOptions{Limit: 2, Offset: 0})
+		require.NoError(t, err)
+		assert.Len(t, r1.Items, 2)
+
+		// Page 2: offset=2, limit=2 → 2 items
+		r2, err := s.ListTransactions(ctx, model.ListOptions{Limit: 2, Offset: 2})
+		require.NoError(t, err)
+		assert.Len(t, r2.Items, 2)
+
+		// Page 3: offset=4, limit=2 → 1 item
+		r3, err := s.ListTransactions(ctx, model.ListOptions{Limit: 2, Offset: 4})
+		require.NoError(t, err)
+		assert.Len(t, r3.Items, 1)
+	})
+
+	t.Run("include count", func(t *testing.T) {
+		s := setupTestDB(t)
+		assetID, expenseID := createTestAccounts(t, s)
+		ctx := context.Background()
+
+		for i := 0; i < 5; i++ {
+			addTx(t, s, assetID, expenseID, "tx")
+		}
+
+		withCount, err := s.ListTransactions(ctx, model.ListOptions{Limit: 10, IncludeCount: true})
+		require.NoError(t, err)
+		assert.Equal(t, 5, withCount.TotalCount)
+
+		withoutCount, err := s.ListTransactions(ctx, model.ListOptions{Limit: 10, IncludeCount: false})
+		require.NoError(t, err)
+		assert.Equal(t, 0, withoutCount.TotalCount)
+	})
+
+	t.Run("default limit", func(t *testing.T) {
+		s := setupTestDB(t)
+		ctx := context.Background()
+
+		result, err := s.ListTransactions(ctx, model.ListOptions{Limit: 0})
+		require.NoError(t, err)
+		assert.Equal(t, 20, result.Limit)
+	})
+
+	t.Run("offset beyond total", func(t *testing.T) {
+		s := setupTestDB(t)
+		assetID, expenseID := createTestAccounts(t, s)
+		ctx := context.Background()
+
+		for i := 0; i < 5; i++ {
+			addTx(t, s, assetID, expenseID, "tx")
+		}
+
+		result, err := s.ListTransactions(ctx, model.ListOptions{Limit: 10, Offset: 100, IncludeCount: true})
+		require.NoError(t, err)
+		assert.Empty(t, result.Items)
+		assert.Equal(t, 5, result.TotalCount)
+	})
+}
+
+// ──────────────────────────────────────────────
+// TestListTransactionsByAccount
+// ──────────────────────────────────────────────
+
+func TestListTransactionsByAccount(t *testing.T) {
+	t.Run("filters by account", func(t *testing.T) {
+		s := setupTestDB(t)
+		ctx := context.Background()
+
+		assetID, expenseID := createTestAccounts(t, s)
+		// Third account not touched by any tx
+		otherID, err := s.CreateAccount(ctx, "Expenses:Other", model.AccountTypeExpense, "USD", "", nil)
+		require.NoError(t, err)
+		_ = otherID
+
+		// 3 txs touch assetID + expenseID
+		for i := 0; i < 3; i++ {
+			addTx(t, s, assetID, expenseID, "food")
+		}
+		// 2 txs touch assetID + otherID
+		for i := 0; i < 2; i++ {
+			_, err := s.CreateTransactionWithSplits(ctx, model.Transaction{
+				Timestamp:   time.Now().Unix(),
+				Description: "other",
+				Status:      model.StatusPending,
+				Type:        model.TxTypeExpense,
+			}, []model.Split{
+				{AccountID: assetID, Amount: -500, Currency: "USD"},
+				{AccountID: otherID, Amount: 500, Currency: "USD"},
+			})
+			require.NoError(t, err)
+		}
+
+		// Filter to expenseID only — should see 3 txs
+		result, err := s.ListTransactionsByAccount(ctx, expenseID, model.ListOptions{Limit: 10, IncludeCount: true})
+		require.NoError(t, err)
+		assert.Len(t, result.Items, 3)
+		assert.Equal(t, 3, result.TotalCount)
+	})
+
+	t.Run("pagination with account filter", func(t *testing.T) {
+		s := setupTestDB(t)
+		ctx := context.Background()
+		assetID, expenseID := createTestAccounts(t, s)
+
+		for i := 0; i < 5; i++ {
+			addTx(t, s, assetID, expenseID, "tx")
+		}
+
+		page1, err := s.ListTransactionsByAccount(ctx, expenseID, model.ListOptions{Limit: 2, Offset: 0})
+		require.NoError(t, err)
+		assert.Len(t, page1.Items, 2)
+
+		page2, err := s.ListTransactionsByAccount(ctx, expenseID, model.ListOptions{Limit: 2, Offset: 2})
+		require.NoError(t, err)
+		assert.Len(t, page2.Items, 2)
+
+		page3, err := s.ListTransactionsByAccount(ctx, expenseID, model.ListOptions{Limit: 2, Offset: 4})
+		require.NoError(t, err)
+		assert.Len(t, page3.Items, 1)
+	})
+
+	t.Run("include count with filter", func(t *testing.T) {
+		s := setupTestDB(t)
+		ctx := context.Background()
+		assetID, expenseID := createTestAccounts(t, s)
+		otherID, err := s.CreateAccount(ctx, "Expenses:Other", model.AccountTypeExpense, "USD", "", nil)
+		require.NoError(t, err)
+
+		// 2 txs touch expenseID
+		for i := 0; i < 2; i++ {
+			addTx(t, s, assetID, expenseID, "food")
+		}
+		// 3 txs touch otherID
+		for i := 0; i < 3; i++ {
+			_, err := s.CreateTransactionWithSplits(ctx, model.Transaction{
+				Timestamp:   time.Now().Unix(),
+				Description: "other",
+				Status:      model.StatusPending,
+				Type:        model.TxTypeExpense,
+			}, []model.Split{
+				{AccountID: assetID, Amount: -500, Currency: "USD"},
+				{AccountID: otherID, Amount: 500, Currency: "USD"},
+			})
+			require.NoError(t, err)
+		}
+
+		// TotalCount should reflect expenseID's 2 txs, not all 5
+		result, err := s.ListTransactionsByAccount(ctx, expenseID, model.ListOptions{Limit: 10, IncludeCount: true})
+		require.NoError(t, err)
+		assert.Len(t, result.Items, 2)
+		assert.Equal(t, 2, result.TotalCount)
+	})
+}


### PR DESCRIPTION
## Summary

- Add `ListOptions` and `ListResult[T]` pagination types in `internal/model/pagination.go`
- Add `ListTransactions` and `ListTransactionsByAccount` to `TransactionRepository` interface with SQLite store implementations using `LIMIT ? OFFSET ?` and optional `COUNT(*)` queries
- Add `ListRecentTransactions` and `ListTransactionHistory` service methods that delegate to the new repo methods
- Add comprehensive service tests (white-box) and store integration tests (black-box) covering pagination, count, defaults, error propagation, and edge cases

Existing methods and CLI callers are untouched — no breaking changes.

Closes #78

## Test plan

- [x] `go test ./...` — all 19 packages pass
- [x] Store tests: pagination across pages, include/exclude count, default limit, offset beyond total, account filtering
- [x] Service tests: happy path, default limit, empty result, error propagation, account-not-found, offset paging

🤖 Generated with [Claude Code](https://claude.com/claude-code)