### PR TITLE
fix: wrap error consistently in GetTransactionByID (issue #25)

### DIFF
--- a/internal/service/transaction_service.go
+++ b/internal/service/transaction_service.go
@@ -52,7 +52,7 @@ func (ts *TransactionService) GetTransactionRule(txType model.TransactionType) (
 func (ts *TransactionService) GetTransactionByID(ctx context.Context, txID int64) (*model.TransactionDetail, error) {
 	tx, err := ts.txRepo.GetTransactionByID(ctx, txID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to retrieve transaction %d: %w", txID, err)
 	}
 
 	splits, err := ts.txRepo.GetSplitsWithAccountsByTransaction(ctx, txID)

--- a/internal/service/transaction_service_test.go
+++ b/internal/service/transaction_service_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestGetTransactionByID_RepoError_WrapsWithContext(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	repoErr := fmt.Errorf("db connection lost")
+	txRepo.getByIDErr[99] = repoErr
+
+	_, err := svc.GetTransactionByID(context.Background(), 99)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, repoErr) {
+		t.Errorf("expected error to wrap %v, got %v", repoErr, err)
+	}
+	if !strings.Contains(err.Error(), "failed to retrieve transaction") {
+		t.Errorf("expected context message in error, got: %s", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

- Wrapped the bare `return nil, err` in `GetTransactionByID` with `fmt.Errorf("failed to retrieve transaction %d: %w", txID, err)` to match the consistent error wrapping convention used throughout the service layer
- Added test `TestGetTransactionByID_RepoError_WrapsWithContext` verifying the error wraps the original (via `errors.Is`) and includes a context message (via `strings.Contains`)

Closes #25

## Test plan

- [x] New test passes: `go test ./internal/service/ -run TestGetTransactionByID_RepoError_WrapsWithContext -v`
- [x] All existing tests pass: `go test ./...`
- [x] No regressions — all callers use `errors.Is` which unwraps correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)