### PR TITLE
fix: move hidden-account filtering to service layer (#108)

### DIFF
--- a/cmd/account/list.go
+++ b/cmd/account/list.go
@@ -20,8 +20,7 @@ type listFlags struct {
 }
 
 type AccountListProvider interface {
-	GetAccountsByType(ctx context.Context, accType model.AccountType) ([]*model.Account, error)
-	GetAllAccounts(ctx context.Context) ([]*model.Account, error)
+	ListAccounts(ctx context.Context, opts service.ListAccountsOptions) ([]*model.Account, error)
 	GetAccountBalance(ctx context.Context, id int64) (int64, error)
 	GetAccountBalanceFormatted(ctx context.Context, id int64) (string, error)
 }
@@ -57,22 +56,17 @@ You can filter by account type or show hidden accounts.`,
 }
 
 func (r *listRunner) Run(ctx context.Context) error {
-
-	var accounts []*model.Account
-	var err error
-
+	opts := service.ListAccountsOptions{
+		ShowHidden: r.flags.ShowHidden,
+	}
 	if r.flags.Type != "" {
-		accounts, err = r.svc.GetAccountsByType(ctx, model.AccountType(r.flags.Type))
-	} else {
-		accounts, err = r.svc.GetAllAccounts(ctx)
+		at := model.AccountType(r.flags.Type)
+		opts.Type = &at
 	}
 
+	accounts, err := r.svc.ListAccounts(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("failed to get accounts: %w", err)
-	}
-
-	if !r.flags.ShowHidden {
-		accounts = r.filterHiddenAccounts(accounts)
 	}
 
 	if r.flags.JSON {
@@ -89,14 +83,4 @@ func (r *listRunner) Run(ctx context.Context) error {
 	return views.NewAccountListView().Render(accounts, func(id int64) (string, error) {
 		return r.svc.GetAccountBalanceFormatted(ctx, id)
 	})
-}
-
-func (r *listRunner) filterHiddenAccounts(accounts []*model.Account) []*model.Account {
-	var filtered []*model.Account
-	for _, acc := range accounts {
-		if !acc.IsHidden {
-			filtered = append(filtered, acc)
-		}
-	}
-	return filtered
 }

--- a/internal/service/account_service.go
+++ b/internal/service/account_service.go
@@ -25,6 +25,37 @@ func NewAccountService(repo repository.AccountRepository, cfg *config.Config, tm
 	return &AccountService{repo: repo, config: cfg, tm: tm}
 }
 
+type ListAccountsOptions struct {
+	Type       *model.AccountType
+	ShowHidden bool
+}
+
+func (as *AccountService) ListAccounts(ctx context.Context, opts ListAccountsOptions) ([]*model.Account, error) {
+	var accounts []*model.Account
+	var err error
+
+	if opts.Type != nil {
+		accounts, err = as.repo.GetAccountsByType(ctx, *opts.Type)
+	} else {
+		accounts, err = as.repo.GetAllAccounts(ctx)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if !opts.ShowHidden {
+		filtered := make([]*model.Account, 0, len(accounts))
+		for _, acc := range accounts {
+			if !acc.IsHidden {
+				filtered = append(filtered, acc)
+			}
+		}
+		accounts = filtered
+	}
+
+	return accounts, nil
+}
+
 func (as *AccountService) GetAllAccounts(ctx context.Context) ([]*model.Account, error) {
 	return as.repo.GetAllAccounts(ctx)
 }

--- a/internal/service/account_service_test.go
+++ b/internal/service/account_service_test.go
@@ -53,3 +53,58 @@ func TestGetAccountByID(t *testing.T) {
 		assert.Equal(t, dbErr, err)
 	})
 }
+
+func TestListAccounts(t *testing.T) {
+	mkAccRepo := func() *mockAccountRepo {
+		r := newMockAccountRepo()
+		r.addAccount(&model.Account{ID: 1, Name: "Assets:Cash", Type: model.AccountTypeAsset, Currency: "USD"})
+		r.addAccount(&model.Account{ID: 2, Name: "Assets:Hidden", Type: model.AccountTypeAsset, Currency: "USD", IsHidden: true})
+		r.addAccount(&model.Account{ID: 3, Name: "Expenses:Food", Type: model.AccountTypeExpense, Currency: "USD"})
+		return r
+	}
+
+	t.Run("hides hidden accounts by default", func(t *testing.T) {
+		svc := newTestAccountService(mkAccRepo(), newMockTransactionRepo())
+
+		accounts, err := svc.ListAccounts(context.Background(), ListAccountsOptions{})
+
+		require.NoError(t, err)
+		assert.Len(t, accounts, 2)
+		for _, acc := range accounts {
+			assert.False(t, acc.IsHidden)
+		}
+	})
+
+	t.Run("shows hidden accounts when ShowHidden is true", func(t *testing.T) {
+		svc := newTestAccountService(mkAccRepo(), newMockTransactionRepo())
+
+		accounts, err := svc.ListAccounts(context.Background(), ListAccountsOptions{ShowHidden: true})
+
+		require.NoError(t, err)
+		assert.Len(t, accounts, 3)
+	})
+
+	t.Run("filters by type", func(t *testing.T) {
+		svc := newTestAccountService(mkAccRepo(), newMockTransactionRepo())
+		at := model.AccountTypeAsset
+
+		accounts, err := svc.ListAccounts(context.Background(), ListAccountsOptions{Type: &at})
+
+		require.NoError(t, err)
+		assert.Len(t, accounts, 1)
+		assert.Equal(t, "Assets:Cash", accounts[0].Name)
+	})
+
+	t.Run("filters by type with ShowHidden", func(t *testing.T) {
+		svc := newTestAccountService(mkAccRepo(), newMockTransactionRepo())
+		at := model.AccountTypeAsset
+
+		accounts, err := svc.ListAccounts(context.Background(), ListAccountsOptions{
+			Type:       &at,
+			ShowHidden: true,
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, accounts, 2)
+	})
+}


### PR DESCRIPTION
## Summary
- Added `ListAccountsOptions` struct and `ListAccounts` method to `AccountService` that handles both type filtering and hidden-account filtering
- Updated `cmd/account/list.go` to use the new service method, removing the duplicated `filterHiddenAccounts` logic
- Any future consumer (e.g. web API) now gets consistent hidden-account filtering from the service layer

Closes #108

## Test Plan
- [x] 4 new unit tests covering: default hidden filtering, ShowHidden override, type filter, combined type + ShowHidden
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)