### PR TITLE
feat: add public GetAccountByID to AccountService

### DIFF
--- a/internal/service/account_service.go
+++ b/internal/service/account_service.go
@@ -40,6 +40,17 @@ func (as *AccountService) GetAccountByName(ctx context.Context, name string) (*m
 	return acc, nil
 }
 
+func (as *AccountService) GetAccountByID(ctx context.Context, id int64) (*model.Account, error) {
+	acc, err := as.repo.GetAccountByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("account #%d: %w", id, ErrNotFound)
+		}
+		return nil, err
+	}
+	return acc, nil
+}
+
 func (as *AccountService) GetAccountsByType(ctx context.Context, accType model.AccountType) ([]*model.Account, error) {
 	return as.repo.GetAccountsByType(ctx, accType)
 }

--- a/internal/service/account_service_test.go
+++ b/internal/service/account_service_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hance08/kea/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAccountByID(t *testing.T) {
+	t.Run("returns account when found", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Cash", Type: model.AccountTypeAsset, Currency: "USD"})
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		acc, err := svc.GetAccountByID(context.Background(), 1)
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), acc.ID)
+		assert.Equal(t, "Assets:Cash", acc.Name)
+	})
+
+	t.Run("wraps ErrNotFound from repo", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		acc, err := svc.GetAccountByID(context.Background(), 999)
+
+		assert.Nil(t, acc)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotFound))
+		assert.Contains(t, err.Error(), "999")
+	})
+
+	t.Run("passes through other errors", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		dbErr := fmt.Errorf("connection refused")
+		accRepo.getByIDErr[42] = dbErr
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		acc, err := svc.GetAccountByID(context.Background(), 42)
+
+		assert.Nil(t, acc)
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, ErrNotFound))
+		assert.Equal(t, dbErr, err)
+	})
+}


### PR DESCRIPTION
## Summary
- Adds public `GetAccountByID(ctx, id)` method to `AccountService`, enabling web layer to look up accounts by numeric ID without bypassing the service layer
- Wraps `repository.ErrNotFound` into `service.ErrNotFound` following the established `GetAccountByName` pattern
- Includes full test coverage (happy path, not-found wrapping, error passthrough)

Closes #104

## Test plan
- [x] Unit tests pass (`go test ./internal/service/ -run TestGetAccountByID -v`)
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)