### PR TITLE
fix: use ExecuteContext to propagate signal context to subcommands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,7 +138,7 @@ func Execute(migrations fs.FS) {
 		rootCmd.AddCommand(NewReportCmd(application.Service))
 		rootCmd.AddCommand(NewReconcileCmd(application.Service))
 
-		if err := rootCmd.Execute(); err != nil {
+		if err := rootCmd.ExecuteContext(ctx); err != nil {
 			pterm.Error.Println(capitalize(err.Error()))
 			return 1
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,7 +89,7 @@ func Execute(migrations fs.FS) {
 		rootCmd.AddCommand(ledgercmd.NewLedgerCmd(registry, migrations, appDir))
 
 		if isLedgerCommand(os.Args[1:]) {
-			if err := rootCmd.Execute(); err != nil {
+			if err := rootCmd.ExecuteContext(context.Background()); err != nil {
 				pterm.Error.Println(capitalize(err.Error()))
 				return 1
 			}
@@ -100,7 +100,7 @@ func Execute(migrations fs.FS) {
 		if err != nil {
 			// No active ledger — only ledger commands are useful.
 			pterm.Warning.Println("No ledger configured. Run: kea ledger add <name>")
-			if err := rootCmd.Execute(); err != nil {
+			if err := rootCmd.ExecuteContext(context.Background()); err != nil {
 				pterm.Error.Println(capitalize(err.Error()))
 				return 1
 			}

--- a/cmd/root_context_test.go
+++ b/cmd/root_context_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestExecuteContextPropagatesContext(t *testing.T) {
+	type ctxKey string
+	key := ctxKey("test-signal")
+
+	ctx := context.WithValue(context.Background(), key, "present")
+
+	var receivedCtx context.Context
+	root := &cobra.Command{Use: "root"}
+	child := &cobra.Command{
+		Use: "child",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			receivedCtx = cmd.Context()
+			return nil
+		},
+	}
+	root.AddCommand(child)
+	root.SetArgs([]string{"child"})
+
+	if err := root.ExecuteContext(ctx); err != nil {
+		t.Fatalf("ExecuteContext returned error: %v", err)
+	}
+
+	if receivedCtx == nil {
+		t.Fatal("child command did not receive a context")
+	}
+	val, ok := receivedCtx.Value(key).(string)
+	if !ok || val != "present" {
+		t.Errorf("child context missing test value: got %q, want %q", val, "present")
+	}
+}


### PR DESCRIPTION
## Summary
- Replace `rootCmd.Execute()` with `rootCmd.ExecuteContext(ctx)` at the main execution site so subcommands receive the signal-aware context created via `signal.NotifyContext`
- Update two early-exit `rootCmd.Execute()` calls to use `ExecuteContext(context.Background())` for consistency
- Add test verifying context propagation through Cobra's `ExecuteContext`

Closes #91

## Test plan
- [x] `go test ./...` — all tests pass
- [x] `make build` — builds successfully
- [x] New `TestExecuteContextPropagatesContext` validates context flows to subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)