### PR TITLE
fix: increase SQLite connection pool to leverage WAL concurrency

### DIFF
--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -37,7 +37,7 @@ func NewStore(dbPath string, migrationsFS fs.FS) (*Store, error) {
 		return nil, fmt.Errorf("can not create database directory %s: %w", dbDir, err)
 	}
 
-	db, err := sql.Open("sqlite3", dbPath+"?_foreign_keys=on&_journal_mode=WAL&_busy_timeout=5000")
+	db, err := sql.Open("sqlite3", dbPath+"?_foreign_keys=on&_journal_mode=WAL&_busy_timeout=5000&_txlock=immediate")
 	success := false
 	defer func() {
 		if !success {
@@ -49,7 +49,8 @@ func NewStore(dbPath string, migrationsFS fs.FS) (*Store, error) {
 		return nil, fmt.Errorf("can not open database : %w", err)
 	}
 
-	db.SetMaxOpenConns(1)
+	db.SetMaxOpenConns(4)
+	db.SetMaxIdleConns(2)
 
 	if err = db.Ping(); err != nil {
 		return nil, fmt.Errorf("can not connect with database : %w", err)

--- a/internal/store/sqlite_pragma_test.go
+++ b/internal/store/sqlite_pragma_test.go
@@ -11,6 +11,50 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewStore_SetsMaxOpenConns(t *testing.T) {
+	s := setupTestDB(t)
+	assert.Equal(t, 4, s.DB().Stats().MaxOpenConnections)
+}
+
+func TestNewStore_UsesTxLockImmediate(t *testing.T) {
+	s := setupTestDB(t)
+	ctx := context.Background()
+
+	db := s.DB()
+
+	// Acquire two dedicated connections from the pool so we can control each independently.
+	conn1, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn1.Close()
+
+	conn2, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn2.Close()
+
+	// Set busy_timeout to 0 on each pinned connection so BeginTx fails immediately.
+	_, err = conn1.ExecContext(ctx, "PRAGMA busy_timeout = 0")
+	require.NoError(t, err)
+	_, err = conn2.ExecContext(ctx, "PRAGMA busy_timeout = 0")
+	require.NoError(t, err)
+
+	// Start a write transaction on connection 1
+	tx1, err := conn1.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	_, err = tx1.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS _txlock_test (id INTEGER)")
+	require.NoError(t, err)
+
+	// With _txlock=immediate, a second write transaction should fail
+	// immediately (SQLITE_BUSY) rather than succeeding and failing later.
+	tx2, err := conn2.BeginTx(ctx, nil)
+	if err == nil {
+		_ = tx2.Rollback()
+	}
+	// The second BEGIN IMMEDIATE should return busy error since tx1 holds the write lock.
+	require.Error(t, err, "second immediate transaction should fail while first holds write lock")
+
+	_ = tx1.Rollback()
+}
+
 func TestNewStore_EnablesWALMode(t *testing.T) {
 	s := setupTestDB(t)
 


### PR DESCRIPTION
## Summary
- Increase `MaxOpenConns` from 1 to 4 and set `MaxIdleConns` to 2, allowing concurrent readers under WAL mode
- Add `_txlock=immediate` to the SQLite DSN so write transactions acquire the write lock upfront (fail-fast) instead of mid-transaction
- Add tests verifying pool size configuration and immediate transaction locking behavior

Closes #109

## Test plan
- [x] `TestNewStore_SetsMaxOpenConns` — verifies pool is configured with 4 max connections
- [x] `TestNewStore_UsesTxLockImmediate` — verifies second write transaction fails immediately with SQLITE_BUSY while first holds the lock
- [x] Existing pragma tests (`TestNewStore_EnablesWALMode`, `TestNewStore_SetsBusyTimeout`) still pass
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)