### PR TITLE
feat: extract transaction list assembly to service layer (#107)

### DIFF
--- a/cmd/transaction/list.go
+++ b/cmd/transaction/list.go
@@ -6,7 +6,6 @@ package transaction
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/service"
@@ -22,11 +21,8 @@ type ListView interface {
 type ListProvider interface {
 	GetTransactionHistory(ctx context.Context, accountName string, limit int) ([]*model.Transaction, error)
 	GetRecentTransactions(ctx context.Context, limit int) ([]*model.Transaction, error)
-	GetTransactionByID(ctx context.Context, txID int64) (*model.TransactionDetail, error)
 	GetTransactionDetailsByIDs(ctx context.Context, txs []*model.Transaction) (map[int64]*model.TransactionDetail, error)
-	GetDisplayAccount(ctx context.Context, splits []model.SplitDetail, txType string) (string, error)
-	GetDisplayOffsetAccount(ctx context.Context, splits []model.SplitDetail, txType string, primaryAccount string) (string, error)
-	GetDisplayAmount(splits []model.SplitDetail) (int64, string)
+	BuildTransactionListItems(ctx context.Context, txs []*model.Transaction, details map[int64]*model.TransactionDetail) []model.TransactionListItem
 }
 
 type listFlags struct {
@@ -106,43 +102,22 @@ func (r *listRunner) buildViewItems(ctx context.Context, transactions []*model.T
 		return nil
 	}
 
-	viewItems := make([]views.TransactionListItem, 0, len(transactions))
-	for _, tx := range transactions {
-		viewItems = append(viewItems, r.convertToViewItem(ctx, tx, detailsMap[tx.ID]))
+	items := r.svc.BuildTransactionListItems(ctx, transactions, detailsMap)
+
+	viewItems := make([]views.TransactionListItem, len(items))
+	for i, item := range items {
+		amountFloat := float64(item.Amount) / 100.0
+		viewItems[i] = views.TransactionListItem{
+			ID:          item.ID,
+			Date:        item.Date,
+			Type:        item.Type,
+			Account:     item.Account,
+			Offset:      item.OffsetAccount,
+			Description: item.Description,
+			Amount:      fmt.Sprintf("%.2f", amountFloat),
+			Currency:    item.Currency,
+			Status:      item.Status,
+		}
 	}
 	return viewItems
-}
-
-func (r *listRunner) convertToViewItem(ctx context.Context, tx *model.Transaction, detail *model.TransactionDetail) views.TransactionListItem {
-	txType := string(detail.Type)
-
-	accountName, err := r.svc.GetDisplayAccount(ctx, detail.Splits, txType)
-	if err != nil {
-		accountName = "-"
-	}
-
-	offsetAccount, err := r.svc.GetDisplayOffsetAccount(ctx, detail.Splits, txType, accountName)
-	if err != nil {
-		offsetAccount = "-"
-	}
-
-	amountCents, currency := r.svc.GetDisplayAmount(detail.Splits)
-	amountFloat := float64(amountCents) / 100.0
-	amountStr := fmt.Sprintf("%.2f", amountFloat)
-
-	date := time.Unix(tx.Timestamp, 0).Format("2006-01-02")
-
-	status := tx.Status.String()
-
-	return views.TransactionListItem{
-		ID:          tx.ID,
-		Date:        date,
-		Type:        txType,
-		Account:     accountName,
-		Offset:      offsetAccount,
-		Description: tx.Description,
-		Amount:      amountStr,
-		Currency:    currency,
-		Status:      status,
-	}
 }

--- a/internal/model/transaction_list_item.go
+++ b/internal/model/transaction_list_item.go
@@ -3,6 +3,7 @@
 
 package model
 
+// TransactionListItem is a display-ready projection of a transaction for list views.
 type TransactionListItem struct {
 	ID            int64
 	Date          string

--- a/internal/model/transaction_list_item.go
+++ b/internal/model/transaction_list_item.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package model
+
+type TransactionListItem struct {
+	ID            int64
+	Date          string
+	Type          string
+	Account       string
+	OffsetAccount string
+	Description   string
+	Amount        int64
+	Currency      string
+	Status        string
+}

--- a/internal/service/transaction_classifier.go
+++ b/internal/service/transaction_classifier.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"time"
 
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/utils"
@@ -252,6 +253,43 @@ func (ts *TransactionService) GetDisplayOffsetAccount(ctx context.Context, split
 	}
 
 	return "(multiple)", nil
+}
+
+func (ts *TransactionService) BuildTransactionListItems(ctx context.Context, txs []*model.Transaction, details map[int64]*model.TransactionDetail) []model.TransactionListItem {
+	items := make([]model.TransactionListItem, 0, len(txs))
+	for _, tx := range txs {
+		detail, ok := details[tx.ID]
+		if !ok {
+			continue
+		}
+
+		txType := string(detail.Type)
+
+		accountName, err := ts.GetDisplayAccount(ctx, detail.Splits, txType)
+		if err != nil {
+			accountName = "-"
+		}
+
+		offsetAccount, err := ts.GetDisplayOffsetAccount(ctx, detail.Splits, txType, accountName)
+		if err != nil {
+			offsetAccount = "-"
+		}
+
+		amountCents, currency := ts.GetDisplayAmount(detail.Splits)
+
+		items = append(items, model.TransactionListItem{
+			ID:            tx.ID,
+			Date:          time.Unix(tx.Timestamp, 0).UTC().Format(model.DateFormat),
+			Type:          txType,
+			Account:       accountName,
+			OffsetAccount: offsetAccount,
+			Description:   tx.Description,
+			Amount:        amountCents,
+			Currency:      currency,
+			Status:        tx.Status.String(),
+		})
+	}
+	return items
 }
 
 func (ts *TransactionService) GetAllowedAccounts(txType model.TransactionType, currentAccountType model.AccountType, allAccounts []*model.Account) []*model.Account {

--- a/internal/service/transaction_classifier.go
+++ b/internal/service/transaction_classifier.go
@@ -255,6 +255,7 @@ func (ts *TransactionService) GetDisplayOffsetAccount(ctx context.Context, split
 	return "(multiple)", nil
 }
 
+// BuildTransactionListItems assembles display-ready list items from transactions and their details.
 func (ts *TransactionService) BuildTransactionListItems(ctx context.Context, txs []*model.Transaction, details map[int64]*model.TransactionDetail) []model.TransactionListItem {
 	items := make([]model.TransactionListItem, 0, len(txs))
 	for _, tx := range txs {
@@ -279,7 +280,7 @@ func (ts *TransactionService) BuildTransactionListItems(ctx context.Context, txs
 
 		items = append(items, model.TransactionListItem{
 			ID:            tx.ID,
-			Date:          time.Unix(tx.Timestamp, 0).UTC().Format(model.DateFormat),
+			Date:          time.Unix(tx.Timestamp, 0).Format(model.DateFormat),
 			Type:          txType,
 			Account:       accountName,
 			OffsetAccount: offsetAccount,

--- a/internal/service/transaction_classifier_test.go
+++ b/internal/service/transaction_classifier_test.go
@@ -562,3 +562,93 @@ func TestValidateSplitsMatchType(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildTransactionListItems(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Expenses:Food", Type: model.AccountTypeExpense})
+	accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Bank", Type: model.AccountTypeAsset})
+
+	txs := []*model.Transaction{
+		{ID: 10, Timestamp: 1700000000, Description: "Lunch", Status: model.StatusCleared, Type: model.TxTypeExpense},
+	}
+	details := map[int64]*model.TransactionDetail{
+		10: {
+			ID: 10, Timestamp: 1700000000, Description: "Lunch",
+			Status: model.StatusCleared, Type: model.TxTypeExpense,
+			Splits: []model.SplitDetail{
+				split("Expenses:Food", model.AccountTypeExpense, 1500),
+				split("Assets:Bank", model.AccountTypeAsset, -1500),
+			},
+		},
+	}
+
+	items := svc.BuildTransactionListItems(context.Background(), txs, details)
+
+	require.Len(t, items, 1)
+	item := items[0]
+	assert.Equal(t, int64(10), item.ID)
+	assert.Equal(t, "2023-11-14", item.Date)
+	assert.Equal(t, "Expense", item.Type)
+	assert.Equal(t, "Expenses:Food", item.Account)
+	assert.Equal(t, "Assets:Bank", item.OffsetAccount)
+	assert.Equal(t, "Lunch", item.Description)
+	assert.Equal(t, int64(1500), item.Amount)
+	assert.Equal(t, "USD", item.Currency)
+	assert.Equal(t, "Cleared", item.Status)
+}
+
+func TestBuildTransactionListItems_SkipsMissingDetail(t *testing.T) {
+	svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
+
+	txs := []*model.Transaction{
+		{ID: 10, Timestamp: 1700000000, Description: "Lunch", Status: model.StatusCleared, Type: model.TxTypeExpense},
+	}
+	details := map[int64]*model.TransactionDetail{}
+
+	items := svc.BuildTransactionListItems(context.Background(), txs, details)
+	assert.Empty(t, items)
+}
+
+func TestBuildTransactionListItems_MultipleTransactions(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Expenses:Food", Type: model.AccountTypeExpense})
+	accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Bank", Type: model.AccountTypeAsset})
+	accRepo.addAccount(&model.Account{ID: 3, Name: "Revenue:Salary", Type: model.AccountTypeRevenue})
+
+	txs := []*model.Transaction{
+		{ID: 10, Timestamp: 1700000000, Description: "Lunch", Status: model.StatusCleared, Type: model.TxTypeExpense},
+		{ID: 11, Timestamp: 1700086400, Description: "Paycheck", Status: model.StatusPending, Type: model.TxTypeIncome},
+	}
+	details := map[int64]*model.TransactionDetail{
+		10: {
+			ID: 10, Timestamp: 1700000000, Description: "Lunch",
+			Status: model.StatusCleared, Type: model.TxTypeExpense,
+			Splits: []model.SplitDetail{
+				split("Expenses:Food", model.AccountTypeExpense, 1500),
+				split("Assets:Bank", model.AccountTypeAsset, -1500),
+			},
+		},
+		11: {
+			ID: 11, Timestamp: 1700086400, Description: "Paycheck",
+			Status: model.StatusPending, Type: model.TxTypeIncome,
+			Splits: []model.SplitDetail{
+				split("Revenue:Salary", model.AccountTypeRevenue, -500000),
+				split("Assets:Bank", model.AccountTypeAsset, 500000),
+			},
+		},
+	}
+
+	items := svc.BuildTransactionListItems(context.Background(), txs, details)
+
+	require.Len(t, items, 2)
+	assert.Equal(t, "Expense", items[0].Type)
+	assert.Equal(t, "Income", items[1].Type)
+	assert.Equal(t, "Revenue:Salary", items[1].Account)
+	assert.Equal(t, "Assets:Bank", items[1].OffsetAccount)
+}

--- a/internal/service/transaction_classifier_test.go
+++ b/internal/service/transaction_classifier_test.go
@@ -6,6 +6,7 @@ package service
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/hance08/kea/internal/model"
 	"github.com/stretchr/testify/assert"
@@ -590,7 +591,7 @@ func TestBuildTransactionListItems(t *testing.T) {
 	require.Len(t, items, 1)
 	item := items[0]
 	assert.Equal(t, int64(10), item.ID)
-	assert.Equal(t, "2023-11-14", item.Date)
+	assert.Equal(t, time.Unix(1700000000, 0).Format(model.DateFormat), item.Date)
 	assert.Equal(t, "Expense", item.Type)
 	assert.Equal(t, "Expenses:Food", item.Account)
 	assert.Equal(t, "Assets:Bank", item.OffsetAccount)


### PR DESCRIPTION
## Summary
- Added `model.TransactionListItem` struct with raw values (`Amount` as `int64` cents) for use by any consumer
- Added `BuildTransactionListItems` method to `TransactionService` that orchestrates display account resolution, offset account resolution, and display amount extraction
- Updated `cmd/transaction/list.go` to call the new service method, removing 4 methods from `ListProvider` interface and deleting the `convertToViewItem` method

Closes #107

## Test plan
- [x] 3 new unit tests for `BuildTransactionListItems` (single tx, missing detail, multiple transactions)
- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean
- [x] Manual: `kea transaction list` output matches previous behavior
- [x] Manual: `kea transaction list --json` output matches previous behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)