### PR TITLE
fix: add missing JSON tags to ListResult and ListOptions (#116)

### DIFF
--- a/internal/model/pagination.go
+++ b/internal/model/pagination.go
@@ -7,15 +7,15 @@ package model
 // IncludeCount lets callers skip the COUNT query when they don't need the total.
 // Default limit is 20 when Limit is zero or negative.
 type ListOptions struct {
-	Limit        int
-	Offset       int
-	IncludeCount bool
+	Limit        int  `json:"limit"`
+	Offset       int  `json:"offset"`
+	IncludeCount bool `json:"include_count,omitempty"`
 }
 
 // ListResult holds a paginated slice of items alongside pagination metadata.
 type ListResult[T any] struct {
-	Items      []T
-	TotalCount int
-	Limit      int
-	Offset     int
+	Items      []T `json:"items"`
+	TotalCount int `json:"total_count"`
+	Limit      int `json:"limit"`
+	Offset     int `json:"offset"`
 }


### PR DESCRIPTION
## Summary
- Add snake_case `json:"..."` struct tags to `ListOptions` and `ListResult[T]` in `internal/model/pagination.go`
- Aligns pagination types with every other model type in the codebase
- Fixes #116

## Test plan
- [x] `go test ./...` — all tests pass (struct tags only affect JSON marshalling, no logic changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)