### PR TITLE
feat: registry file-watch with graceful Store swap (#119)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,7 +112,7 @@ func Execute(migrations fs.FS) {
 		cfg.Database.Path = activePath
 		cfg.ActiveLedger = registry.ActiveName()
 
-		application, cleanup, err := app.NewApp(cfg, migrations)
+		application, cleanup, err := app.NewApp(cfg, registry, migrations)
 		if err != nil {
 			pterm.Error.Println(err)
 			return 1

--- a/docs/superpowers/plans/2026-05-19-ledger-file-watch.md
+++ b/docs/superpowers/plans/2026-05-19-ledger-file-watch.md
@@ -1,0 +1,992 @@
+# Ledger File-Watch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable the Registry to watch `ledgers.yaml` for changes and notify subscribers so the Store can gracefully swap its DB connection — fixing the split-brain between CLI and long-lived processes.
+
+**Architecture:** Registry owns an fsnotify watcher on `ledgers.yaml` and fires `OnSwitch` callbacks when the active ledger changes. Store protects `db`/`rawDB` with a `sync.RWMutex` and exposes a `Swap` method. App wires the two together via a callback.
+
+**Tech Stack:** Go, `github.com/fsnotify/fsnotify`, `sync.RWMutex`, SQLite
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `internal/ledger/registry.go` | Add `mu`, `callbacks`, `watcher` fields; `OnSwitch`, `Watch`, `StopWatch`, `reload` methods |
+| `internal/ledger/registry_test.go` | Add watcher + callback tests |
+| `internal/store/sqlite.go` | Add `mu sync.RWMutex`; `Swap` method; read-lock in `ExecTx`, `Close`, `DB` |
+| `internal/store/export_test.go` | Update `QueryRowContext` to acquire read-lock |
+| `internal/store/sqlite_account.go` | Add read-lock to all 13 public methods |
+| `internal/store/sqlite_transaction.go` | Add read-lock to all 17 public methods |
+| `internal/store/sqlite_reconcile.go` | Add read-lock to all 5 public methods |
+| `internal/store/sqlite_swap_test.go` | New: swap + concurrency tests |
+| `internal/app/app.go` | Add `Registry` field; update `NewApp` signature; wire callback; update cleanup |
+| `cmd/root.go` | Pass `registry` to `NewApp` |
+| `go.mod` / `go.sum` | Add `github.com/fsnotify/fsnotify` |
+
+---
+
+### Task 1: Add fsnotify dependency
+
+**Files:**
+- Modify: `go.mod`
+
+- [ ] **Step 1: Add the dependency**
+
+Run:
+```bash
+go get github.com/fsnotify/fsnotify
+```
+
+- [ ] **Step 2: Tidy**
+
+Run:
+```bash
+go mod tidy
+```
+
+- [ ] **Step 3: Verify the project compiles**
+
+Run:
+```bash
+go build ./...
+```
+Expected: success, no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go.mod go.sum
+git commit -m "chore: add fsnotify dependency for ledger file-watch (#119)"
+```
+
+---
+
+### Task 2: Registry — OnSwitch, Watch, StopWatch
+
+**Files:**
+- Modify: `internal/ledger/registry.go`
+- Modify: `internal/ledger/registry_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these tests to `internal/ledger/registry_test.go`:
+
+```go
+func TestWatch_FiresOnSwitch(t *testing.T) {
+	dir := t.TempDir()
+	r, err := Load(dir)
+	require.NoError(t, err)
+	require.NoError(t, r.Add("work", "/tmp/work.db"))
+
+	var gotName, gotPath string
+	done := make(chan struct{})
+	r.OnSwitch(func(name, path string) {
+		gotName = name
+		gotPath = path
+		close(done)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = r.Watch(ctx)
+	}()
+
+	// Give the watcher time to start.
+	time.Sleep(200 * time.Millisecond)
+
+	// Simulate an external process switching the ledger.
+	r2, err := Load(dir)
+	require.NoError(t, err)
+	require.NoError(t, r2.Switch("work"))
+
+	select {
+	case <-done:
+		assert.Equal(t, "work", gotName)
+		assert.Equal(t, "/tmp/work.db", gotPath)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnSwitch callback")
+	}
+}
+
+func TestWatch_NoCallbackWhenActiveUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	r, err := Load(dir)
+	require.NoError(t, err)
+	require.NoError(t, r.Add("work", "/tmp/work.db"))
+
+	called := make(chan struct{}, 1)
+	r.OnSwitch(func(name, path string) {
+		called <- struct{}{}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = r.Watch(ctx)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Write the same active ledger — should NOT fire callback.
+	r2, err := Load(dir)
+	require.NoError(t, err)
+	require.NoError(t, r2.Switch("default"))
+
+	select {
+	case <-called:
+		t.Fatal("callback should not fire when active ledger is unchanged")
+	case <-time.After(500 * time.Millisecond):
+		// OK — no callback fired.
+	}
+}
+
+func TestWatch_StopWatchPreventsCallbacks(t *testing.T) {
+	dir := t.TempDir()
+	r, err := Load(dir)
+	require.NoError(t, err)
+	require.NoError(t, r.Add("work", "/tmp/work.db"))
+
+	called := make(chan struct{}, 1)
+	r.OnSwitch(func(name, path string) {
+		called <- struct{}{}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	watchDone := make(chan struct{})
+	go func() {
+		_ = r.Watch(ctx)
+		close(watchDone)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Stop the watcher.
+	r.StopWatch()
+	cancel()
+	<-watchDone
+
+	// Switch after stop — no callback should fire.
+	r2, err := Load(dir)
+	require.NoError(t, err)
+	require.NoError(t, r2.Switch("work"))
+
+	select {
+	case <-called:
+		t.Fatal("callback should not fire after StopWatch")
+	case <-time.After(500 * time.Millisecond):
+		// OK.
+	}
+}
+
+func TestWatch_DebouncesRapidWrites(t *testing.T) {
+	dir := t.TempDir()
+	r, err := Load(dir)
+	require.NoError(t, err)
+	require.NoError(t, r.Add("work", "/tmp/work.db"))
+	require.NoError(t, r.Add("personal", "/tmp/personal.db"))
+
+	var callCount int32
+	var lastName string
+	done := make(chan struct{}, 10)
+	r.OnSwitch(func(name, path string) {
+		atomic.AddInt32(&callCount, 1)
+		lastName = name
+		done <- struct{}{}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = r.Watch(ctx)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Rapid-fire switches: default → work → personal (within debounce window).
+	r2, err := Load(dir)
+	require.NoError(t, err)
+	require.NoError(t, r2.Switch("work"))
+	require.NoError(t, r2.Switch("personal"))
+
+	select {
+	case <-done:
+		// Wait a bit more to see if extra callbacks arrive.
+		time.Sleep(300 * time.Millisecond)
+		count := atomic.LoadInt32(&callCount)
+		assert.Equal(t, int32(1), count, "debounce should coalesce rapid writes into a single callback")
+		assert.Equal(t, "personal", lastName, "should reflect the final state")
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnSwitch callback")
+	}
+}
+```
+
+Add these imports to the test file's import block: `"context"`, `"sync/atomic"`, `"time"`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+go test ./internal/ledger/ -run "TestWatch" -v
+```
+Expected: compilation errors — `OnSwitch`, `Watch`, `StopWatch` not defined.
+
+- [ ] **Step 3: Implement Registry watcher**
+
+In `internal/ledger/registry.go`, add these imports: `"context"`, `"sync"`, `"time"`, `"github.com/fsnotify/fsnotify"`.
+
+Add new fields to the `Registry` struct:
+
+```go
+type Registry struct {
+	ActiveLedger   string           `yaml:"active"`
+	Ledgers        map[string]Entry `yaml:"ledgers"`
+	MigratedLegacy bool             `yaml:"-"`
+	filePath       string
+	mu             sync.Mutex
+	callbacks      []func(name string, path string)
+	watcher        *fsnotify.Watcher
+}
+```
+
+Add these methods after the existing methods:
+
+```go
+func (r *Registry) OnSwitch(fn func(name, path string)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.callbacks = append(r.callbacks, fn)
+}
+
+func (r *Registry) Watch(ctx context.Context) error {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("create watcher: %w", err)
+	}
+	r.mu.Lock()
+	r.watcher = w
+	r.mu.Unlock()
+
+	defer w.Close()
+
+	if err := w.Add(r.filePath); err != nil {
+		return fmt.Errorf("watch %s: %w", r.filePath, err)
+	}
+
+	var debounce *time.Timer
+	for {
+		select {
+		case <-ctx.Done():
+			if debounce != nil {
+				debounce.Stop()
+			}
+			return ctx.Err()
+		case event, ok := <-w.Events:
+			if !ok {
+				return nil
+			}
+			if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
+				continue
+			}
+			if debounce != nil {
+				debounce.Stop()
+			}
+			debounce = time.AfterFunc(100*time.Millisecond, func() {
+				r.reload()
+			})
+		case err, ok := <-w.Errors:
+			if !ok {
+				return nil
+			}
+			fmt.Fprintf(os.Stderr, "ledger watcher error: %v\n", err)
+		}
+	}
+}
+
+func (r *Registry) StopWatch() {
+	r.mu.Lock()
+	w := r.watcher
+	r.watcher = nil
+	r.mu.Unlock()
+	if w != nil {
+		_ = w.Close()
+	}
+}
+
+func (r *Registry) reload() {
+	data, err := os.ReadFile(r.filePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reload ledgers.yaml: %v\n", err)
+		return
+	}
+	var fresh Registry
+	if err := yaml.Unmarshal(data, &fresh); err != nil {
+		fmt.Fprintf(os.Stderr, "parse ledgers.yaml: %v\n", err)
+		return
+	}
+
+	prev := r.ActiveLedger
+	if fresh.ActiveLedger == prev {
+		return
+	}
+
+	r.ActiveLedger = fresh.ActiveLedger
+	r.Ledgers = fresh.Ledgers
+	if r.Ledgers == nil {
+		r.Ledgers = make(map[string]Entry)
+	}
+
+	entry, exists := r.Ledgers[r.ActiveLedger]
+	if !exists {
+		fmt.Fprintf(os.Stderr, "reloaded active ledger %q not found in registry\n", r.ActiveLedger)
+		return
+	}
+
+	r.mu.Lock()
+	cbs := make([]func(string, string), len(r.callbacks))
+	copy(cbs, r.callbacks)
+	r.mu.Unlock()
+
+	for _, fn := range cbs {
+		fn(r.ActiveLedger, entry.Path)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+go test ./internal/ledger/ -run "TestWatch" -v -count=1
+```
+Expected: all 4 `TestWatch_*` tests pass.
+
+- [ ] **Step 5: Run full ledger test suite to check for regressions**
+
+Run:
+```bash
+go test ./internal/ledger/ -v -count=1
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/ledger/registry.go internal/ledger/registry_test.go
+git commit -m "feat(ledger): add file-watch with OnSwitch callbacks (#119)
+
+Registry watches ledgers.yaml for changes and fires registered
+callbacks when the active ledger changes. Includes 100ms debounce."
+```
+
+---
+
+### Task 3: Store — Add RWMutex and read-lock to sqlite.go
+
+**Files:**
+- Modify: `internal/store/sqlite.go`
+- Modify: `internal/store/export_test.go`
+
+- [ ] **Step 1: Run existing store tests to confirm green baseline**
+
+Run:
+```bash
+go test ./internal/store/ -v -count=1
+```
+Expected: all tests pass.
+
+- [ ] **Step 2: Add `mu sync.RWMutex` to Store and read-lock `ExecTx`, `Close`, `DB`**
+
+In `internal/store/sqlite.go`, add `"sync"` to imports.
+
+Update `Store` struct:
+
+```go
+type Store struct {
+	db    DBTX
+	rawDB *sql.DB
+	mu    sync.RWMutex
+}
+```
+
+Update `ExecTx`:
+
+```go
+func (s *Store) ExecTx(ctx context.Context, fn func(repository.Repository) error) error {
+	s.mu.RLock()
+	db, ok := s.db.(*sql.DB)
+	s.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("store is already in a transaction")
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	txStore := &Store{db: tx}
+
+	err = fn(txStore)
+	if err != nil {
+		if rbErr := tx.Rollback(); rbErr != nil {
+			return fmt.Errorf("tx err: %v, rb err: %v", err, rbErr)
+		}
+		return err
+	}
+	return tx.Commit()
+}
+```
+
+Update `Close`:
+
+```go
+func (s *Store) Close() error {
+	s.mu.RLock()
+	db, ok := s.db.(*sql.DB)
+	s.mu.RUnlock()
+	if ok {
+		return db.Close()
+	}
+	return nil
+}
+```
+
+Update `DB`:
+
+```go
+func (s *Store) DB() *sql.DB {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.rawDB
+}
+```
+
+Update `export_test.go` — the `QueryRowContext` helper also accesses `s.db`:
+
+```go
+func (s *Store) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.db.QueryRowContext(ctx, query, args...)
+}
+```
+
+- [ ] **Step 3: Run store tests to verify nothing broke**
+
+Run:
+```bash
+go test ./internal/store/ -v -count=1
+```
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/store/sqlite.go internal/store/export_test.go
+git commit -m "refactor(store): add RWMutex to Store for safe DB swap (#119)
+
+Read-lock ExecTx, Close, DB, and QueryRowContext (export_test).
+Prepares for Swap method and per-method read-locks."
+```
+
+---
+
+### Task 4: Store — Add read-lock to sqlite_account.go methods
+
+**Files:**
+- Modify: `internal/store/sqlite_account.go`
+
+- [ ] **Step 1: Add read-lock to every method that accesses `s.db` or `s.rawDB`**
+
+For each method in `sqlite_account.go`, add `s.mu.RLock()` and `defer s.mu.RUnlock()` as the first two lines of the method body. The methods are:
+
+1. `CreateAccount` — first line of method body
+2. `GetAllAccounts` — first line of method body
+3. `GetAccountByName` — first line of method body
+4. `GetAccountByID` — first line of method body
+5. `AccountExists` — first line of method body
+6. `GetAllAccountBalances` — first line of method body
+7. `HasChildAccounts` — first line of method body
+8. `GetAccountsByType` — first line of method body
+9. `GetAccountBalance` — first line of method body
+10. `scanAccounts` — first line of method body
+11. `AccountHasTransactions` — first line of method body
+12. `DeleteAccount` — first line of method body
+13. `UpdateAccountMetadata` — first line of method body
+
+For `RenameAccount`, which uses `s.rawDB` directly:
+
+```go
+func (s *Store) RenameAccount(ctx context.Context, oldName, newName string) error {
+	s.mu.RLock()
+	rawDB := s.rawDB
+	s.mu.RUnlock()
+	if rawDB == nil {
+		return fmt.Errorf("store is already in a transaction")
+	}
+
+	tx, err := rawDB.BeginTx(ctx, nil)
+	// ... rest unchanged ...
+}
+```
+
+- [ ] **Step 2: Run account store tests**
+
+Run:
+```bash
+go test ./internal/store/ -run "Account" -v -count=1
+```
+Expected: all account tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/store/sqlite_account.go
+git commit -m "refactor(store): add read-lock to account query methods (#119)"
+```
+
+---
+
+### Task 5: Store — Add read-lock to sqlite_transaction.go methods
+
+**Files:**
+- Modify: `internal/store/sqlite_transaction.go`
+
+- [ ] **Step 1: Add read-lock to every method that accesses `s.db`**
+
+For each method in `sqlite_transaction.go`, add `s.mu.RLock()` and `defer s.mu.RUnlock()` as the first two lines of the method body. The methods are:
+
+1. `CreateTransactionWithSplits`
+2. `GetTransactionByID`
+3. `GetTransactionsByAccount`
+4. `GetTransactionsByDateRange`
+5. `GetAllTransactions`
+6. `UpdateTransactionStatus`
+7. `DeleteTransaction`
+8. `UpdateTransactionBasic`
+9. `UpdateSplit`
+10. `DeleteSplit`
+11. `CreateSplit`
+12. `GetSplitsByTransaction`
+13. `GetSplitsWithAccountsByDateRange`
+14. `GetSplitsWithAccountsByTransaction`
+15. `GetSplitsWithAccountsByTransactionIDs`
+16. `ListTransactions`
+17. `ListTransactionsByAccount`
+18. `scanTransactions`
+
+- [ ] **Step 2: Run transaction store tests**
+
+Run:
+```bash
+go test ./internal/store/ -run "Transaction" -v -count=1
+```
+Expected: all transaction tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/store/sqlite_transaction.go
+git commit -m "refactor(store): add read-lock to transaction query methods (#119)"
+```
+
+---
+
+### Task 6: Store — Add read-lock to sqlite_reconcile.go methods
+
+**Files:**
+- Modify: `internal/store/sqlite_reconcile.go`
+
+- [ ] **Step 1: Add read-lock to every method that accesses `s.db`**
+
+For each method in `sqlite_reconcile.go`, add `s.mu.RLock()` and `defer s.mu.RUnlock()` as the first two lines of the method body. The methods are:
+
+1. `GetUnreconciledTransactionsByAccount`
+2. `MarkSplitsReconciledByAccount`
+3. `BulkUpdateTransactionStatus`
+4. `GetLastReconciledBalance`
+5. `SetLastReconciledBalance`
+
+- [ ] **Step 2: Run reconcile store tests**
+
+Run:
+```bash
+go test ./internal/store/ -run "Reconcil" -v -count=1
+```
+Expected: all reconcile tests pass.
+
+- [ ] **Step 3: Run full store test suite**
+
+Run:
+```bash
+go test ./internal/store/ -v -count=1
+```
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/store/sqlite_reconcile.go
+git commit -m "refactor(store): add read-lock to reconcile query methods (#119)"
+```
+
+---
+
+### Task 7: Store — Swap method
+
+**Files:**
+- Modify: `internal/store/sqlite.go`
+- Create: `internal/store/sqlite_swap_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/store/sqlite_swap_test.go`:
+
+```go
+package store_test
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/hance08/kea/internal/model"
+	"github.com/hance08/kea/internal/repository"
+	"github.com/hance08/kea/internal/store"
+	"github.com/hance08/kea/migrations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSwap_QueriesHitNewDB(t *testing.T) {
+	dir := t.TempDir()
+	dbA := filepath.Join(dir, "a.db")
+	dbB := filepath.Join(dir, "b.db")
+
+	s, err := store.NewStore(dbA, migrations.FS)
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	ctx := context.Background()
+
+	// Create an account in DB A.
+	err = s.ExecTx(ctx, func(repo repository.Repository) error {
+		_, err := repo.CreateAccount(ctx, "Assets:BankA", model.AccountTypeAsset, "USD", "", nil)
+		return err
+	})
+	require.NoError(t, err)
+
+	// Pre-create DB B with its own account.
+	sB, err := store.NewStore(dbB, migrations.FS)
+	require.NoError(t, err)
+	err = sB.ExecTx(ctx, func(repo repository.Repository) error {
+		_, err := repo.CreateAccount(ctx, "Assets:BankB", model.AccountTypeAsset, "USD", "", nil)
+		return err
+	})
+	require.NoError(t, err)
+	require.NoError(t, sB.Close())
+
+	// Swap to DB B.
+	err = s.Swap(dbB, migrations.FS)
+	require.NoError(t, err)
+
+	// After swap, BankA should not exist; BankB should.
+	_, err = s.GetAccountByName(ctx, "Assets:BankA")
+	assert.Error(t, err, "BankA should not exist in DB B")
+
+	acc, err := s.GetAccountByName(ctx, "Assets:BankB")
+	require.NoError(t, err)
+	assert.Equal(t, "Assets:BankB", acc.Name)
+}
+
+func TestSwap_FailedSwapKeepsOldConnection(t *testing.T) {
+	dir := t.TempDir()
+	dbA := filepath.Join(dir, "a.db")
+
+	s, err := store.NewStore(dbA, migrations.FS)
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	ctx := context.Background()
+
+	err = s.ExecTx(ctx, func(repo repository.Repository) error {
+		_, err := repo.CreateAccount(ctx, "Assets:BankA", model.AccountTypeAsset, "USD", "", nil)
+		return err
+	})
+	require.NoError(t, err)
+
+	// Swap to an invalid path — should fail.
+	err = s.Swap("/nonexistent/dir/bad.db", migrations.FS)
+	require.Error(t, err)
+
+	// Old connection should still work.
+	acc, err := s.GetAccountByName(ctx, "Assets:BankA")
+	require.NoError(t, err)
+	assert.Equal(t, "Assets:BankA", acc.Name)
+}
+
+func TestSwap_ConcurrentReads(t *testing.T) {
+	dir := t.TempDir()
+	dbA := filepath.Join(dir, "a.db")
+	dbB := filepath.Join(dir, "b.db")
+
+	s, err := store.NewStore(dbA, migrations.FS)
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	ctx := context.Background()
+
+	err = s.ExecTx(ctx, func(repo repository.Repository) error {
+		_, err := repo.CreateAccount(ctx, "Assets:BankA", model.AccountTypeAsset, "USD", "", nil)
+		return err
+	})
+	require.NoError(t, err)
+
+	// Pre-create DB B.
+	sB, err := store.NewStore(dbB, migrations.FS)
+	require.NoError(t, err)
+	err = sB.ExecTx(ctx, func(repo repository.Repository) error {
+		_, err := repo.CreateAccount(ctx, "Assets:BankB", model.AccountTypeAsset, "USD", "", nil)
+		return err
+	})
+	require.NoError(t, err)
+	require.NoError(t, sB.Close())
+
+	// Launch concurrent readers and a swap in the middle.
+	var wg sync.WaitGroup
+	errs := make(chan error, 20)
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := s.GetAllAccounts(ctx)
+			if err != nil {
+				errs <- err
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := s.Swap(dbB, migrations.FS); err != nil {
+			errs <- err
+		}
+	}()
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("concurrent operation failed: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+go test ./internal/store/ -run "TestSwap" -v -count=1
+```
+Expected: compilation error — `Swap` method not defined.
+
+- [ ] **Step 3: Implement the Swap method**
+
+Add this method to `internal/store/sqlite.go`, after `Close()`:
+
+```go
+func (s *Store) Swap(newPath string, migrationsFS fs.FS) error {
+	newStore, err := NewStore(newPath, migrationsFS)
+	if err != nil {
+		return fmt.Errorf("open new database: %w", err)
+	}
+
+	s.mu.Lock()
+	oldDB := s.rawDB
+	s.rawDB = newStore.rawDB
+	s.db = newStore.db
+	s.mu.Unlock()
+
+	if oldDB != nil {
+		_ = oldDB.Close()
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+go test ./internal/store/ -run "TestSwap" -v -count=1
+```
+Expected: all 3 `TestSwap_*` tests pass.
+
+- [ ] **Step 5: Run full store test suite**
+
+Run:
+```bash
+go test ./internal/store/ -v -count=1
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/store/sqlite.go internal/store/sqlite_swap_test.go
+git commit -m "feat(store): add Swap method for graceful DB reconnection (#119)
+
+Opens new connection first, swaps under write lock, then closes old
+connection. Failed swap leaves old connection intact."
+```
+
+---
+
+### Task 8: App wiring — NewApp signature + callback
+
+**Files:**
+- Modify: `internal/app/app.go`
+- Modify: `cmd/root.go`
+
+- [ ] **Step 1: Update App struct and NewApp signature**
+
+In `internal/app/app.go`, add `"github.com/hance08/kea/internal/ledger"` to imports.
+
+Update `App` struct:
+
+```go
+type App struct {
+	Service  *service.Service
+	Registry *ledger.Registry
+}
+```
+
+Update `NewApp` signature and body:
+
+```go
+func NewApp(cfg *config.Config, registry *ledger.Registry, migrationFS fs.FS) (*App, func(), error) {
+	dbPathRaw := cfg.Database.Path
+
+	if dbPathRaw == "" {
+		appDir, err := GetAppDataDir()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to determine data directory: %w", err)
+		}
+		dbPathRaw = filepath.Join(appDir, "kea.db")
+	}
+
+	if err := backup.Run(dbPathRaw, nil); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: backup failed: %v\n", err)
+	}
+
+	dbStore, err := store.NewStore(dbPathRaw, migrationFS)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to initialize database: %w", err)
+	}
+
+	svc := service.NewService(dbStore, dbStore, dbStore, cfg)
+
+	registry.OnSwitch(func(name, path string) {
+		if err := dbStore.Swap(path, migrationFS); err != nil {
+			fmt.Fprintf(os.Stderr, "ledger switch failed: %v\n", err)
+			return
+		}
+		cfg.ActiveLedger = name
+	})
+
+	cleanup := func() {
+		registry.StopWatch()
+		if err := dbStore.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing DB: %v\n", err)
+		}
+	}
+
+	return &App{
+		Service:  svc,
+		Registry: registry,
+	}, cleanup, nil
+}
+```
+
+- [ ] **Step 2: Update cmd/root.go to pass registry**
+
+In `cmd/root.go`, change line 115 from:
+
+```go
+application, cleanup, err := app.NewApp(cfg, migrations)
+```
+
+to:
+
+```go
+application, cleanup, err := app.NewApp(cfg, registry, migrations)
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run:
+```bash
+go build ./...
+```
+Expected: success.
+
+- [ ] **Step 4: Run full test suite**
+
+Run:
+```bash
+go test ./... -count=1
+```
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/app/app.go cmd/root.go
+git commit -m "feat(app): wire Registry OnSwitch to Store Swap (#119)
+
+NewApp registers an OnSwitch callback that swaps the Store DB and
+updates cfg.ActiveLedger. Cleanup calls StopWatch before Close."
+```
+
+---
+
+### Task 9: End-to-end verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run:
+```bash
+go test ./... -v -count=1
+```
+Expected: all tests pass across all packages.
+
+- [ ] **Step 2: Build the binary**
+
+Run:
+```bash
+make build
+```
+Expected: builds successfully.
+
+- [ ] **Step 3: Smoke test CLI commands**
+
+Run:
+```bash
+./kea_test ledger list
+./kea_test info
+```
+Expected: both commands work as before — no behavior change for CLI.

--- a/docs/superpowers/specs/2026-05-19-ledger-file-watch-design.md
+++ b/docs/superpowers/specs/2026-05-19-ledger-file-watch-design.md
@@ -1,0 +1,153 @@
+# Ledger File-Watch Design
+
+**Issue:** #119 — CLI ledger switch is invisible to running web server (split-brain)
+
+**Date:** 2026-05-19
+
+## Problem
+
+The ledger registry (`ledgers.yaml`) is loaded once at startup and held in memory.
+If a long-lived process (web server) is running with ledger A and the CLI switches to
+ledger B, the server's in-memory registry and Store still point to ledger A. The user
+sees inconsistent data between CLI and web — a silent split-brain.
+
+## Solution
+
+Registry-owned file-watch with graceful Store swap. The Registry watches `ledgers.yaml`
+for changes and fires callbacks when the active ledger changes. The Store swaps its DB
+connection gracefully using a read-write mutex so in-flight queries complete safely.
+
+## Design
+
+### 1. Registry — File Watcher & Callbacks
+
+**File:** `internal/ledger/registry.go`
+
+New fields on `Registry`:
+
+- `mu sync.Mutex` — protects the callbacks slice
+- `callbacks []func(name string, path string)` — switch listeners
+- `watcher *fsnotify.Watcher` — nil until `Watch()` is called
+
+New methods:
+
+- `OnSwitch(fn func(name, path string))` — registers a callback fired when the active
+  ledger changes due to a file-watch reload.
+- `Watch(ctx context.Context) error` — starts an fsnotify watcher on `ledgers.yaml`.
+  On file write events, re-reads the YAML. If `ActiveLedger` changed compared to the
+  previous in-memory value, resolves the new DB path and fires all registered callbacks.
+  Blocks until ctx is cancelled. Uses a 100ms debounce timer to coalesce rapid
+  file-write events.
+- `StopWatch()` — closes the fsnotify watcher. Idempotent.
+
+Thread safety: the callbacks slice is protected by `mu`. Registry fields (`ActiveLedger`,
+`Ledgers`) are only mutated by the watcher goroutine during reload — no concurrent
+writes since the CLI process that triggered the switch is a separate OS process.
+
+**New dependency:** `github.com/fsnotify/fsnotify`
+
+### 2. Store — Graceful DB Swap
+
+**File:** `internal/store/sqlite.go`
+
+New field on `Store`:
+
+- `mu sync.RWMutex` — protects `db` and `rawDB` during swap
+
+New method:
+
+- `Swap(newPath string, migrationsFS fs.FS) error` — opens a new SQLite connection to
+  `newPath`, runs migrations, acquires write lock, swaps `rawDB` and `db`, releases
+  lock, closes old connection. If the new connection fails, the old connection remains
+  active and the error is returned.
+
+Query method changes: all Store methods that access `s.db` acquire `s.mu.RLock()` at
+entry and defer `s.mu.RUnlock()`. This includes:
+
+- All account query methods (sqlite_account.go)
+- All transaction query methods (sqlite_transaction.go)
+- `ExecTx` — acquires read lock to get `*sql.DB` and begin the transaction, then
+  releases it. The child `txStore` has no mutex (scoped to one goroutine, no swap).
+- `Close` and `DB` methods
+
+### 3. App Wiring & Lifecycle
+
+**File:** `internal/app/app.go`
+
+`App` struct change:
+
+- Add `Registry *ledger.Registry` field
+
+`NewApp` signature change:
+
+```go
+func NewApp(cfg *config.Config, registry *ledger.Registry, migrationFS fs.FS) (*App, func(), error)
+```
+
+Callback wiring (inside `NewApp`, after Store and Service creation):
+
+```go
+registry.OnSwitch(func(name, path string) {
+    if err := dbStore.Swap(path, migrationFS); err != nil {
+        fmt.Fprintf(os.Stderr, "ledger switch failed: %v\n", err)
+        return
+    }
+    cfg.ActiveLedger = name
+})
+```
+
+Cleanup function calls `registry.StopWatch()` before closing the Store.
+
+**Watch is started by the caller, not NewApp.** Only long-lived processes (future
+`serve` command) call `registry.Watch(ctx)` in a goroutine. Current CLI commands do
+not start the watcher — zero behavior change for existing commands.
+
+**File:** `cmd/root.go`
+
+Pass registry to `NewApp`:
+
+```go
+application, cleanup, err := app.NewApp(cfg, registry, migrations)
+```
+
+### 4. Testing Strategy
+
+**Registry watcher tests** (`internal/ledger/registry_test.go`):
+
+- Test that modifying `ledgers.yaml` on disk triggers the `OnSwitch` callback with the
+  correct name and path.
+- Test debouncing: rapid writes produce a single callback.
+- Test that `StopWatch()` stops the watcher and no further callbacks fire.
+- Test that unchanged `ActiveLedger` after a file write does not fire callbacks.
+
+**Store swap tests** (`internal/store/sqlite_swap_test.go`):
+
+- Test that `Swap` to a new DB path results in queries hitting the new database.
+- Test that a failed `Swap` (invalid path) leaves the old connection intact.
+- Test concurrent reads during a swap complete without error.
+
+**App integration** — covered by verifying the callback wiring connects Registry
+change to Store swap. No new app-level tests needed beyond the unit tests above.
+
+### 5. Files Changed
+
+| File | Change |
+|------|--------|
+| `go.mod` / `go.sum` | Add `github.com/fsnotify/fsnotify` |
+| `internal/ledger/registry.go` | Add `mu`, `callbacks`, `watcher` fields; `OnSwitch`, `Watch`, `StopWatch` methods; internal `reload` helper |
+| `internal/ledger/registry_test.go` | New: watcher and callback tests |
+| `internal/store/sqlite.go` | Add `mu` field; `Swap` method; read-lock in `ExecTx`, `Close`, `DB` |
+| `internal/store/sqlite_account.go` | Add read-lock to each method |
+| `internal/store/sqlite_transaction.go` | Add read-lock to each method |
+| `internal/store/sqlite_swap_test.go` | New: swap and concurrency tests |
+| `internal/app/app.go` | Add `Registry` to `App`; update `NewApp` signature; wire callback; update cleanup |
+| `cmd/root.go` | Pass `registry` to `NewApp` |
+
+### 6. What This Does NOT Change
+
+- CLI command behavior — short-lived commands never start the watcher.
+- The `Switch()` method itself — it still writes `ledgers.yaml` to disk as before.
+- The `KEA_LEDGER` env var override — still respected by `ActiveName()`. When set,
+  the watcher still fires callbacks for `ActiveLedger` changes in the YAML, but
+  `ActiveName()` continues to return the env var value. The callback updates
+  `cfg.ActiveLedger` to mirror the registry's own field, not the resolved name.

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
+	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gookit/color v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
-github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/golang-migrate/migrate/v4 v4.19.0 h1:RcjOnCGz3Or6HQYEJ/EEVLfWnmw9KnoigPSjzhCuaSE=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -50,6 +50,7 @@ func NewApp(cfg *config.Config, registry *ledger.Registry, migrationFS fs.FS) (*
 			return
 		}
 		cfg.ActiveLedger = name
+		cfg.Database.Path = path
 	})
 
 	cleanup := func() {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -11,16 +11,18 @@ import (
 
 	"github.com/hance08/kea/internal/backup"
 	"github.com/hance08/kea/internal/config"
+	"github.com/hance08/kea/internal/ledger"
 	"github.com/hance08/kea/internal/service"
 	"github.com/hance08/kea/internal/store"
 )
 
 type App struct {
-	Service *service.Service
+	Service  *service.Service
+	Registry *ledger.Registry
 }
 
 // NewApp initialize config, database and core logic, then return App entity
-func NewApp(cfg *config.Config, migrationFS fs.FS) (*App, func(), error) {
+func NewApp(cfg *config.Config, registry *ledger.Registry, migrationFS fs.FS) (*App, func(), error) {
 	dbPathRaw := cfg.Database.Path
 
 	if dbPathRaw == "" {
@@ -42,14 +44,24 @@ func NewApp(cfg *config.Config, migrationFS fs.FS) (*App, func(), error) {
 
 	svc := service.NewService(dbStore, dbStore, dbStore, cfg)
 
+	registry.OnSwitch(func(name, path string) {
+		if err := dbStore.Swap(path, migrationFS); err != nil {
+			fmt.Fprintf(os.Stderr, "ledger switch failed: %v\n", err)
+			return
+		}
+		cfg.ActiveLedger = name
+	})
+
 	cleanup := func() {
+		registry.StopWatch()
 		if err := dbStore.Close(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error closing DB: %v\n", err)
 		}
 	}
 
 	return &App{
-		Service: svc,
+		Service:  svc,
+		Registry: registry,
 	}, cleanup, nil
 }
 

--- a/internal/ledger/registry.go
+++ b/internal/ledger/registry.go
@@ -192,16 +192,28 @@ func (r *Registry) OnSwitch(fn func(name, path string)) {
 	r.callbacks = append(r.callbacks, fn)
 }
 
+const debounceDuration = 100 * time.Millisecond
+
+// ErrWatcherAlreadyRunning is returned by Watch when a watcher is already active.
+var ErrWatcherAlreadyRunning = errors.New("watcher already running")
+
 // Watch monitors ledgers.yaml for changes and fires registered OnSwitch
 // callbacks when the active ledger changes. It blocks until ctx is cancelled
-// or the watcher is stopped via StopWatch. Includes a 100ms debounce to
-// coalesce rapid writes into a single callback.
+// or the watcher is stopped via StopWatch. Includes a debounce to coalesce
+// rapid writes into a single callback. Returns ErrWatcherAlreadyRunning if
+// Watch has already been called without a subsequent StopWatch.
 func (r *Registry) Watch(ctx context.Context) error {
 	w, err := fsnotify.NewWatcher()
 	if err != nil {
 		return fmt.Errorf("create watcher: %w", err)
 	}
+
 	r.mu.Lock()
+	if r.watcher != nil {
+		r.mu.Unlock()
+		_ = w.Close()
+		return ErrWatcherAlreadyRunning
+	}
 	r.watcher = w
 	r.mu.Unlock()
 
@@ -211,16 +223,21 @@ func (r *Registry) Watch(ctx context.Context) error {
 		return fmt.Errorf("watch %s: %w", r.filePath, err)
 	}
 
-	var debounce *time.Timer
+	var (
+		debounce *time.Timer
+		wg       sync.WaitGroup
+	)
 	for {
 		select {
 		case <-ctx.Done():
 			if debounce != nil {
 				debounce.Stop()
 			}
+			wg.Wait()
 			return ctx.Err()
 		case event, ok := <-w.Events:
 			if !ok {
+				wg.Wait()
 				return nil
 			}
 			if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
@@ -229,11 +246,14 @@ func (r *Registry) Watch(ctx context.Context) error {
 			if debounce != nil {
 				debounce.Stop()
 			}
-			debounce = time.AfterFunc(100*time.Millisecond, func() {
+			wg.Add(1)
+			debounce = time.AfterFunc(debounceDuration, func() {
+				defer wg.Done()
 				r.reload()
 			})
 		case err, ok := <-w.Errors:
 			if !ok {
+				wg.Wait()
 				return nil
 			}
 			fmt.Fprintf(os.Stderr, "ledger watcher error: %v\n", err)
@@ -265,30 +285,29 @@ func (r *Registry) reload() {
 		fmt.Fprintf(os.Stderr, "parse ledgers.yaml: %v\n", err)
 		return
 	}
-
-	prev := r.ActiveLedger
-	if fresh.ActiveLedger == prev {
-		return
-	}
-
-	r.ActiveLedger = fresh.ActiveLedger
-	r.Ledgers = fresh.Ledgers
-	if r.Ledgers == nil {
-		r.Ledgers = make(map[string]Entry)
-	}
-
-	entry, exists := r.Ledgers[r.ActiveLedger]
-	if !exists {
-		fmt.Fprintf(os.Stderr, "reloaded active ledger %q not found in registry\n", r.ActiveLedger)
-		return
+	if fresh.Ledgers == nil {
+		fresh.Ledgers = make(map[string]Entry)
 	}
 
 	r.mu.Lock()
+	prev := r.ActiveLedger
+	if fresh.ActiveLedger == prev {
+		r.mu.Unlock()
+		return
+	}
+	r.ActiveLedger = fresh.ActiveLedger
+	r.Ledgers = fresh.Ledgers
+	entry, exists := r.Ledgers[r.ActiveLedger]
 	cbs := make([]func(string, string), len(r.callbacks))
 	copy(cbs, r.callbacks)
 	r.mu.Unlock()
 
+	if !exists {
+		fmt.Fprintf(os.Stderr, "reloaded active ledger %q not found in registry\n", fresh.ActiveLedger)
+		return
+	}
+
 	for _, fn := range cbs {
-		fn(r.ActiveLedger, entry.Path)
+		fn(fresh.ActiveLedger, entry.Path)
 	}
 }

--- a/internal/ledger/registry.go
+++ b/internal/ledger/registry.go
@@ -4,12 +4,16 @@
 package ledger
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
+	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"gopkg.in/yaml.v3"
 )
 
@@ -31,6 +35,9 @@ type Registry struct {
 	Ledgers        map[string]Entry `yaml:"ledgers"`
 	MigratedLegacy bool             `yaml:"-"`
 	filePath       string
+	mu             sync.Mutex
+	callbacks      []func(name string, path string)
+	watcher        *fsnotify.Watcher
 }
 
 // EmptyRegistry returns a Registry with no ledgers and no active ledger.
@@ -175,4 +182,113 @@ func (r *Registry) Remove(name string, deleteFile bool) error {
 		}
 	}
 	return nil
+}
+
+// OnSwitch registers a callback that is called when the active ledger changes.
+// Multiple callbacks may be registered; all are called on each change.
+func (r *Registry) OnSwitch(fn func(name, path string)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.callbacks = append(r.callbacks, fn)
+}
+
+// Watch monitors ledgers.yaml for changes and fires registered OnSwitch
+// callbacks when the active ledger changes. It blocks until ctx is cancelled
+// or the watcher is stopped via StopWatch. Includes a 100ms debounce to
+// coalesce rapid writes into a single callback.
+func (r *Registry) Watch(ctx context.Context) error {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("create watcher: %w", err)
+	}
+	r.mu.Lock()
+	r.watcher = w
+	r.mu.Unlock()
+
+	defer w.Close()
+
+	if err := w.Add(r.filePath); err != nil {
+		return fmt.Errorf("watch %s: %w", r.filePath, err)
+	}
+
+	var debounce *time.Timer
+	for {
+		select {
+		case <-ctx.Done():
+			if debounce != nil {
+				debounce.Stop()
+			}
+			return ctx.Err()
+		case event, ok := <-w.Events:
+			if !ok {
+				return nil
+			}
+			if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
+				continue
+			}
+			if debounce != nil {
+				debounce.Stop()
+			}
+			debounce = time.AfterFunc(100*time.Millisecond, func() {
+				r.reload()
+			})
+		case err, ok := <-w.Errors:
+			if !ok {
+				return nil
+			}
+			fmt.Fprintf(os.Stderr, "ledger watcher error: %v\n", err)
+		}
+	}
+}
+
+// StopWatch closes the underlying fsnotify watcher, causing Watch to return.
+func (r *Registry) StopWatch() {
+	r.mu.Lock()
+	w := r.watcher
+	r.watcher = nil
+	r.mu.Unlock()
+	if w != nil {
+		_ = w.Close()
+	}
+}
+
+// reload reads ledgers.yaml from disk and fires OnSwitch callbacks if the
+// active ledger has changed since the last read.
+func (r *Registry) reload() {
+	data, err := os.ReadFile(r.filePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reload ledgers.yaml: %v\n", err)
+		return
+	}
+	var fresh Registry
+	if err := yaml.Unmarshal(data, &fresh); err != nil {
+		fmt.Fprintf(os.Stderr, "parse ledgers.yaml: %v\n", err)
+		return
+	}
+
+	prev := r.ActiveLedger
+	if fresh.ActiveLedger == prev {
+		return
+	}
+
+	r.ActiveLedger = fresh.ActiveLedger
+	r.Ledgers = fresh.Ledgers
+	if r.Ledgers == nil {
+		r.Ledgers = make(map[string]Entry)
+	}
+
+	entry, exists := r.Ledgers[r.ActiveLedger]
+	if !exists {
+		fmt.Fprintf(os.Stderr, "reloaded active ledger %q not found in registry\n", r.ActiveLedger)
+		return
+	}
+
+	r.mu.Lock()
+	cbs := make([]func(string, string), len(r.callbacks))
+	copy(cbs, r.callbacks)
+	r.mu.Unlock()
+
+	for _, fn := range cbs {
+		fn(r.ActiveLedger, entry.Path)
+	}
 }

--- a/internal/ledger/registry.go
+++ b/internal/ledger/registry.go
@@ -217,27 +217,30 @@ func (r *Registry) Watch(ctx context.Context) error {
 	r.watcher = w
 	r.mu.Unlock()
 
-	defer w.Close()
+	defer func() {
+		r.mu.Lock()
+		r.watcher = nil
+		r.mu.Unlock()
+		_ = w.Close()
+	}()
 
 	if err := w.Add(r.filePath); err != nil {
 		return fmt.Errorf("watch %s: %w", r.filePath, err)
 	}
 
-	var (
-		debounce *time.Timer
-		wg       sync.WaitGroup
-	)
+	var debounce *time.Timer
 	for {
 		select {
 		case <-ctx.Done():
 			if debounce != nil {
 				debounce.Stop()
 			}
-			wg.Wait()
 			return ctx.Err()
 		case event, ok := <-w.Events:
 			if !ok {
-				wg.Wait()
+				if debounce != nil {
+					debounce.Stop()
+				}
 				return nil
 			}
 			if event.Op&(fsnotify.Write|fsnotify.Create) == 0 {
@@ -246,14 +249,14 @@ func (r *Registry) Watch(ctx context.Context) error {
 			if debounce != nil {
 				debounce.Stop()
 			}
-			wg.Add(1)
 			debounce = time.AfterFunc(debounceDuration, func() {
-				defer wg.Done()
 				r.reload()
 			})
 		case err, ok := <-w.Errors:
 			if !ok {
-				wg.Wait()
+				if debounce != nil {
+					debounce.Stop()
+				}
 				return nil
 			}
 			fmt.Fprintf(os.Stderr, "ledger watcher error: %v\n", err)

--- a/internal/ledger/registry_test.go
+++ b/internal/ledger/registry_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -366,11 +367,16 @@ func TestWatch_DebouncesRapidWrites(t *testing.T) {
 	require.NoError(t, r.Add("personal", "/tmp/personal.db"))
 
 	var callCount int32
-	var lastName string
+	var (
+		lastNameMu sync.Mutex
+		lastName   string
+	)
 	done := make(chan struct{}, 10)
 	r.OnSwitch(func(name, path string) {
 		atomic.AddInt32(&callCount, 1)
+		lastNameMu.Lock()
 		lastName = name
+		lastNameMu.Unlock()
 		done <- struct{}{}
 	})
 
@@ -394,8 +400,11 @@ func TestWatch_DebouncesRapidWrites(t *testing.T) {
 		// Wait a bit more to see if extra callbacks arrive.
 		time.Sleep(300 * time.Millisecond)
 		count := atomic.LoadInt32(&callCount)
+		lastNameMu.Lock()
+		last := lastName
+		lastNameMu.Unlock()
 		assert.Equal(t, int32(1), count, "debounce should coalesce rapid writes into a single callback")
-		assert.Equal(t, "personal", lastName, "should reflect the final state")
+		assert.Equal(t, "personal", last, "should reflect the final state")
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for OnSwitch callback")
 	}

--- a/internal/ledger/registry_test.go
+++ b/internal/ledger/registry_test.go
@@ -4,10 +4,13 @@
 package ledger
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -244,4 +247,156 @@ func TestRemove_PersistsToDisk(t *testing.T) {
 	r2, err := Load(dir)
 	require.NoError(t, err)
 	assert.NotContains(t, r2.Ledgers, "personal")
+}
+
+func TestWatch_FiresOnSwitch(t *testing.T) {
+	dir := t.TempDir()
+	r, err := Load(dir)
+	require.NoError(t, err)
+	require.NoError(t, r.Add("work", "/tmp/work.db"))
+
+	var gotName, gotPath string
+	done := make(chan struct{})
+	r.OnSwitch(func(name, path string) {
+		gotName = name
+		gotPath = path
+		close(done)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = r.Watch(ctx)
+	}()
+
+	// Give the watcher time to start.
+	time.Sleep(200 * time.Millisecond)
+
+	// Simulate an external process switching the ledger.
+	r2, err := Load(dir)
+	require.NoError(t, err)
+	require.NoError(t, r2.Switch("work"))
+
+	select {
+	case <-done:
+		assert.Equal(t, "work", gotName)
+		assert.Equal(t, "/tmp/work.db", gotPath)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnSwitch callback")
+	}
+}
+
+func TestWatch_NoCallbackWhenActiveUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	r, err := Load(dir)
+	require.NoError(t, err)
+	require.NoError(t, r.Add("work", "/tmp/work.db"))
+
+	called := make(chan struct{}, 1)
+	r.OnSwitch(func(name, path string) {
+		called <- struct{}{}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = r.Watch(ctx)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Write the same active ledger — should NOT fire callback.
+	r2, err := Load(dir)
+	require.NoError(t, err)
+	require.NoError(t, r2.Switch("default"))
+
+	select {
+	case <-called:
+		t.Fatal("callback should not fire when active ledger is unchanged")
+	case <-time.After(500 * time.Millisecond):
+		// OK — no callback fired.
+	}
+}
+
+func TestWatch_StopWatchPreventsCallbacks(t *testing.T) {
+	dir := t.TempDir()
+	r, err := Load(dir)
+	require.NoError(t, err)
+	require.NoError(t, r.Add("work", "/tmp/work.db"))
+
+	called := make(chan struct{}, 1)
+	r.OnSwitch(func(name, path string) {
+		called <- struct{}{}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	watchDone := make(chan struct{})
+	go func() {
+		_ = r.Watch(ctx)
+		close(watchDone)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Stop the watcher.
+	r.StopWatch()
+	cancel()
+	<-watchDone
+
+	// Switch after stop — no callback should fire.
+	r2, err := Load(dir)
+	require.NoError(t, err)
+	require.NoError(t, r2.Switch("work"))
+
+	select {
+	case <-called:
+		t.Fatal("callback should not fire after StopWatch")
+	case <-time.After(500 * time.Millisecond):
+		// OK.
+	}
+}
+
+func TestWatch_DebouncesRapidWrites(t *testing.T) {
+	dir := t.TempDir()
+	r, err := Load(dir)
+	require.NoError(t, err)
+	require.NoError(t, r.Add("work", "/tmp/work.db"))
+	require.NoError(t, r.Add("personal", "/tmp/personal.db"))
+
+	var callCount int32
+	var lastName string
+	done := make(chan struct{}, 10)
+	r.OnSwitch(func(name, path string) {
+		atomic.AddInt32(&callCount, 1)
+		lastName = name
+		done <- struct{}{}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = r.Watch(ctx)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Rapid-fire switches: default → work → personal (within debounce window).
+	r2, err := Load(dir)
+	require.NoError(t, err)
+	require.NoError(t, r2.Switch("work"))
+	require.NoError(t, r2.Switch("personal"))
+
+	select {
+	case <-done:
+		// Wait a bit more to see if extra callbacks arrive.
+		time.Sleep(300 * time.Millisecond)
+		count := atomic.LoadInt32(&callCount)
+		assert.Equal(t, int32(1), count, "debounce should coalesce rapid writes into a single callback")
+		assert.Equal(t, "personal", lastName, "should reflect the final state")
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnSwitch callback")
+	}
 }

--- a/internal/ledger/registry_test.go
+++ b/internal/ledger/registry_test.go
@@ -381,10 +381,10 @@ func TestWatch_DebouncesRapidWrites(t *testing.T) {
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
+	watchDone := make(chan struct{})
 	go func() {
 		_ = r.Watch(ctx)
+		close(watchDone)
 	}()
 
 	time.Sleep(200 * time.Millisecond)
@@ -408,4 +408,7 @@ func TestWatch_DebouncesRapidWrites(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for OnSwitch callback")
 	}
+
+	cancel()
+	<-watchDone
 }

--- a/internal/store/export_test.go
+++ b/internal/store/export_test.go
@@ -9,5 +9,7 @@ import (
 )
 
 func (s *Store) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.db.QueryRowContext(ctx, query, args...)
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/sqlite3"
@@ -29,6 +30,7 @@ type DBTX interface {
 type Store struct {
 	db    DBTX
 	rawDB *sql.DB
+	mu    sync.RWMutex
 }
 
 func NewStore(dbPath string, migrationsFS fs.FS) (*Store, error) {
@@ -64,7 +66,9 @@ func NewStore(dbPath string, migrationsFS fs.FS) (*Store, error) {
 }
 
 func (s *Store) ExecTx(ctx context.Context, fn func(repository.Repository) error) error {
+	s.mu.RLock()
 	db, ok := s.db.(*sql.DB)
+	s.mu.RUnlock()
 	if !ok {
 		return fmt.Errorf("store is already in a transaction")
 	}
@@ -87,7 +91,10 @@ func (s *Store) ExecTx(ctx context.Context, fn func(repository.Repository) error
 }
 
 func (s *Store) Close() error {
-	if db, ok := s.db.(*sql.DB); ok {
+	s.mu.RLock()
+	db, ok := s.db.(*sql.DB)
+	s.mu.RUnlock()
+	if ok {
 		return db.Close()
 	}
 	return nil
@@ -95,6 +102,8 @@ func (s *Store) Close() error {
 
 // DB returns the underlying *sql.DB. Returns nil for transaction-scoped Stores.
 func (s *Store) DB() *sql.DB {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.rawDB
 }
 

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -100,6 +100,25 @@ func (s *Store) Close() error {
 	return nil
 }
 
+func (s *Store) Swap(newPath string, migrationsFS fs.FS) error {
+	newStore, err := NewStore(newPath, migrationsFS)
+	if err != nil {
+		return fmt.Errorf("open new database: %w", err)
+	}
+
+	s.mu.Lock()
+	oldDB := s.rawDB
+	s.rawDB = newStore.rawDB
+	s.db = newStore.db
+	s.mu.Unlock()
+
+	if oldDB != nil {
+		_ = oldDB.Close()
+	}
+
+	return nil
+}
+
 // DB returns the underlying *sql.DB. Returns nil for transaction-scoped Stores.
 func (s *Store) DB() *sql.DB {
 	s.mu.RLock()

--- a/internal/store/sqlite_account.go
+++ b/internal/store/sqlite_account.go
@@ -217,8 +217,6 @@ func (s *Store) GetAccountBalance(ctx context.Context, accountID int64) (int64, 
 }
 
 func (s *Store) scanAccounts(rows *sql.Rows) ([]*model.Account, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 	var accounts []*model.Account
 	for rows.Next() {
 		acc := &model.Account{}

--- a/internal/store/sqlite_account.go
+++ b/internal/store/sqlite_account.go
@@ -14,6 +14,8 @@ import (
 )
 
 func (s *Store) CreateAccount(ctx context.Context, name string, accType model.AccountType, currency string, description string, parentID *int64) (int64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	if !accType.IsValid() {
 		return 0, fmt.Errorf("account type %q: %w", accType, ErrInvalidAccountType)
 	}
@@ -47,6 +49,8 @@ func (s *Store) CreateAccount(ctx context.Context, name string, accType model.Ac
 }
 
 func (s *Store) GetAllAccounts(ctx context.Context) ([]*model.Account, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	rows, err := s.db.QueryContext(ctx, `
         SELECT id, name, type, parent_id, currency, description, is_hidden
         FROM accounts
