### PR TITLE
refactor: deduplicate determineMode into model.ParseTransactionTypeLabel (#112)

### DIFF
--- a/cmd/add_actions.go
+++ b/cmd/add_actions.go
@@ -83,7 +83,7 @@ func (r *addRunner) runInteractive(ctx context.Context) (addTransactionInput, er
 		return addTransactionInput{}, err
 	}
 
-	mode := r.determineMode(rawType)
+	mode := model.ParseTransactionTypeLabel(rawType)
 
 	// Step 2: Get description (optional)
 	description, err := prompts.PromptDescription("Transaction description (optional):", false)
@@ -188,16 +188,6 @@ func (r *addRunner) validateAccountSelectable(ctx context.Context, accountName s
 	return nil
 }
 
-func (r *addRunner) determineMode(rawInput string) model.TransactionType {
-	lower := strings.ToLower(rawInput)
-	if strings.Contains(lower, "expense") {
-		return model.TxTypeExpense
-	}
-	if strings.Contains(lower, "income") {
-		return model.TxTypeIncome
-	}
-	return model.TxTypeTransfer
-}
 
 var modeUIConfigs = map[model.TransactionType]struct{ Src, Dst string }{
 	model.TxTypeExpense:  {"Payment Source:", "Expense Type:"},

--- a/cmd/transaction/edit_actions.go
+++ b/cmd/transaction/edit_actions.go
@@ -6,7 +6,6 @@ package transaction
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/utils"
@@ -261,7 +260,7 @@ func (r *editRunner) actionEditType(ctx context.Context, detail *model.Transacti
 		return err
 	}
 
-	newType := r.determineMode(rawType)
+	newType := model.ParseTransactionTypeLabel(rawType)
 
 	if err := r.txSvc.ValidateSplitsMatchType(ctx, newType, detail.Splits); err != nil {
 		r.view.ShowWarning(fmt.Sprintf("Cannot change type to %s: %s", newType, err.Error()))
@@ -274,16 +273,6 @@ func (r *editRunner) actionEditType(ctx context.Context, detail *model.Transacti
 	return nil
 }
 
-func (r *editRunner) determineMode(rawInput string) model.TransactionType {
-	lower := strings.ToLower(rawInput)
-	if strings.Contains(lower, "expense") {
-		return model.TxTypeExpense
-	}
-	if strings.Contains(lower, "income") {
-		return model.TxTypeIncome
-	}
-	return model.TxTypeTransfer
-}
 
 func (r *editRunner) actionSave(ctx context.Context, detail *model.TransactionDetail) error {
 	// Validate via Service

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -162,6 +162,17 @@ func ParseTransactionType(s string) (TransactionType, error) {
 	}
 }
 
+func ParseTransactionTypeLabel(s string) TransactionType {
+	lower := strings.ToLower(s)
+	if strings.Contains(lower, "expense") {
+		return TxTypeExpense
+	}
+	if strings.Contains(lower, "income") {
+		return TxTypeIncome
+	}
+	return TxTypeTransfer
+}
+
 func ParseTransactionStatus(s string) TransactionStatus {
 	if strings.ToLower(s) == "pending" {
 		return StatusPending

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -55,6 +55,30 @@ func TestParseTransactionType(t *testing.T) {
 	}
 }
 
+func TestParseTransactionTypeLabel(t *testing.T) {
+	tests := []struct {
+		input string
+		want  TransactionType
+	}{
+		{"Expense (pay a bill...)", TxTypeExpense},
+		{"expense", TxTypeExpense},
+		{"EXPENSE", TxTypeExpense},
+		{"Income (receive payment...)", TxTypeIncome},
+		{"income", TxTypeIncome},
+		{"Transfer (move between accounts)", TxTypeTransfer},
+		{"transfer", TxTypeTransfer},
+		{"something else", TxTypeTransfer},
+		{"", TxTypeTransfer},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := ParseTransactionTypeLabel(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestParseTransactionStatus(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
## Summary
- Extracted duplicated `determineMode` logic from `cmd/add_actions.go` and `cmd/transaction/edit_actions.go` into a single `ParseTransactionTypeLabel` function in `internal/model/types.go`
- Uses fuzzy substring matching to map TUI prompt labels (e.g. "Record Expense") to `model.TransactionType` values
- Existing `ParseTransactionType` (strict exact-match) remains unchanged

## Test plan
- [x] Added 9 test cases for `ParseTransactionTypeLabel` covering TUI labels, case variations, unknown input, and empty string
- [x] All existing model tests pass with no regressions
- [x] Full test suite (`go test ./...`) passes

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)