### PR TITLE
fix: add missing down migrations for 0001-0004

### DIFF
--- a/migrations/0001_create_initial_schema.down.sql
+++ b/migrations/0001_create_initial_schema.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS splits;
+DROP TABLE IF EXISTS transactions;
+DROP TABLE IF EXISTS accounts;

--- a/migrations/0002_add_external_id.down.sql
+++ b/migrations/0002_add_external_id.down.sql
@@ -1,0 +1,14 @@
+DROP INDEX IF EXISTS idx_transactions_external_id;
+
+CREATE TABLE transactions_new (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp   INTEGER NOT NULL,
+    description TEXT,
+    status      INTEGER NOT NULL DEFAULT 0
+);
+
+INSERT INTO transactions_new SELECT id, timestamp, description, status FROM transactions;
+DROP TABLE transactions;
+ALTER TABLE transactions_new RENAME TO transactions;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_timestamp ON transactions (timestamp);

--- a/migrations/0003_add_split_reconciled.down.sql
+++ b/migrations/0003_add_split_reconciled.down.sql
@@ -1,0 +1,19 @@
+DROP INDEX IF EXISTS idx_splits_reconciled;
+
+CREATE TABLE splits_new (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    transaction_id   INTEGER NOT NULL,
+    account_id       INTEGER NOT NULL,
+    amount           INTEGER NOT NULL,
+    currency         TEXT NOT NULL,
+    memo             TEXT,
+    FOREIGN KEY (transaction_id) REFERENCES transactions(id) ON DELETE CASCADE,
+    FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE RESTRICT
+);
+
+INSERT INTO splits_new SELECT id, transaction_id, account_id, amount, currency, memo FROM splits;
+DROP TABLE splits;
+ALTER TABLE splits_new RENAME TO splits;
+
+CREATE INDEX IF NOT EXISTS idx_splits_transaction_id ON splits (transaction_id);
+CREATE INDEX IF NOT EXISTS idx_splits_account_id ON splits (account_id);

--- a/migrations/0004_add_account_reconcile_state.down.sql
+++ b/migrations/0004_add_account_reconcile_state.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS account_reconcile_state;


### PR DESCRIPTION
## Summary
- Add `.down.sql` files for migrations 0001–0004 so the schema can be fully rolled back with `golang-migrate`
- Migrations 0001 and 0004 use `DROP TABLE`; 0002 and 0003 use SQLite's "recreate table without column" pattern (consistent with existing `0005_add_transaction_type.down.sql`)
- Verified with up→down→up round-trip test

Closes #30, closes #59

## Test plan
- [x] Round-trip verification: apply all ups, roll back all downs, re-apply all ups — schema intact
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)