@@ -63,6 +67,8 @@ func (s *Store) GetAllAccounts(ctx context.Context) ([]*model.Account, error) {
 }
 
 func (s *Store) GetAccountByName(ctx context.Context, name string) (*model.Account, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	row := s.db.QueryRowContext(ctx, "SELECT id, name, type, parent_id, currency, description, is_hidden FROM accounts WHERE name = ?", name)
 
 	acc := &model.Account{}
@@ -89,6 +95,8 @@ func (s *Store) GetAccountByName(ctx context.Context, name string) (*model.Accou
 }
 
 func (s *Store) GetAccountByID(ctx context.Context, id int64) (*model.Account, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	row := s.db.QueryRowContext(ctx, "SELECT id, name, type, parent_id, currency, description, is_hidden FROM accounts WHERE id = ?", id)
 
 	acc := &model.Account{}
@@ -115,6 +123,8 @@ func (s *Store) GetAccountByID(ctx context.Context, id int64) (*model.Account, e
 }
 
 func (s *Store) AccountExists(ctx context.Context, name string) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	var exists bool
 	row := s.db.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM accounts WHERE name = ?)", name)
 	if err := row.Scan(&exists); err != nil {
@@ -124,6 +134,8 @@ func (s *Store) AccountExists(ctx context.Context, name string) (bool, error) {
 }
 
 func (s *Store) GetAllAccountBalances(ctx context.Context, asOf int64) (map[int64]int64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	rows, err := s.db.QueryContext(ctx, `
         SELECT s.account_id, SUM(s.amount)
         FROM splits s
@@ -154,6 +166,8 @@ func (s *Store) GetAllAccountBalances(ctx context.Context, asOf int64) (map[int6
 }
 
 func (s *Store) HasChildAccounts(ctx context.Context, accountID int64) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	var exists bool
 	row := s.db.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM accounts WHERE parent_id = ?)", accountID)
 	if err := row.Scan(&exists); err != nil {
@@ -163,6 +177,8 @@ func (s *Store) HasChildAccounts(ctx context.Context, accountID int64) (bool, er
 }
 
 func (s *Store) GetAccountsByType(ctx context.Context, accType model.AccountType) ([]*model.Account, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	rows, err := s.db.QueryContext(ctx, `
         SELECT id, name, type, parent_id, currency, description, is_hidden
         FROM accounts
@@ -181,6 +197,8 @@ func (s *Store) GetAccountsByType(ctx context.Context, accType model.AccountType
 }
 
 func (s *Store) GetAccountBalance(ctx context.Context, accountID int64) (int64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	var balance sql.NullInt64
 	err := s.db.QueryRowContext(ctx, `
         SELECT SUM(amount)
@@ -199,6 +217,8 @@ func (s *Store) GetAccountBalance(ctx context.Context, accountID int64) (int64, 
 }
 
 func (s *Store) scanAccounts(rows *sql.Rows) ([]*model.Account, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	var accounts []*model.Account
 	for rows.Next() {
 		acc := &model.Account{}
@@ -229,6 +249,8 @@ func (s *Store) scanAccounts(rows *sql.Rows) ([]*model.Account, error) {
 
 // AccountHasTransactions returns true when the account is referenced by any split.
 func (s *Store) AccountHasTransactions(ctx context.Context, accountID int64) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	var exists bool
 	row := s.db.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM splits WHERE account_id = ?)", accountID)
 	if err := row.Scan(&exists); err != nil {
@@ -240,11 +262,14 @@ func (s *Store) AccountHasTransactions(ctx context.Context, accountID int64) (bo
 // RenameAccount updates the name of an account and cascades the rename to all descendants.
 // Both updates run in a single transaction.
 func (s *Store) RenameAccount(ctx context.Context, oldName, newName string) error {
-	if s.rawDB == nil {
+	s.mu.RLock()
+	rawDB := s.rawDB
+	s.mu.RUnlock()
+	if rawDB == nil {
 		return fmt.Errorf("store is already in a transaction")
 	}
 
-	tx, err := s.rawDB.BeginTx(ctx, nil)
+	tx, err := rawDB.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
@@ -276,6 +301,8 @@ func (s *Store) RenameAccount(ctx context.Context, oldName, newName string) erro
 
 // DeleteAccount removes an account record by ID.
 func (s *Store) DeleteAccount(ctx context.Context, accountID int64) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	result, err := s.db.ExecContext(ctx, "DELETE FROM accounts WHERE id = ?", accountID)
 	if err != nil {
 		return fmt.Errorf("failed to delete account: %w", err)
@@ -295,6 +322,8 @@ func (s *Store) DeleteAccount(ctx context.Context, accountID int64) error {
 
 // UpdateAccountMetadata updates the description and hidden status of an account.
 func (s *Store) UpdateAccountMetadata(ctx context.Context, accountID int64, description string, isHidden bool) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE accounts SET description = ?, is_hidden = ? WHERE id = ?`,
 		description, isHidden, accountID,

--- a/internal/store/sqlite_reconcile.go
+++ b/internal/store/sqlite_reconcile.go
@@ -116,8 +116,6 @@ func (s *Store) MarkSplitsReconciledByAccount(ctx context.Context, accountID int
 // in a single UPDATE statement. Returns an error if the affected row count
 // does not match len(txIDs) — indicating one or more IDs did not exist.
 func (s *Store) BulkUpdateTransactionStatus(ctx context.Context, txIDs []int64, status model.TransactionStatus) error {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 	if len(txIDs) == 0 {
 		return nil
 	}

--- a/internal/store/sqlite_reconcile.go
+++ b/internal/store/sqlite_reconcile.go
@@ -109,13 +109,19 @@ func (s *Store) MarkSplitsReconciledByAccount(ctx context.Context, accountID int
 	}
 
 	// 2. Upgrade all affected transactions to StatusReconciled.
-	return rowsAffected, s.BulkUpdateTransactionStatus(ctx, txIDs, model.StatusReconciled)
+	return rowsAffected, s.bulkUpdateTransactionStatus(ctx, txIDs, model.StatusReconciled)
 }
 
 // BulkUpdateTransactionStatus sets the status of all listed transaction IDs
 // in a single UPDATE statement. Returns an error if the affected row count
 // does not match len(txIDs) — indicating one or more IDs did not exist.
 func (s *Store) BulkUpdateTransactionStatus(ctx context.Context, txIDs []int64, status model.TransactionStatus) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.bulkUpdateTransactionStatus(ctx, txIDs, status)
+}
+
+func (s *Store) bulkUpdateTransactionStatus(ctx context.Context, txIDs []int64, status model.TransactionStatus) error {
 	if len(txIDs) == 0 {
 		return nil
 	}

--- a/internal/store/sqlite_reconcile.go
+++ b/internal/store/sqlite_reconcile.go
@@ -19,6 +19,8 @@ import (
 // ensures multi-account transactions remain visible for other accounts after one
 // account has already been reconciled. Results are ordered by timestamp ASC.
 func (s *Store) GetUnreconciledTransactionsByAccount(ctx context.Context, accountID int64) ([]*model.ReconcileEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	rows, err := s.db.QueryContext(ctx, `
         SELECT
             t.id, t.timestamp, t.description, t.status,
@@ -78,6 +80,8 @@ func (s *Store) GetUnreconciledTransactionsByAccount(ctx context.Context, accoun
 // transaction Reconciled here does not hide it from other accounts that still
 // need to reconcile their own splits.
 func (s *Store) MarkSplitsReconciledByAccount(ctx context.Context, accountID int64, txIDs []int64) (int64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	if len(txIDs) == 0 {
 		return 0, nil
 	}
@@ -112,6 +116,8 @@ func (s *Store) MarkSplitsReconciledByAccount(ctx context.Context, accountID int
 // in a single UPDATE statement. Returns an error if the affected row count
 // does not match len(txIDs) — indicating one or more IDs did not exist.
 func (s *Store) BulkUpdateTransactionStatus(ctx context.Context, txIDs []int64, status model.TransactionStatus) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	if len(txIDs) == 0 {
 		return nil
 	}
@@ -149,6 +155,8 @@ func (s *Store) BulkUpdateTransactionStatus(ctx context.Context, txIDs []int64, 
 // accountID. Returns 0 if the account has never been reconciled (no row in
 // account_reconcile_state for this account yet).
 func (s *Store) GetLastReconciledBalance(ctx context.Context, accountID int64) (int64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	var balance int64
 	err := s.db.QueryRowContext(ctx,
 		"SELECT last_reconciled_balance FROM account_reconcile_state WHERE account_id = ?",
@@ -167,6 +175,8 @@ func (s *Store) GetLastReconciledBalance(ctx context.Context, accountID int64) (
 // accountID. An upsert is used so that the first reconcile for an account
 // inserts a row; subsequent reconciles update it.
 func (s *Store) SetLastReconciledBalance(ctx context.Context, accountID int64, balance int64) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	_, err := s.db.ExecContext(ctx, `
         INSERT INTO account_reconcile_state (account_id, last_reconciled_balance)
         VALUES (?, ?)

--- a/internal/store/sqlite_swap_test.go
+++ b/internal/store/sqlite_swap_test.go
@@ -1,0 +1,140 @@
+package store_test
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/hance08/kea/internal/model"
+	"github.com/hance08/kea/internal/repository"
+	"github.com/hance08/kea/internal/store"
+	"github.com/hance08/kea/migrations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSwap_QueriesHitNewDB(t *testing.T) {
+	dir := t.TempDir()
+	dbA := filepath.Join(dir, "a.db")
+	dbB := filepath.Join(dir, "b.db")
+
+	s, err := store.NewStore(dbA, migrations.FS)
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	ctx := context.Background()
+
+	// Create an account in DB A.
+	err = s.ExecTx(ctx, func(repo repository.Repository) error {
+		_, err := repo.CreateAccount(ctx, "Assets:BankA", model.AccountTypeAsset, "USD", "", nil)
+		return err
+	})
+	require.NoError(t, err)
+
+	// Pre-create DB B with its own account.
+	sB, err := store.NewStore(dbB, migrations.FS)
+	require.NoError(t, err)
+	err = sB.ExecTx(ctx, func(repo repository.Repository) error {
+		_, err := repo.CreateAccount(ctx, "Assets:BankB", model.AccountTypeAsset, "USD", "", nil)
+		return err
+	})
+	require.NoError(t, err)
+	require.NoError(t, sB.Close())
+
+	// Swap to DB B.
+	err = s.Swap(dbB, migrations.FS)
+	require.NoError(t, err)
+
+	// After swap, BankA should not exist; BankB should.
+	_, err = s.GetAccountByName(ctx, "Assets:BankA")
+	assert.Error(t, err, "BankA should not exist in DB B")
+
+	acc, err := s.GetAccountByName(ctx, "Assets:BankB")
+	require.NoError(t, err)
+	assert.Equal(t, "Assets:BankB", acc.Name)
+}
+
+func TestSwap_FailedSwapKeepsOldConnection(t *testing.T) {
+	dir := t.TempDir()
+	dbA := filepath.Join(dir, "a.db")
+
+	s, err := store.NewStore(dbA, migrations.FS)
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	ctx := context.Background()
+
+	err = s.ExecTx(ctx, func(repo repository.Repository) error {
+		_, err := repo.CreateAccount(ctx, "Assets:BankA", model.AccountTypeAsset, "USD", "", nil)
+		return err
+	})
+	require.NoError(t, err)
+
+	// Swap to an invalid path — should fail.
+	err = s.Swap("/nonexistent/dir/bad.db", migrations.FS)
+	require.Error(t, err)
+
+	// Old connection should still work.
+	acc, err := s.GetAccountByName(ctx, "Assets:BankA")
+	require.NoError(t, err)
+	assert.Equal(t, "Assets:BankA", acc.Name)
+}
+
+func TestSwap_ConcurrentReads(t *testing.T) {
+	dir := t.TempDir()
+	dbA := filepath.Join(dir, "a.db")
+	dbB := filepath.Join(dir, "b.db")
+
+	s, err := store.NewStore(dbA, migrations.FS)
+	require.NoError(t, err)
+	defer func() { _ = s.Close() }()
+
+	ctx := context.Background()
+
+	err = s.ExecTx(ctx, func(repo repository.Repository) error {
+		_, err := repo.CreateAccount(ctx, "Assets:BankA", model.AccountTypeAsset, "USD", "", nil)
+		return err
+	})
+	require.NoError(t, err)
+
+	// Pre-create DB B.
+	sB, err := store.NewStore(dbB, migrations.FS)
+	require.NoError(t, err)
+	err = sB.ExecTx(ctx, func(repo repository.Repository) error {
+		_, err := repo.CreateAccount(ctx, "Assets:BankB", model.AccountTypeAsset, "USD", "", nil)
+		return err
+	})
+	require.NoError(t, err)
+	require.NoError(t, sB.Close())
+
+	// Launch concurrent readers and a swap in the middle.
+	var wg sync.WaitGroup
+	errs := make(chan error, 20)
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := s.GetAllAccounts(ctx)
+			if err != nil {
+				errs <- err
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := s.Swap(dbB, migrations.FS); err != nil {
+			errs <- err
+		}
+	}()
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("concurrent operation failed: %v", err)
+	}
+}

--- a/internal/store/sqlite_transaction.go
+++ b/internal/store/sqlite_transaction.go
@@ -558,9 +558,6 @@ func (s *Store) ListTransactionsByAccount(ctx context.Context, accountID int64, 
 }
 
 func (s *Store) scanTransactions(rows *sql.Rows) ([]*model.Transaction, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	var transactions []*model.Transaction
 	for rows.Next() {
 		tx := &model.Transaction{}

--- a/internal/store/sqlite_transaction.go
+++ b/internal/store/sqlite_transaction.go
@@ -16,6 +16,9 @@ import (
 // CreateTransactionWithSplits inserts a transaction and its splits.
 // It relies on the caller (Service layer) to wrap it in ExecTx for atomicity.
 func (s *Store) CreateTransactionWithSplits(ctx context.Context, tx model.Transaction, splits []model.Split) (int64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	stmtTx, err := s.db.PrepareContext(ctx, `
         INSERT INTO transactions (timestamp, description, status, external_id, type)
         VALUES (?, ?, ?, ?, ?)
@@ -63,6 +66,9 @@ func (s *Store) CreateTransactionWithSplits(ctx context.Context, tx model.Transa
 }
 
 func (s *Store) GetTransactionByID(ctx context.Context, txID int64) (*model.Transaction, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	var tx model.Transaction
 	err := s.db.QueryRowContext(ctx, `
         SELECT id, timestamp, description, status, external_id, type
@@ -79,6 +85,9 @@ func (s *Store) GetTransactionByID(ctx context.Context, txID int64) (*model.Tran
 }
 
 func (s *Store) GetTransactionsByAccount(ctx context.Context, accountID int64, limit int) ([]*model.Transaction, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	if limit <= 0 {
 		limit = 100
 	}
@@ -102,6 +111,9 @@ func (s *Store) GetTransactionsByAccount(ctx context.Context, accountID int64, l
 }
 
 func (s *Store) GetTransactionsByDateRange(ctx context.Context, startTime, endTime int64) ([]*model.Transaction, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	rows, err := s.db.QueryContext(ctx, `
         SELECT id, timestamp, description, status, external_id, type
         FROM transactions
@@ -119,6 +131,9 @@ func (s *Store) GetTransactionsByDateRange(ctx context.Context, startTime, endTi
 }
 
 func (s *Store) GetAllTransactions(ctx context.Context, limit int) ([]*model.Transaction, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	if limit <= 0 {
 		limit = 100
 	}
@@ -140,6 +155,9 @@ func (s *Store) GetAllTransactions(ctx context.Context, limit int) ([]*model.Tra
 }
 
 func (s *Store) UpdateTransactionStatus(ctx context.Context, txID int64, status model.TransactionStatus) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	result, err := s.db.ExecContext(ctx, `
         UPDATE transactions
         SET status = ?
@@ -162,6 +180,9 @@ func (s *Store) UpdateTransactionStatus(ctx context.Context, txID int64, status 
 }
 
 func (s *Store) DeleteTransaction(ctx context.Context, txID int64) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	result, err := s.db.ExecContext(ctx, `
         DELETE FROM transactions
         WHERE id = ?
@@ -183,6 +204,9 @@ func (s *Store) DeleteTransaction(ctx context.Context, txID int64) error {
 }
 
 func (s *Store) UpdateTransactionBasic(ctx context.Context, txID int64, description string, timestamp int64, status model.TransactionStatus, txType model.TransactionType) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	result, err := s.db.ExecContext(ctx, `
         UPDATE transactions
         SET description = ?, timestamp = ?, status = ?, type = ?
@@ -205,6 +229,9 @@ func (s *Store) UpdateTransactionBasic(ctx context.Context, txID int64, descript
 }
 
 func (s *Store) UpdateSplit(ctx context.Context, splitID int64, accountID int64, amount int64, currency string, memo string) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	result, err := s.db.ExecContext(ctx, `
         UPDATE splits
         SET account_id = ?, amount = ?, currency = ?, memo = ?
@@ -227,6 +254,9 @@ func (s *Store) UpdateSplit(ctx context.Context, splitID int64, accountID int64,
 }
 
 func (s *Store) DeleteSplit(ctx context.Context, splitID int64) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	result, err := s.db.ExecContext(ctx, `
         DELETE FROM splits
         WHERE id = ?
@@ -248,6 +278,9 @@ func (s *Store) DeleteSplit(ctx context.Context, splitID int64) error {
 }
 
 func (s *Store) CreateSplit(ctx context.Context, txID int64, split *model.Split) (int64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	result, err := s.db.ExecContext(ctx, `
         INSERT INTO splits (transaction_id, account_id, amount, currency, memo)
         VALUES (?, ?, ?, ?, ?)
@@ -265,6 +298,9 @@ func (s *Store) CreateSplit(ctx context.Context, txID int64, split *model.Split)
 }
 
 func (s *Store) GetSplitsByTransaction(ctx context.Context, txID int64) ([]*model.Split, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	rows, err := s.db.QueryContext(ctx, `
         SELECT id, transaction_id, account_id, amount, currency, memo
         FROM splits
@@ -299,6 +335,9 @@ func (s *Store) GetSplitsByTransaction(ctx context.Context, txID int64) ([]*mode
 }
 
 func (s *Store) GetSplitsWithAccountsByDateRange(ctx context.Context, startTime, endTime int64) (map[int64][]model.SplitDetail, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	rows, err := s.db.QueryContext(ctx, `
         SELECT
             s.id, s.transaction_id, s.account_id, s.amount, s.currency, s.memo,
@@ -333,6 +372,9 @@ func (s *Store) GetSplitsWithAccountsByDateRange(ctx context.Context, startTime,
 }
 
 func (s *Store) GetSplitsWithAccountsByTransaction(ctx context.Context, txID int64) ([]model.SplitDetail, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	rows, err := s.db.QueryContext(ctx, `
         SELECT
             s.id, s.account_id, s.amount, s.currency, s.memo,
@@ -368,6 +410,9 @@ func (s *Store) GetSplitsWithAccountsByTransaction(ctx context.Context, txID int
 // list command's --limit flag (default 20). SQLite's SQLITE_MAX_VARIABLE_NUMBER
 // is 999 by default, so this is safe for practical list sizes.
 func (s *Store) GetSplitsWithAccountsByTransactionIDs(ctx context.Context, txIDs []int64) (map[int64][]model.SplitDetail, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	if len(txIDs) == 0 {
 		return make(map[int64][]model.SplitDetail), nil
 	}
@@ -428,6 +473,9 @@ func normalizeListOpts(opts model.ListOptions) model.ListOptions {
 }
 
 func (s *Store) ListTransactions(ctx context.Context, opts model.ListOptions) (*model.ListResult[*model.Transaction], error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	opts = normalizeListOpts(opts)
 
 	result := &model.ListResult[*model.Transaction]{
@@ -464,6 +512,9 @@ func (s *Store) ListTransactions(ctx context.Context, opts model.ListOptions) (*
 }
 
 func (s *Store) ListTransactionsByAccount(ctx context.Context, accountID int64, opts model.ListOptions) (*model.ListResult[*model.Transaction], error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	opts = normalizeListOpts(opts)
 
 	result := &model.ListResult[*model.Transaction]{
@@ -507,6 +558,9 @@ func (s *Store) ListTransactionsByAccount(ctx context.Context, accountID int64, 
 }
 
 func (s *Store) scanTransactions(rows *sql.Rows) ([]*model.Transaction, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	var transactions []*model.Transaction
 	for rows.Next() {
 		tx := &model.Transaction{}


### PR DESCRIPTION
## Summary

Fixes #119 — CLI ledger switch is invisible to running web server (split-brain).

- **Registry file-watch**: `OnSwitch` callback registration, `Watch` method with fsnotify + 100ms debounce, `StopWatch` for cleanup. Thread-safe with mutex-protected callbacks.
- **Store graceful swap**: `sync.RWMutex` on all query methods, `Swap` method that opens new connection first, write-locks to atomically swap `db`/`rawDB`, then closes old connection. Failed swaps leave old connection intact.
- **App wiring**: `OnSwitch` callback connects Registry file change to `Store.Swap` + `cfg.ActiveLedger` update. Cleanup calls `StopWatch` before `Close`.

`Watch()` is not started by `NewApp` — only future long-lived processes (e.g., `serve` command) call `registry.Watch(ctx)`. Current CLI commands have zero behavior change.

## Test plan

- [x] Registry watcher tests: fires on switch, no callback when unchanged, StopWatch prevents callbacks, debounce coalesces rapid writes
- [x] Store swap tests: queries hit new DB, failed swap keeps old connection, concurrent reads during swap
- [x] Full test suite passes with `-race` flag (11 packages, 0 failures)
- [x] CLI smoke test: `go run ./cmd/kea ledger list` works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)