### PR TITLE
refactor: use TxType constants in modeUIConfigs and remove duplicate Mode constants

### DIFF
--- a/cmd/add_actions.go
+++ b/cmd/add_actions.go
@@ -200,9 +200,9 @@ func (r *addRunner) determineMode(rawInput string) model.TransactionType {
 }
 
 var modeUIConfigs = map[model.TransactionType]struct{ Src, Dst string }{
-	model.ModeExpense:  {"Payment Source:", "Expense Type:"},
-	model.ModeIncome:   {"Revenue Type:", "Deposit To:"},
-	model.ModeTransfer: {"From Account:", "To Account:"},
+	model.TxTypeExpense:  {"Payment Source:", "Expense Type:"},
+	model.TxTypeIncome:   {"Revenue Type:", "Deposit To:"},
+	model.TxTypeTransfer: {"From Account:", "To Account:"},
 }
 
 func (r *addRunner) runFromSplitFlags(flags *addFlags) (addTransactionInput, error) {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -134,10 +134,6 @@ const (
 )
 
 const (
-	ModeExpense  = "Expense"
-	ModeIncome   = "Income"
-	ModeTransfer = "Transfer"
-
 	DateFormat                = "2006-01-02"
 	SystemTransactionID int64 = 1
 	MinSplitsCount            = 2


### PR DESCRIPTION
## Summary
- Replace `model.ModeExpense/ModeIncome/ModeTransfer` with `model.TxTypeExpense/TxTypeIncome/TxTypeTransfer` in the `modeUIConfigs` map
- Remove the now-unused `Mode*` constants from `internal/model/types.go`

Closes #65

## Test plan
- [x] `go test ./...` passes — no behavior change since the constants had identical string values

🤖 Generated with [Claude Code](https://claude.com/claude-code)