### PR TITLE
fix: validate AccountType defensively in store layer

### DIFF
--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -13,4 +13,5 @@ var (
 	ErrAccountExists       = fmt.Errorf("account already exists: %w", repository.ErrAlreadyExists)
 	ErrRecordNotFound      = fmt.Errorf("record not found: %w", repository.ErrNotFound)
 	ErrConstraintViolation = fmt.Errorf("database constraint violation")
+	ErrInvalidAccountType  = fmt.Errorf("invalid account type")
 )

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -98,7 +98,7 @@ func (s *Store) DB() *sql.DB {
 }
 
 func runMigrations(db *sql.DB, migrationsFS fs.FS) error {
-	driver, err := sqlite3.WithInstance(db, &sqlite3.Config{})
+	driver, err := sqlite3.WithInstance(db, &sqlite3.Config{NoTxWrap: true})
 	if err != nil {
 		return fmt.Errorf("failed to set up migrate driver : %w", err)
 	}

--- a/internal/store/sqlite_account.go
+++ b/internal/store/sqlite_account.go
@@ -14,6 +14,9 @@ import (
 )
 
 func (s *Store) CreateAccount(ctx context.Context, name string, accType model.AccountType, currency string, description string, parentID *int64) (int64, error) {
+	if !accType.IsValid() {
+		return 0, fmt.Errorf("account type %q: %w", accType, ErrInvalidAccountType)
+	}
 	stmt, err := s.db.PrepareContext(ctx, `
         INSERT INTO accounts (name, type, currency, description, parent_id)
         VALUES (?, ?, ?, ?, ?)

--- a/internal/store/sqlite_account_test.go
+++ b/internal/store/sqlite_account_test.go
@@ -436,3 +436,13 @@ func TestGetAllAccountBalances(t *testing.T) {
 	assert.Equal(t, int64(-800), balances[assetID])
 	assert.Equal(t, int64(800), balances[expenseID])
 }
+
+func TestAccountTypeCheckConstraint_RejectsInvalidTypeAtDBLevel(t *testing.T) {
+	s := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := s.DB().ExecContext(ctx,
+		`INSERT INTO accounts (name, type, currency, description) VALUES (?, ?, ?, ?)`,
+		"Test:Invalid", "X", "USD", "")
+	require.Error(t, err, "DB should reject invalid account type")
+}

--- a/internal/store/sqlite_account_test.go
+++ b/internal/store/sqlite_account_test.go
@@ -392,6 +392,15 @@ func TestGetAccountBalance(t *testing.T) {
 	assert.Equal(t, int64(2000), bal)
 }
 
+func TestCreateAccount_RejectsInvalidAccountType(t *testing.T) {
+	s := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := s.CreateAccount(ctx, "Assets:Test", model.AccountType("X"), "USD", "", nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, store.ErrInvalidAccountType)
+}
+
 func TestGetAllAccountBalances(t *testing.T) {
 	s := setupTestDB(t)
 	ctx := context.Background()

--- a/migrations/0007_add_account_type_check.down.sql
+++ b/migrations/0007_add_account_type_check.down.sql
@@ -1,5 +1,7 @@
 PRAGMA foreign_keys = OFF;
 
+BEGIN;
+
 CREATE TABLE accounts_new (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     name        TEXT NOT NULL UNIQUE,
@@ -18,5 +20,7 @@ DROP TABLE accounts;
 ALTER TABLE accounts_new RENAME TO accounts;
 
 CREATE INDEX IF NOT EXISTS idx_accounts_name ON accounts (name);
+
+COMMIT;
 
 PRAGMA foreign_keys = ON;

--- a/migrations/0007_add_account_type_check.down.sql
+++ b/migrations/0007_add_account_type_check.down.sql
@@ -1,0 +1,22 @@
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE accounts_new (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT NOT NULL UNIQUE,
+    type        TEXT NOT NULL,
+    parent_id   INTEGER,
+    currency    TEXT NOT NULL,
+    description TEXT,
+    is_hidden   INTEGER NOT NULL DEFAULT 0,
+
+    FOREIGN KEY (parent_id) REFERENCES accounts(id)
+);
+
+INSERT INTO accounts_new SELECT id, name, type, parent_id, currency, description, is_hidden FROM accounts;
+
+DROP TABLE accounts;
+ALTER TABLE accounts_new RENAME TO accounts;
+
+CREATE INDEX IF NOT EXISTS idx_accounts_name ON accounts (name);
+
+PRAGMA foreign_keys = ON;

--- a/migrations/0007_add_account_type_check.up.sql
+++ b/migrations/0007_add_account_type_check.up.sql
@@ -1,5 +1,7 @@
 PRAGMA foreign_keys = OFF;
 
+BEGIN;
+
 CREATE TABLE accounts_new (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     name        TEXT NOT NULL UNIQUE,
@@ -18,5 +20,7 @@ DROP TABLE accounts;
 ALTER TABLE accounts_new RENAME TO accounts;
 
 CREATE INDEX IF NOT EXISTS idx_accounts_name ON accounts (name);
+
+COMMIT;
 
 PRAGMA foreign_keys = ON;

--- a/migrations/0007_add_account_type_check.up.sql
+++ b/migrations/0007_add_account_type_check.up.sql
@@ -1,0 +1,22 @@
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE accounts_new (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT NOT NULL UNIQUE,
+    type        TEXT NOT NULL CHECK(type IN ('A','L','C','R','E')),
+    parent_id   INTEGER,
+    currency    TEXT NOT NULL,
+    description TEXT,
+    is_hidden   INTEGER NOT NULL DEFAULT 0,
+
+    FOREIGN KEY (parent_id) REFERENCES accounts(id)
+);
+
+INSERT INTO accounts_new SELECT id, name, type, parent_id, currency, description, is_hidden FROM accounts;
+
+DROP TABLE accounts;
+ALTER TABLE accounts_new RENAME TO accounts;
+
+CREATE INDEX IF NOT EXISTS idx_accounts_name ON accounts (name);
+
+PRAGMA foreign_keys = ON;


### PR DESCRIPTION
## Summary
- Add `ErrInvalidAccountType` sentinel and `accType.IsValid()` guard at the top of `Store.CreateAccount`, rejecting invalid types before any DB work
- Add migration 0007 with a `CHECK(type IN ('A','L','C','R','E'))` constraint on the `accounts` table as a DB-level safety net
- Both layers are independently tested

Closes #28

## Test plan
- [x] `TestCreateAccount_RejectsInvalidAccountType` — verifies Go-level guard returns `ErrInvalidAccountType` for invalid types
- [x] `TestAccountTypeCheckConstraint_RejectsInvalidTypeAtDBLevel` — verifies DB CHECK constraint rejects invalid types via raw SQL insert
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)