### PR TITLE
fix: add missing Type field to JSONTxDetail (#121)

### DIFF
--- a/ui/views/json_test.go
+++ b/ui/views/json_test.go
@@ -50,6 +50,7 @@ func TestToJSONTxDetail(t *testing.T) {
 		Timestamp:   1711238400, // 2024-03-24
 		Description: "Buy coffee",
 		Status:      model.StatusCleared,
+		Type:        model.TxTypeExpense,
 		Splits: []model.SplitDetail{
 			{ID: 1, AccountID: 10, AccountName: "Assets:Cash", AccountType: model.AccountTypeAsset, Amount: -500, Currency: "TWD", Memo: ""},
 			{ID: 2, AccountID: 20, AccountName: "Expenses:Food", AccountType: model.AccountTypeExpense, Amount: 500, Currency: "TWD", Memo: "lunch"},
@@ -58,6 +59,7 @@ func TestToJSONTxDetail(t *testing.T) {
 	got := ToJSONTxDetail(detail)
 	assert.Equal(t, int64(42), got.ID)
 	assert.Equal(t, "Cleared", got.Status)
+	assert.Equal(t, "Expense", got.Type)
 	assert.Len(t, got.Splits, 2)
 	assert.Equal(t, -5.0, got.Splits[0].Amount)
 	assert.Equal(t, 5.0, got.Splits[1].Amount)

--- a/ui/views/json_types.go
+++ b/ui/views/json_types.go
@@ -39,6 +39,7 @@ type JSONTxDetail struct {
 	ID          int64             `json:"id"`
 	Date        string            `json:"date"`
 	Description string            `json:"description"`
+	Type        string            `json:"type"`
 	Status      string            `json:"status"`
 	Splits      []JSONSplitDetail `json:"splits"`
 }
@@ -101,6 +102,7 @@ func ToJSONTxDetail(d *model.TransactionDetail) JSONTxDetail {
 		ID:          d.ID,
 		Date:        time.Unix(d.Timestamp, 0).Format(model.DateFormat),
 		Description: d.Description,
+		Type:        string(d.Type),
 		Status:      d.Status.String(),
 		Splits:      splits,
 	}


### PR DESCRIPTION
## Summary
- Add `Type string` field to `JSONTxDetail` struct so `kea transaction show --json` includes the transaction type
- Populate `Type` in `ToJSONTxDetail` converter using `string(d.Type)`, matching the pattern already used by `JSONTxListItem`
- Update `TestToJSONTxDetail` to cover the new field

Closes #121

## Test Plan
- [x] `TestToJSONTxDetail` asserts `got.Type == "Expense"` after converting a `TransactionDetail` with `Type: model.TxTypeExpense`
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)