### PR TITLE
fix: numeric precision in FormatAmount and AbsInt64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v0.8.0
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/dustin/go-humanize v1.0.1
 	github.com/golang-migrate/migrate/v4 v4.19.0
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/mattn/go-sqlite3 v1.14.32
@@ -36,6 +35,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.3.0 // indirect
 	github.com/containerd/console v1.0.5 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect

--- a/internal/utils/amount.go
+++ b/internal/utils/amount.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -12,6 +13,9 @@ import (
 )
 
 func FormatAmount(cents int64) string {
+	if cents == math.MinInt64 {
+		panic("utils.FormatAmount: undefined for math.MinInt64 (overflow)")
+	}
 	negative := cents < 0
 	if negative {
 		cents = -cents

--- a/internal/utils/amount.go
+++ b/internal/utils/amount.go
@@ -8,13 +8,52 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/dustin/go-humanize"
 	"github.com/hance08/kea/internal/model"
 )
 
 func FormatAmount(cents int64) string {
-	amountVal := float64(cents) / float64(model.CentsPerUnit)
-	return humanize.CommafWithDigits(amountVal, 2)
+	negative := cents < 0
+	if negative {
+		cents = -cents
+	}
+
+	whole := cents / int64(model.CentsPerUnit)
+	frac := cents % int64(model.CentsPerUnit)
+
+	wholeStr := insertCommas(strconv.FormatInt(whole, 10))
+
+	var result string
+	if frac == 0 {
+		result = wholeStr
+	} else if frac%10 == 0 {
+		result = fmt.Sprintf("%s.%d", wholeStr, frac/10)
+	} else {
+		result = fmt.Sprintf("%s.%02d", wholeStr, frac)
+	}
+
+	if negative {
+		return "-" + result
+	}
+	return result
+}
+
+func insertCommas(s string) string {
+	n := len(s)
+	if n <= 3 {
+		return s
+	}
+
+	var buf strings.Builder
+	firstGroup := n % 3
+	if firstGroup == 0 {
+		firstGroup = 3
+	}
+	buf.WriteString(s[:firstGroup])
+	for i := firstGroup; i < n; i += 3 {
+		buf.WriteByte(',')
+		buf.WriteString(s[i : i+3])
+	}
+	return buf.String()
 }
 
 func ParseAmount(amountStr string) (int64, error) {

--- a/internal/utils/amount_test.go
+++ b/internal/utils/amount_test.go
@@ -32,6 +32,9 @@ func TestFormatAmount(t *testing.T) {
 		{"one million whole", 100000000, "1,000,000"},
 		{"negative whole", -500, "-5"},
 		{"negative with decimal", -150, "-1.5"},
+		{"large amount near float64 precision limit", 9007199254740993, "90,071,992,547,409.93"},
+		{"max practical (90 trillion)", 9000000000000000, "90,000,000,000,000"},
+		{"negative large", -9007199254740993, "-90,071,992,547,409.93"},
 	}
 
 	for _, tt := range tests {

--- a/internal/utils/amount_test.go
+++ b/internal/utils/amount_test.go
@@ -4,6 +4,7 @@
 package utils_test
 
 import (
+	"math"
 	"testing"
 
 	"github.com/hance08/kea/internal/utils"
@@ -15,7 +16,7 @@ import (
 // FormatAmount
 // ──────────────────────────────────────────────
 
-// Note: humanize.CommafWithDigits trims trailing zeros.
+// FormatAmount trims trailing zeros.
 // e.g. 100 cents (1.00) → "1", 150 cents (1.50) → "1.5"
 func TestFormatAmount(t *testing.T) {
 	tests := []struct {
@@ -43,6 +44,12 @@ func TestFormatAmount(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestFormatAmount_MinInt64_Panics(t *testing.T) {
+	assert.Panics(t, func() {
+		utils.FormatAmount(math.MinInt64)
+	})
 }
 
 // ──────────────────────────────────────────────

--- a/internal/utils/math.go
+++ b/internal/utils/math.go
@@ -3,7 +3,12 @@
 
 package utils
 
+import "math"
+
 func AbsInt64(n int64) int64 {
+	if n == math.MinInt64 {
+		panic("utils.AbsInt64: undefined for math.MinInt64 (overflow)")
+	}
 	if n < 0 {
 		return -n
 	}

--- a/internal/utils/math_test.go
+++ b/internal/utils/math_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package utils_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/hance08/kea/internal/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAbsInt64(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int64
+		want int64
+	}{
+		{"positive", 42, 42},
+		{"negative", -42, 42},
+		{"zero", 0, 0},
+		{"max int64", math.MaxInt64, math.MaxInt64},
+		{"negative one", -1, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, utils.AbsInt64(tt.n))
+		})
+	}
+}
+
+func TestAbsInt64_MinInt64_Panics(t *testing.T) {
+	assert.Panics(t, func() {
+		utils.AbsInt64(math.MinInt64)
+	})
+}


### PR DESCRIPTION
## Summary
- **AbsInt64 overflow (closes #31):** `AbsInt64(math.MinInt64)` silently returned a negative value due to two's complement overflow. Now panics explicitly, since this value (~$92 quadrillion) is unreachable in practice and silent corruption is worse than a loud failure.
- **FormatAmount precision (closes #67):** Rewrote `FormatAmount` to use integer arithmetic (div/mod by 100 + manual comma insertion) instead of converting to `float64`, which lost precision for values above 2^53. Removed the `go-humanize` dependency.

## Test plan
- [x] Added `TestAbsInt64` table-driven tests (positive, negative, zero, max int64)
- [x] Added `TestAbsInt64_MinInt64_Panics` asserting the new panic behavior
- [x] Added large-amount test cases to `TestFormatAmount` (near 2^53, 90 trillion, negative large)
- [x] All existing tests continue to pass (`go test ./...`)
- [x] `make build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)