### PR TITLE
fix: consistent ErrNotFound translation from repository to service layer

### DIFF
--- a/internal/service/account_ops.go
+++ b/internal/service/account_ops.go
@@ -173,6 +173,9 @@ func (as *AccountService) createOpeningBalanceInRepo(ctx context.Context, repo r
 func (as *AccountService) DeleteAccountByName(ctx context.Context, name string) error {
 	acc, err := as.repo.GetAccountByName(ctx, name)
 	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return fmt.Errorf("account %q: %w", name, ErrNotFound)
+		}
 		return err
 	}
 

--- a/internal/service/account_ops_test.go
+++ b/internal/service/account_ops_test.go
@@ -521,6 +521,15 @@ func TestDeleteAccountByName(t *testing.T) {
 		err := svc.DeleteAccountByName(context.Background(), "Assets:NonExistent")
 		require.Error(t, err)
 	})
+
+	t.Run("non-existent account returns ErrNotFound", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		err := svc.DeleteAccountByName(context.Background(), "Assets:DoesNotExist")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotFound), "expected ErrNotFound, got: %v", err)
+	})
 }
 
 // ──────────────────────────────────────────────

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -307,7 +307,7 @@ func (m *mockTransactionRepo) GetTransactionByID(_ context.Context, txID int64) 
 	}
 	tx, ok := m.transactions[txID]
 	if !ok {
-		return nil, fmt.Errorf("transaction ID %d not found", txID)
+		return nil, fmt.Errorf("transaction ID %d not found: %w", txID, repository.ErrNotFound)
 	}
 	return tx, nil
 }

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -215,6 +215,9 @@ func (ts *TransactionService) DeleteTransaction(ctx context.Context, txID int64)
 
 	tx, err := ts.txRepo.GetTransactionByID(ctx, txID)
 	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return fmt.Errorf("transaction #%d: %w", txID, ErrNotFound)
+		}
 		return fmt.Errorf("failed to get transaction: %w", err)
 	}
 

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -242,7 +242,10 @@ func (ts *TransactionService) UpdateTransactionStatus(ctx context.Context, txID 
 
 	oldTx, err := ts.txRepo.GetTransactionByID(ctx, txID)
 	if err != nil {
-		return fmt.Errorf("transaction not found: %w", err)
+		if errors.Is(err, repository.ErrNotFound) {
+			return fmt.Errorf("transaction #%d: %w", txID, ErrNotFound)
+		}
+		return fmt.Errorf("failed to get transaction: %w", err)
 	}
 
 	if oldTx.Status == model.StatusReconciled {

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -268,7 +268,10 @@ func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, inp
 
 	oldTx, err := ts.txRepo.GetTransactionByID(ctx, input.ID)
 	if err != nil {
-		return fmt.Errorf("transaction not found: %w", err)
+		if errors.Is(err, repository.ErrNotFound) {
+			return fmt.Errorf("transaction #%d: %w", input.ID, ErrNotFound)
+		}
+		return fmt.Errorf("failed to get transaction: %w", err)
 	}
 
 	if oldTx.Status == model.StatusReconciled {

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -432,10 +432,11 @@ func TestDeleteTransaction(t *testing.T) {
 		assert.True(t, errors.Is(err, ErrNotEditable), "expected ErrNotEditable, got: %v", err)
 	})
 
-	t.Run("non-existent transaction returns error", func(t *testing.T) {
+	t.Run("non-existent transaction returns ErrNotFound", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
 		err := svc.DeleteTransaction(context.Background(), 999)
 		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotFound), "expected ErrNotFound, got: %v", err)
 	})
 
 	t.Run("reconciled transaction rejected", func(t *testing.T) {

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -522,10 +522,11 @@ func TestUpdateTransactionStatus(t *testing.T) {
 		assert.True(t, errors.Is(err, ErrNotEditable), "expected ErrNotEditable, got: %v", err)
 	})
 
-	t.Run("non-existent transaction returns error", func(t *testing.T) {
+	t.Run("non-existent transaction returns ErrNotFound", func(t *testing.T) {
 		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
 		err := svc.UpdateTransactionStatus(context.Background(), 999, model.StatusCleared)
 		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotFound), "expected ErrNotFound, got: %v", err)
 	})
 }
 

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -597,11 +597,18 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		assert.Equal(t, "status", ve.Field)
 	})
 
-	t.Run("non-existent transaction returns error", func(t *testing.T) {
-		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 999, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense,
-			Splits: []model.SplitDetail{{AccountID: 1, Amount: 0}, {AccountID: 2, Amount: 0}}})
+	t.Run("non-existent transaction returns ErrNotFound", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{
+			ID:     999,
+			Status: model.StatusPending,
+			Splits: []model.SplitDetail{{AccountID: 1, Amount: 100}, {AccountID: 2, Amount: -100}},
+		})
 		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotFound), "expected ErrNotFound, got: %v", err)
 	})
 
 	t.Run("reconciled transaction rejected", func(t *testing.T) {

--- a/internal/service/transaction_service.go
+++ b/internal/service/transaction_service.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hance08/kea/internal/config"
@@ -52,6 +53,9 @@ func (ts *TransactionService) GetTransactionRule(txType model.TransactionType) (
 func (ts *TransactionService) GetTransactionByID(ctx context.Context, txID int64) (*model.TransactionDetail, error) {
 	tx, err := ts.txRepo.GetTransactionByID(ctx, txID)
 	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("transaction #%d: %w", txID, ErrNotFound)
+		}
 		return nil, fmt.Errorf("failed to retrieve transaction %d: %w", txID, err)
 	}
 

--- a/internal/service/transaction_service_test.go
+++ b/internal/service/transaction_service_test.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/hance08/kea/internal/repository"
 )
 
 func TestGetTransactionByID_RepoError_WrapsWithContext(t *testing.T) {
@@ -29,5 +31,26 @@ func TestGetTransactionByID_RepoError_WrapsWithContext(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "failed to retrieve transaction") {
 		t.Errorf("expected context message in error, got: %s", err.Error())
+	}
+}
+
+func TestGetTransactionByID_NotFound_WrapsServiceErrNotFound(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	// Simulate repository.ErrNotFound
+	txRepo.getByIDErr[999] = repository.ErrNotFound
+
+	_, err := svc.GetTransactionByID(context.Background(), 999)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected error to wrap service.ErrNotFound, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "transaction") {
+		t.Errorf("expected 'transaction' in error message, got: %s", err.Error())
 	}
 }


### PR DESCRIPTION
## Summary

Closes #106

- Fixed transaction mock `GetTransactionByID` to wrap `repository.ErrNotFound` (matching account mock pattern)
- Added `repository.ErrNotFound` → `service.ErrNotFound` translation in 5 service methods: `GetTransactionByID`, `DeleteTransaction`, `UpdateTransactionStatus`, `UpdateTransactionComplete`, `DeleteAccountByName`
- Added/updated tests asserting `errors.Is(err, service.ErrNotFound)` for all fixed methods

## Test Plan

- [x] All existing tests pass with no regressions
- [x] New tests verify `service.ErrNotFound` is returned for not-found lookups in each fixed method
- [x] Generic repo errors (non-404) still wrap with context message, not `ErrNotFound`
- [x] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)