### PR TITLE
fix: reject partial reconcile flags instead of falling back to interactive mode

### DIFF
--- a/cmd/reconcile.go
+++ b/cmd/reconcile.go
@@ -49,8 +49,9 @@ matching transactions as reconciled.
 Interactive mode (default):
   kea reconcile "Assets:Checking"
 
-Non-interactive / agent mode (all flags required):
-  kea reconcile "Assets:Checking" --balance 2450.00 --ids 12,15,18 --json`,
+Non-interactive / agent mode (--balance and --ids required):
+  kea reconcile "Assets:Checking" --balance 2450.00 --ids 12,15,18
+  kea reconcile "Assets:Checking" --balance 2450.00 --ids 12,15,18 --force --json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner := &reconcileRunner{
@@ -64,8 +65,8 @@ Non-interactive / agent mode (all flags required):
 
 	cmd.Flags().StringVar(&flags.Balance, "balance", "", "statement ending balance (e.g. 2450.00)")
 	cmd.Flags().StringVar(&flags.IDs, "ids", "", "comma-separated transaction IDs to reconcile (non-interactive)")
-	cmd.Flags().BoolVar(&flags.Force, "force", false, "skip balance-mismatch warning (non-interactive mode)")
-	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output result as JSON")
+	cmd.Flags().BoolVar(&flags.Force, "force", false, "skip balance-mismatch warning; implies non-interactive mode")
+	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output result as JSON (works in both modes)")
 
 	return cmd
 }

--- a/cmd/reconcile_actions.go
+++ b/cmd/reconcile_actions.go
@@ -23,13 +23,19 @@ func (r *reconcileRunner) Run(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	accountName := args[0]
 
-	// Resolve account.
 	acc, err := r.accSvc.GetAccountByName(ctx, accountName)
 	if err != nil {
 		return fmt.Errorf("account %q not found: %w", accountName, err)
 	}
 
-	nonInteractive := cmd.Flags().Changed("balance") && cmd.Flags().Changed("ids")
+	nonInteractive, err := resolveMode(
+		cmd.Flags().Changed("balance"),
+		cmd.Flags().Changed("ids"),
+		cmd.Flags().Changed("force"),
+	)
+	if err != nil {
+		return err
+	}
 
 	if nonInteractive {
 		return r.runNonInteractive(ctx, acc)
@@ -148,6 +154,27 @@ func (r *reconcileRunner) runInteractive(ctx context.Context, acc *model.Account
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────
+
+func resolveMode(balanceSet, idsSet, forceSet bool) (bool, error) {
+	if !balanceSet && !idsSet && !forceSet {
+		return false, nil
+	}
+
+	var missing []string
+	if !balanceSet {
+		missing = append(missing, "--balance")
+	}
+	if !idsSet {
+		missing = append(missing, "--ids")
+	}
+	if len(missing) > 0 {
+		return false, fmt.Errorf(
+			"non-interactive mode requires both --balance and --ids; missing: %s",
+			strings.Join(missing, ", "),
+		)
+	}
+	return true, nil
+}
 
 func parseIDs(s string) ([]int64, error) {
 	if strings.TrimSpace(s) == "" {

--- a/cmd/reconcile_actions_test.go
+++ b/cmd/reconcile_actions_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveMode(t *testing.T) {
+	t.Run("no flags means interactive", func(t *testing.T) {
+		mode, err := resolveMode(false, false, false)
+		require.NoError(t, err)
+		assert.False(t, mode)
+	})
+
+	t.Run("balance and ids means non-interactive", func(t *testing.T) {
+		mode, err := resolveMode(true, true, false)
+		require.NoError(t, err)
+		assert.True(t, mode)
+	})
+
+	t.Run("balance and ids and force means non-interactive", func(t *testing.T) {
+		mode, err := resolveMode(true, true, true)
+		require.NoError(t, err)
+		assert.True(t, mode)
+	})
+
+	t.Run("balance only is an error", func(t *testing.T) {
+		_, err := resolveMode(true, false, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--ids")
+	})
+
+	t.Run("ids only is an error", func(t *testing.T) {
+		_, err := resolveMode(false, true, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--balance")
+	})
+
+	t.Run("force only is an error", func(t *testing.T) {
+		_, err := resolveMode(false, false, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--balance")
+		assert.Contains(t, err.Error(), "--ids")
+	})
+
+	t.Run("force with balance only is an error", func(t *testing.T) {
+		_, err := resolveMode(true, false, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--ids")
+	})
+
+	t.Run("force with ids only is an error", func(t *testing.T) {
+		_, err := resolveMode(false, true, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--balance")
+	})
+}


### PR DESCRIPTION
## Summary
- Extracts a `resolveMode` helper that treats any of `--balance`, `--ids`, or `--force` as a non-interactive mode request
- Rejects incomplete flag combinations with a clear error listing the missing flags, instead of silently falling back to interactive mode
- Adds 8 test cases covering all flag combinations

Closes #45

## Test plan
- [x] `go test ./cmd/ -run TestResolveMode -v` — all 8 cases pass
- [x] `go test ./...` — full suite passes, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)