### PR TITLE
fix: validate transaction status in CreateTransaction and UpdateTransactionComplete

### DIFF
--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -252,9 +252,8 @@ func (ts *TransactionService) UpdateTransactionStatus(ctx context.Context, txID 
 // UpdateTransactionComplete performs a complete update of a transaction including splits
 // This operation is atomic - either all changes succeed or all fail
 func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, input model.UpdateTransactionInput) error {
-	// Validate status
-	if input.Status != model.StatusPending && input.Status != model.StatusCleared && input.Status != model.StatusReconciled {
-		return validationErrorf("status", "invalid status: must be 0 (Pending), 1 (Cleared) or 2 (Reconciled)")
+	if input.Status != model.StatusPending && input.Status != model.StatusCleared {
+		return validationErrorf("status", "invalid status: must be Pending or Cleared")
 	}
 
 	if input.ID == model.SystemTransactionID {

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -34,6 +34,10 @@ func (ts *TransactionService) CreateTransaction(ctx context.Context, input model
 		return 0, validationErrorf("type", "transaction type is required")
 	}
 
+	if input.Status != model.StatusPending && input.Status != model.StatusCleared {
+		return 0, validationErrorf("status", "invalid status: new transactions must be Pending or Cleared")
+	}
+
 	// Set default timestamp: Use current system time if not provided.
 	if input.Timestamp == 0 {
 		input.Timestamp = time.Now().Unix()

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -267,6 +267,50 @@ func TestCreateTransaction(t *testing.T) {
 		assert.Contains(t, err.Error(), "split #1")
 		assert.Contains(t, err.Error(), "parent account")
 	})
+
+	t.Run("status reconciled(2) rejected on create", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+		input := model.TransactionDetail{
+			Type:   model.TxTypeExpense,
+			Status: model.StatusReconciled,
+			Splits: []model.SplitDetail{
+				{AccountName: "Expenses:Food", Amount: 500},
+				{AccountName: "Assets:Bank", Amount: -500},
+			},
+		}
+		_, err := svc.CreateTransaction(context.Background(), input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid status")
+
+		var ve *ValidationError
+		assert.True(t, errors.As(err, &ve))
+		assert.Equal(t, "status", ve.Field)
+	})
+
+	t.Run("invalid status(99) rejected on create", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+		input := model.TransactionDetail{
+			Type:   model.TxTypeExpense,
+			Status: model.TransactionStatus(99),
+			Splits: []model.SplitDetail{
+				{AccountName: "Expenses:Food", Amount: 500},
+				{AccountName: "Assets:Bank", Amount: -500},
+			},
+		}
+		_, err := svc.CreateTransaction(context.Background(), input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid status")
+
+		var ve *ValidationError
+		assert.True(t, errors.As(err, &ve))
+		assert.Equal(t, "status", ve.Field)
+	})
 }
 
 // ──────────────────────────────────────────────

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -569,6 +569,32 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid status")
 	})
 
+	t.Run("setting status to reconciled(2) rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		txRepo.addTransaction(
+			&model.Transaction{ID: 5, Status: model.StatusPending},
+			makeExistingSplits(10, 11),
+		)
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		splits := []model.SplitDetail{
+			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -800, Currency: "USD"},
+			{ID: 11, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 800, Currency: "USD"},
+		}
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{
+			ID: 5, Description: "Trying reconciled", Timestamp: 0,
+			Status: model.StatusReconciled, Type: model.TxTypeExpense, Splits: splits,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid status")
+
+		var ve *ValidationError
+		assert.True(t, errors.As(err, &ve))
+		assert.Equal(t, "status", ve.Field)
+	})
+
 	t.Run("non-existent transaction returns error", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
 		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 999, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense,


### PR DESCRIPTION
## Summary
- Add status validation to `CreateTransaction` — reject `StatusReconciled` and arbitrary integer values; only `Pending` and `Cleared` are allowed for new transactions
- Tighten `UpdateTransactionComplete` validation to also reject `StatusReconciled` — reconciliation must go through the `ReconcileTransactions` workflow

Closes #113

## Test Plan
- [x] Added test: `CreateTransaction` rejects `StatusReconciled`
- [x] Added test: `CreateTransaction` rejects invalid status (99)
- [x] Added test: `UpdateTransactionComplete` rejects `StatusReconciled`
- [x] Existing tests for `UpdateTransactionComplete` invalid status (99) still pass
- [x] Existing tests for reconciled transaction immutability still pass
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)