### PR TITLE
fix: skip interactive TUI prompt in non-interactive contexts (#118)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/term"
 )
 
 var cfgFile string
@@ -236,6 +237,21 @@ func ensureCurrency(cfg *config.Config) error {
 	return initWizard(cfg)
 }
 
+func isInteractive() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+func setCurrency(cfg *config.Config, currency string) error {
+	cfg.Defaults.Currency = currency
+	viper.Set("defaults.currency", currency)
+
+	if err := viper.WriteConfig(); err != nil {
+		return fmt.Errorf("failed to save config to file: %w", err)
+	}
+
+	return nil
+}
+
 func initConfig(cfgFile string) (*config.Config, error) {
 	var appDir string
 	if cfgFile != "" {
@@ -290,11 +306,8 @@ func initWizard(cfg *config.Config) error {
 		return err
 	}
 
-	cfg.Defaults.Currency = currency
-	viper.Set("defaults.currency", currency)
-
-	if err := viper.WriteConfig(); err != nil {
-		return fmt.Errorf("failed to save config to file: %w", err)
+	if err := setCurrency(cfg, currency); err != nil {
+		return err
 	}
 
 	pterm.Success.Printf("Configuration saved. Default currency set to: %s\n", currency)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -230,11 +230,25 @@ func migrateLegacySysAccWith(ctx context.Context, acc accountMigrator, cfg *conf
 }
 
 func ensureCurrency(cfg *config.Config) error {
+	return ensureCurrencyWith(cfg, isInteractive())
+}
+
+func ensureCurrencyWith(cfg *config.Config, interactive bool) error {
 	if cfg.Defaults.Currency != "" {
 		return nil
 	}
 
-	return initWizard(cfg)
+	if interactive {
+		return initWizard(cfg)
+	}
+
+	if err := setCurrency(cfg, "USD"); err != nil {
+		return err
+	}
+
+	pterm.Warning.Println("No default currency configured; defaulting to USD.")
+
+	return nil
 }
 
 func isInteractive() bool {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -206,6 +206,23 @@ func TestSetCurrency(t *testing.T) {
 	assert.Contains(t, string(contents), "EUR")
 }
 
+func TestEnsureCurrency_NonInteractiveFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("defaults:\n  currency: \"\"\n"), 0o644))
+
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.SetConfigFile(cfgPath)
+	require.NoError(t, viper.ReadInConfig())
+
+	cfg := &config.Config{}
+	err := ensureCurrencyWith(cfg, false)
+	require.NoError(t, err)
+	assert.Equal(t, "USD", cfg.Defaults.Currency)
+	assert.Equal(t, "USD", viper.GetString("defaults.currency"))
+}
+
 func TestIsLedgerCommand(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -190,6 +190,7 @@ func TestSetCurrency(t *testing.T) {
 	require.NoError(t, os.WriteFile(cfgPath, []byte("defaults:\n  currency: \"\"\n"), 0o644))
 
 	viper.Reset()
+	t.Cleanup(viper.Reset)
 	viper.SetConfigFile(cfgPath)
 	require.NoError(t, viper.ReadInConfig())
 
@@ -199,6 +200,10 @@ func TestSetCurrency(t *testing.T) {
 
 	assert.Equal(t, "EUR", cfg.Defaults.Currency)
 	assert.Equal(t, "EUR", viper.GetString("defaults.currency"))
+
+	contents, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(contents), "EUR")
 }
 
 func TestIsLedgerCommand(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/service"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -174,6 +175,30 @@ func TestLedgerCommand_SkipsDBInit(t *testing.T) {
 	// The bogus DB file must not have been created or opened.
 	_, statErr := os.Stat(bogusPath)
 	assert.True(t, os.IsNotExist(statErr), "DB file should not exist — DB init must not have run")
+}
+
+func TestEnsureCurrency_AlreadySet(t *testing.T) {
+	cfg := &config.Config{Defaults: config.DefaultsConfig{Currency: "TWD"}}
+	err := ensureCurrency(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "TWD", cfg.Defaults.Currency)
+}
+
+func TestSetCurrency(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("defaults:\n  currency: \"\"\n"), 0o644))
+
+	viper.Reset()
+	viper.SetConfigFile(cfgPath)
+	require.NoError(t, viper.ReadInConfig())
+
+	cfg := &config.Config{}
+	err := setCurrency(cfg, "EUR")
+	require.NoError(t, err)
+
+	assert.Equal(t, "EUR", cfg.Defaults.Currency)
+	assert.Equal(t, "EUR", viper.GetString("defaults.currency"))
 }
 
 func TestIsLedgerCommand(t *testing.T) {

--- a/docs/superpowers/plans/2026-05-19-non-interactive-currency-fallback.md
+++ b/docs/superpowers/plans/2026-05-19-non-interactive-currency-fallback.md
@@ -1,0 +1,214 @@
+# Non-Interactive Currency Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent `ensureCurrency` from launching an interactive TUI prompt when stdin is not a terminal — fall back to USD instead.
+
+**Architecture:** Add an `isInteractive()` helper using Go 1.24+ `os.IsTerminal()`. Extract the config-writing logic from `initWizard` into a shared `setCurrency` helper. Modify `ensureCurrency` to branch: interactive → TUI wizard, non-interactive → USD fallback with warning.
+
+**Tech Stack:** Go stdlib (`os.IsTerminal`), viper, pterm, testify
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `cmd/root.go` | Modify | Add `isInteractive()`, `setCurrency()`, update `ensureCurrency` |
+| `cmd/root_test.go` | Modify | Add tests for `ensureCurrency` branching logic |
+
+---
+
+### Task 1: Add `isInteractive` helper and `setCurrency` extractor
+
+**Files:**
+- Modify: `cmd/root.go:231-237` (ensureCurrency), `cmd/root.go:287-303` (initWizard)
+
+- [ ] **Step 1: Write failing tests for the non-interactive fallback path**
+
+Add to `cmd/root_test.go`:
+
+```go
+func TestEnsureCurrency_AlreadySet(t *testing.T) {
+	cfg := &config.Config{Defaults: config.DefaultsConfig{Currency: "TWD"}}
+	err := ensureCurrency(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "TWD", cfg.Defaults.Currency)
+}
+
+func TestSetCurrency(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("defaults:\n  currency: \"\"\n"), 0o644))
+
+	viper.Reset()
+	viper.SetConfigFile(cfgPath)
+	require.NoError(t, viper.ReadInConfig())
+
+	cfg := &config.Config{}
+	err := setCurrency(cfg, "EUR")
+	require.NoError(t, err)
+
+	assert.Equal(t, "EUR", cfg.Defaults.Currency)
+	assert.Equal(t, "EUR", viper.GetString("defaults.currency"))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/ -run "TestEnsureCurrency_AlreadySet|TestSetCurrency" -v`
+Expected: FAIL — `setCurrency` undefined
+
+- [ ] **Step 3: Add `isInteractive` and `setCurrency` to `cmd/root.go`**
+
+Add the `isInteractive` function after `ensureCurrency` (around line 237):
+
+```go
+func isInteractive() bool {
+	return os.IsTerminal(os.Stdin.Fd())
+}
+```
+
+Extract config-writing logic from `initWizard` into `setCurrency`:
+
+```go
+func setCurrency(cfg *config.Config, currency string) error {
+	cfg.Defaults.Currency = currency
+	viper.Set("defaults.currency", currency)
+
+	if err := viper.WriteConfig(); err != nil {
+		return fmt.Errorf("failed to save config to file: %w", err)
+	}
+
+	return nil
+}
+```
+
+Update `initWizard` to use `setCurrency`:
+
+```go
+func initWizard(cfg *config.Config) error {
+	currency, err := prompts.PromptInitCurrency("USD")
+	if err != nil {
+		return err
+	}
+
+	if err := setCurrency(cfg, currency); err != nil {
+		return err
+	}
+
+	pterm.Success.Printf("Configuration saved. Default currency set to: %s\n", currency)
+
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./cmd/ -run "TestEnsureCurrency_AlreadySet|TestSetCurrency" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/root.go cmd/root_test.go
+git commit -m "refactor: extract setCurrency helper and add isInteractive detection"
+```
+
+---
+
+### Task 2: Update `ensureCurrency` to branch on TTY
+
+**Files:**
+- Modify: `cmd/root.go:231-237` (ensureCurrency)
+- Modify: `cmd/root_test.go`
+
+- [ ] **Step 1: Write failing test for non-interactive fallback**
+
+Add to `cmd/root_test.go`:
+
+```go
+func TestEnsureCurrency_NonInteractiveFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("defaults:\n  currency: \"\"\n"), 0o644))
+
+	viper.Reset()
+	viper.SetConfigFile(cfgPath)
+	require.NoError(t, viper.ReadInConfig())
+
+	cfg := &config.Config{}
+	err := ensureCurrencyWith(cfg, false)
+	require.NoError(t, err)
+	assert.Equal(t, "USD", cfg.Defaults.Currency)
+	assert.Equal(t, "USD", viper.GetString("defaults.currency"))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/ -run TestEnsureCurrency_NonInteractiveFallback -v`
+Expected: FAIL — `ensureCurrencyWith` undefined
+
+- [ ] **Step 3: Implement `ensureCurrencyWith` and update `ensureCurrency`**
+
+Replace the existing `ensureCurrency` in `cmd/root.go`:
+
+```go
+func ensureCurrency(cfg *config.Config) error {
+	return ensureCurrencyWith(cfg, isInteractive())
+}
+
+func ensureCurrencyWith(cfg *config.Config, interactive bool) error {
+	if cfg.Defaults.Currency != "" {
+		return nil
+	}
+
+	if interactive {
+		return initWizard(cfg)
+	}
+
+	if err := setCurrency(cfg, "USD"); err != nil {
+		return err
+	}
+
+	pterm.Warning.Println("No default currency configured; defaulting to USD.")
+
+	return nil
+}
+```
+
+- [ ] **Step 4: Run all tests to verify they pass**
+
+Run: `go test ./cmd/ -run "TestEnsureCurrency|TestSetCurrency" -v`
+Expected: All PASS
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `go test ./...`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/root.go cmd/root_test.go
+git commit -m "fix: fallback to USD when ensureCurrency runs without a TTY (#118)"
+```
+
+---
+
+### Task 3: Build and verify
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Build the binary**
+
+Run: `make build`
+Expected: Succeeds, produces `./kea_test` binary
+
+- [ ] **Step 2: Run full test suite one final time**
+
+Run: `go test ./... -count=1`
+Expected: All PASS
+
+- [ ] **Step 3: Commit if any cleanup needed, otherwise done**

--- a/docs/superpowers/specs/2026-05-19-non-interactive-currency-fallback-design.md
+++ b/docs/superpowers/specs/2026-05-19-non-interactive-currency-fallback-design.md
@@ -1,0 +1,50 @@
+# Non-Interactive Currency Fallback
+
+**Date:** 2026-05-19
+**Issue:** #118 — `ensureCurrency` launches interactive TUI prompt that blocks non-interactive contexts
+
+## Problem
+
+`cmd/root.go` calls `ensureCurrency()` on every non-ledger startup. When no default currency is configured, it falls through to `initWizard()` which launches an interactive `huh` TUI prompt. This blocks indefinitely in non-interactive contexts (future `kea serve`, piped input, cron jobs, Docker containers).
+
+## Solution
+
+Add a `isInteractive()` TTY detection helper using Go 1.24+ `os.IsTerminal()`. Modify `ensureCurrency` to branch:
+
+- **Interactive (TTY attached):** Current behavior — call `initWizard` for TUI prompt.
+- **Non-interactive (no TTY):** Fall back to `"USD"`, persist to config, print a warning via `pterm.Warning`.
+
+## Changes
+
+### `cmd/root.go`
+
+**New function — `isInteractive()`:**
+
+```go
+func isInteractive() bool {
+    return os.IsTerminal(os.Stdin.Fd())
+}
+```
+
+**Modified function — `ensureCurrency(cfg)`:**
+
+When `cfg.Defaults.Currency` is empty:
+1. If `isInteractive()` returns true, call `initWizard(cfg)` (existing behavior).
+2. Otherwise, set currency to `"USD"`, write via `viper.Set` + `viper.WriteConfig`, and print a `pterm.Warning` message: `"No default currency configured; defaulting to USD."`.
+
+### No other files change
+
+- `initWizard` is unchanged.
+- `initSysAcc` is already non-interactive.
+- No new flags or command structure changes.
+- No new dependencies (`os.IsTerminal` is stdlib since Go 1.24).
+
+## Testing
+
+- Test the non-interactive fallback path: when currency is empty and `isInteractive` returns false, verify USD is set and config is written.
+- Test that the interactive path still delegates to `initWizard`.
+- `isInteractive()` itself is a thin stdlib wrapper — not unit tested directly.
+
+## Future Impact
+
+When `kea serve` is implemented, it will automatically skip the TUI wizard because server processes typically don't have a TTY attached. No additional work needed in the serve command.

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pterm/pterm v0.12.82
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/term v0.37.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -62,6 +63,5 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.39.0 // indirect
-	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 )


### PR DESCRIPTION
## Summary

- Added `isInteractive()` TTY detection using `golang.org/x/term` to determine if stdin is a terminal
- Extracted `setCurrency()` helper from `initWizard()` for reusable config persistence
- Split `ensureCurrency` into a testable `ensureCurrencyWith(cfg, interactive)` that falls back to USD with a warning when no TTY is attached, instead of blocking on a TUI prompt

Closes #118

## Test Plan

- [x] `TestEnsureCurrency_AlreadySet` — verifies no-op when currency is already configured
- [x] `TestSetCurrency` — verifies config struct, viper state, and file persistence
- [x] `TestEnsureCurrency_NonInteractiveFallback` — verifies USD fallback when `interactive=false`
- [x] Full test suite passes (`go test ./...`)
- [x] `make build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)