### PR TITLE
feat: multi-dimensional transaction filtering (#114)

### DIFF
--- a/cmd/add_actions.go
+++ b/cmd/add_actions.go
@@ -34,8 +34,14 @@ func (r *addRunner) runFromFlags(ctx context.Context, flags *addFlags) (addTrans
 		return addTransactionInput{}, fmt.Errorf("invalid amount: %w", err)
 	}
 
-	// Parse status
-	status := model.ParseTransactionStatus(flags.Status)
+	// Parse status (default to Cleared when not specified)
+	status := model.StatusCleared
+	if flags.Status != "" {
+		status, err = model.ParseTransactionStatus(flags.Status)
+		if err != nil {
+			return addTransactionInput{}, err
+		}
+	}
 
 	// Parse timestamp
 	timestamp, err := r.txSvc.ParseTransactionDate(flags.Timestamp)
@@ -213,7 +219,13 @@ func (r *addRunner) runFromSplitFlags(flags *addFlags) (addTransactionInput, err
 		description = "-"
 	}
 
-	status := model.ParseTransactionStatus(flags.Status)
+	status := model.StatusCleared
+	if flags.Status != "" {
+		status, err = model.ParseTransactionStatus(flags.Status)
+		if err != nil {
+			return addTransactionInput{}, err
+		}
+	}
 
 	timestamp, err := r.txSvc.ParseTransactionDate(flags.Timestamp)
 	if err != nil {

--- a/cmd/transaction/list.go
+++ b/cmd/transaction/list.go
@@ -6,6 +6,7 @@ package transaction
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/service"
@@ -19,16 +20,21 @@ type ListView interface {
 }
 
 type ListProvider interface {
-	GetTransactionHistory(ctx context.Context, accountName string, limit int) ([]*model.Transaction, error)
-	GetRecentTransactions(ctx context.Context, limit int) ([]*model.Transaction, error)
+	FilterTransactions(ctx context.Context, filter model.TransactionFilter, opts model.ListOptions) (*model.ListResult[*model.Transaction], error)
+	FilterTransactionsByAccountName(ctx context.Context, accountName string, filter model.TransactionFilter, opts model.ListOptions) (*model.ListResult[*model.Transaction], error)
 	GetTransactionDetailsByIDs(ctx context.Context, txs []*model.Transaction) (map[int64]*model.TransactionDetail, error)
 	BuildTransactionListItems(ctx context.Context, txs []*model.Transaction, details map[int64]*model.TransactionDetail) []model.TransactionListItem
 }
 
 type listFlags struct {
-	Account string
-	Limit   int
-	JSON    bool
+	Account     string
+	Limit       int
+	JSON        bool
+	Status      string
+	Type        string
+	From        string
+	To          string
+	Description string
 }
 
 type listRunner struct {
@@ -61,6 +67,11 @@ date, type, account, description, amount, and status.`,
 	cmd.Flags().StringVarP(&flags.Account, "account", "a", "", "Filter transactions by account name")
 	cmd.Flags().IntVarP(&flags.Limit, "limit", "l", 20, "Maximum number of transactions to display")
 	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output as JSON")
+	cmd.Flags().StringVar(&flags.Status, "status", "", "Filter by status (pending, cleared, reconciled)")
+	cmd.Flags().StringVar(&flags.Type, "type", "", "Filter by type (expense, income, transfer)")
+	cmd.Flags().StringVar(&flags.From, "from", "", "Filter from date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&flags.To, "to", "", "Filter to date (YYYY-MM-DD)")
+	cmd.Flags().StringVarP(&flags.Description, "description", "d", "", "Filter by description (substring match)")
 
 	return cmd
 }
@@ -87,10 +98,60 @@ func (r *listRunner) Run(ctx context.Context) error {
 }
 
 func (r *listRunner) fetchTransactions(ctx context.Context) ([]*model.Transaction, error) {
-	if r.flags.Account != "" {
-		return r.svc.GetTransactionHistory(ctx, r.flags.Account, r.flags.Limit)
+	filter, err := r.buildFilter()
+	if err != nil {
+		return nil, err
 	}
-	return r.svc.GetRecentTransactions(ctx, r.flags.Limit)
+
+	opts := model.ListOptions{Limit: r.flags.Limit, IncludeCount: false}
+
+	var result *model.ListResult[*model.Transaction]
+	if r.flags.Account != "" {
+		result, err = r.svc.FilterTransactionsByAccountName(ctx, r.flags.Account, filter, opts)
+	} else {
+		result, err = r.svc.FilterTransactions(ctx, filter, opts)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return result.Items, nil
+}
+
+func (r *listRunner) buildFilter() (model.TransactionFilter, error) {
+	var filter model.TransactionFilter
+
+	if r.flags.Status != "" {
+		s := model.ParseTransactionStatus(r.flags.Status)
+		filter.Status = &s
+	}
+	if r.flags.Type != "" {
+		txType, err := model.ParseTransactionType(r.flags.Type)
+		if err != nil {
+			return filter, err
+		}
+		filter.Type = &txType
+	}
+	if r.flags.From != "" {
+		t, err := time.Parse(model.DateFormat, r.flags.From)
+		if err != nil {
+			return filter, fmt.Errorf("invalid --from date: %w", err)
+		}
+		ts := t.Unix()
+		filter.StartTime = &ts
+	}
+	if r.flags.To != "" {
+		t, err := time.Parse(model.DateFormat, r.flags.To)
+		if err != nil {
+			return filter, fmt.Errorf("invalid --to date: %w", err)
+		}
+		ts := t.Add(24*time.Hour - time.Second).Unix()
+		filter.EndTime = &ts
+	}
+	if r.flags.Description != "" {
+		filter.Description = &r.flags.Description
+	}
+
+	return filter, nil
 }
 
 func (r *listRunner) buildViewItems(ctx context.Context, transactions []*model.Transaction) []views.TransactionListItem {

--- a/cmd/transaction/list.go
+++ b/cmd/transaction/list.go
@@ -121,7 +121,10 @@ func (r *listRunner) buildFilter() (model.TransactionFilter, error) {
 	var filter model.TransactionFilter
 
 	if r.flags.Status != "" {
-		s := model.ParseTransactionStatus(r.flags.Status)
+		s, err := model.ParseTransactionStatus(r.flags.Status)
+		if err != nil {
+			return filter, err
+		}
 		filter.Status = &s
 	}
 	if r.flags.Type != "" {

--- a/internal/model/transaction_filter.go
+++ b/internal/model/transaction_filter.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package model
+
+type TransactionFilter struct {
+	AccountID   *int64
+	Type        *TransactionType
+	Status      *TransactionStatus
+	StartTime   *int64
+	EndTime     *int64
+	Description *string
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -173,9 +173,15 @@ func ParseTransactionTypeLabel(s string) TransactionType {
 	return TxTypeTransfer
 }
 
-func ParseTransactionStatus(s string) TransactionStatus {
-	if strings.ToLower(s) == "pending" {
-		return StatusPending
+func ParseTransactionStatus(s string) (TransactionStatus, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "pending":
+		return StatusPending, nil
+	case "cleared":
+		return StatusCleared, nil
+	case "reconciled":
+		return StatusReconciled, nil
+	default:
+		return 0, fmt.Errorf("invalid transaction status %q: must be pending, cleared, or reconciled", s)
 	}
-	return StatusCleared
 }

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -81,22 +81,30 @@ func TestParseTransactionTypeLabel(t *testing.T) {
 
 func TestParseTransactionStatus(t *testing.T) {
 	tests := []struct {
-		input string
-		want  TransactionStatus
+		input   string
+		want    TransactionStatus
+		wantErr bool
 	}{
-		{"pending", StatusPending},
-		{"Pending", StatusPending},
-		{"PENDING", StatusPending},
-		{"cleared", StatusCleared},
-		{"Cleared", StatusCleared},
-		{"", StatusCleared},
-		{"anything", StatusCleared},
+		{"pending", StatusPending, false},
+		{"Pending", StatusPending, false},
+		{"PENDING", StatusPending, false},
+		{"cleared", StatusCleared, false},
+		{"Cleared", StatusCleared, false},
+		{"reconciled", StatusReconciled, false},
+		{"Reconciled", StatusReconciled, false},
+		{"", 0, true},
+		{"anything", 0, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := ParseTransactionStatus(tt.input)
-			assert.Equal(t, tt.want, got)
+			got, err := ParseTransactionStatus(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
 		})
 	}
 }

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -88,6 +88,12 @@ type TransactionRepository interface {
 	// id DESC. When opts.IncludeCount is true the result also carries the total
 	// distinct transaction count.
 	ListTransactionsByAccount(ctx context.Context, accountID int64, opts model.ListOptions) (*model.ListResult[*model.Transaction], error)
+
+	// FilterTransactions returns a paginated list of transactions matching the
+	// given filter criteria. Nil filter fields are ignored (no filtering on
+	// that dimension). When filter.AccountID is set the query joins on splits.
+	// Results are ordered by timestamp DESC, id DESC.
+	FilterTransactions(ctx context.Context, filter model.TransactionFilter, opts model.ListOptions) (*model.ListResult[*model.Transaction], error)
 }
 
 type Repository interface {

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/hance08/kea/internal/config"
 	"github.com/hance08/kea/internal/model"
@@ -256,6 +257,7 @@ type mockTransactionRepo struct {
 	// pagination support
 	listTxErr          error
 	listTxByAccountErr error
+	filterErr          error
 }
 
 func newMockTransactionRepo() *mockTransactionRepo {
@@ -564,6 +566,54 @@ func (m *mockTransactionRepo) ListTransactionsByAccount(_ context.Context, accou
 	result.Offset = offset
 	result.Items = matching[offset:end]
 	return result, nil
+}
+
+func (m *mockTransactionRepo) FilterTransactions(_ context.Context, filter model.TransactionFilter, opts model.ListOptions) (*model.ListResult[*model.Transaction], error) {
+	if m.filterErr != nil {
+		return nil, m.filterErr
+	}
+	var items []*model.Transaction
+	for _, tx := range m.transactions {
+		if filter.Type != nil && tx.Type != *filter.Type {
+			continue
+		}
+		if filter.Status != nil && tx.Status != *filter.Status {
+			continue
+		}
+		if filter.StartTime != nil && tx.Timestamp < *filter.StartTime {
+			continue
+		}
+		if filter.EndTime != nil && tx.Timestamp > *filter.EndTime {
+			continue
+		}
+		if filter.AccountID != nil {
+			found := false
+			for _, s := range m.splits[tx.ID] {
+				if s.AccountID == *filter.AccountID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+		if filter.Description != nil {
+			if !strings.Contains(strings.ToLower(tx.Description), strings.ToLower(*filter.Description)) {
+				continue
+			}
+		}
+		items = append(items, tx)
+	}
+	if items == nil {
+		items = []*model.Transaction{}
+	}
+	return &model.ListResult[*model.Transaction]{
+		Items:      items,
+		TotalCount: len(items),
+		Limit:      opts.Limit,
+		Offset:     opts.Offset,
+	}, nil
 }
 
 // ──────────────────────────────────────────────

--- a/internal/service/transaction_filter_test.go
+++ b/internal/service/transaction_filter_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hance08/kea/internal/model"
+)
+
+func TestFilterTransactions_Service(t *testing.T) {
+	t.Run("delegates to repo with filter", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		txRepo.addTransaction(&model.Transaction{ID: 1, Timestamp: 1000, Description: "Groceries", Status: model.StatusCleared, Type: model.TxTypeExpense}, nil)
+		txRepo.addTransaction(&model.Transaction{ID: 2, Timestamp: 2000, Description: "Salary", Status: model.StatusPending, Type: model.TxTypeIncome}, nil)
+
+		txType := model.TxTypeExpense
+		result, err := svc.FilterTransactions(context.Background(), model.TransactionFilter{Type: &txType}, model.ListOptions{Limit: 10})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Items) != 1 {
+			t.Errorf("expected 1 item, got %d", len(result.Items))
+		}
+		if result.Items[0].Description != "Groceries" {
+			t.Errorf("expected Groceries, got %s", result.Items[0].Description)
+		}
+	})
+
+	t.Run("repo error propagates", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		txRepo.filterErr = errors.New("db failure")
+
+		_, err := svc.FilterTransactions(context.Background(), model.TransactionFilter{}, model.ListOptions{Limit: 10})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestFilterTransactionsByAccountName(t *testing.T) {
+	t.Run("resolves account name and filters", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		accRepo.addAccount(&model.Account{ID: 5, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD"})
+
+		txRepo.addTransaction(&model.Transaction{ID: 1, Timestamp: 1000, Description: "ATM", Status: model.StatusCleared, Type: model.TxTypeExpense},
+			[]*model.Split{{ID: 1, TransactionID: 1, AccountID: 5, Amount: -1000, Currency: "USD"}})
+		txRepo.addTransaction(&model.Transaction{ID: 2, Timestamp: 2000, Description: "Salary", Status: model.StatusPending, Type: model.TxTypeIncome},
+			[]*model.Split{{ID: 2, TransactionID: 2, AccountID: 99, Amount: 5000, Currency: "USD"}})
+
+		result, err := svc.FilterTransactionsByAccountName(context.Background(), "Assets:Bank", model.TransactionFilter{}, model.ListOptions{Limit: 10})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Items) != 1 {
+			t.Errorf("expected 1 item, got %d", len(result.Items))
+		}
+	})
+
+	t.Run("unknown account returns error", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		_, err := svc.FilterTransactionsByAccountName(context.Background(), "Nonexistent", model.TransactionFilter{}, model.ListOptions{Limit: 10})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}

--- a/internal/service/transaction_service.go
+++ b/internal/service/transaction_service.go
@@ -127,6 +127,21 @@ func (ts *TransactionService) ListTransactionHistory(ctx context.Context, accoun
 	return ts.txRepo.ListTransactionsByAccount(ctx, account.ID, opts)
 }
 
+// FilterTransactions returns a paginated, multi-dimensionally filtered transaction list.
+func (ts *TransactionService) FilterTransactions(ctx context.Context, filter model.TransactionFilter, opts model.ListOptions) (*model.ListResult[*model.Transaction], error) {
+	return ts.txRepo.FilterTransactions(ctx, filter, opts)
+}
+
+// FilterTransactionsByAccountName resolves an account name to its ID, then delegates to FilterTransactions.
+func (ts *TransactionService) FilterTransactionsByAccountName(ctx context.Context, accountName string, filter model.TransactionFilter, opts model.ListOptions) (*model.ListResult[*model.Transaction], error) {
+	account, err := ts.accRepo.GetAccountByName(ctx, accountName)
+	if err != nil {
+		return nil, fmt.Errorf("account not found: %w", err)
+	}
+	filter.AccountID = &account.ID
+	return ts.txRepo.FilterTransactions(ctx, filter, opts)
+}
+
 // GetTransactionHistory retrieves transaction history for a specific account
 func (ts *TransactionService) GetTransactionHistory(ctx context.Context, accountName string, limit int) ([]*model.Transaction, error) {
 	// Get account by name

--- a/internal/store/sqlite_transaction.go
+++ b/internal/store/sqlite_transaction.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hance08/kea/internal/model"
 	sqlite "github.com/mattn/go-sqlite3"
@@ -573,4 +574,89 @@ func (s *Store) scanTransactions(rows *sql.Rows) ([]*model.Transaction, error) {
 	}
 
 	return transactions, nil
+}
+
+func (s *Store) FilterTransactions(ctx context.Context, filter model.TransactionFilter, opts model.ListOptions) (*model.ListResult[*model.Transaction], error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	opts = normalizeListOpts(opts)
+
+	needsJoin := filter.AccountID != nil
+
+	var whereClauses []string
+	var args []any
+
+	if filter.AccountID != nil {
+		whereClauses = append(whereClauses, "s.account_id = ?")
+		args = append(args, *filter.AccountID)
+	}
+	if filter.Type != nil {
+		whereClauses = append(whereClauses, "t.type = ?")
+		args = append(args, string(*filter.Type))
+	}
+	if filter.Status != nil {
+		whereClauses = append(whereClauses, "t.status = ?")
+		args = append(args, int(*filter.Status))
+	}
+	if filter.StartTime != nil {
+		whereClauses = append(whereClauses, "t.timestamp >= ?")
+		args = append(args, *filter.StartTime)
+	}
+	if filter.EndTime != nil {
+		whereClauses = append(whereClauses, "t.timestamp <= ?")
+		args = append(args, *filter.EndTime)
+	}
+	if filter.Description != nil {
+		whereClauses = append(whereClauses, "t.description LIKE ?")
+		args = append(args, "%"+*filter.Description+"%")
+	}
+
+	whereSQL := ""
+	if len(whereClauses) > 0 {
+		whereSQL = "WHERE " + strings.Join(whereClauses, " AND ")
+	}
+
+	fromSQL := "FROM transactions t"
+	selectDistinct := ""
+	countExpr := "COUNT(*)"
+	if needsJoin {
+		fromSQL = "FROM transactions t INNER JOIN splits s ON t.id = s.transaction_id"
+		selectDistinct = "DISTINCT "
+		countExpr = "COUNT(DISTINCT t.id)"
+	}
+
+	result := &model.ListResult[*model.Transaction]{
+		Limit:  opts.Limit,
+		Offset: opts.Offset,
+	}
+
+	if opts.IncludeCount {
+		countQuery := fmt.Sprintf("SELECT %s %s %s", countExpr, fromSQL, whereSQL)
+		if err := s.db.QueryRowContext(ctx, countQuery, args...).Scan(&result.TotalCount); err != nil {
+			return nil, fmt.Errorf("failed to count filtered transactions: %w", err)
+		}
+	}
+
+	query := fmt.Sprintf(
+		"SELECT %st.id, t.timestamp, t.description, t.status, t.external_id, t.type %s %s ORDER BY t.timestamp DESC, t.id DESC LIMIT ? OFFSET ?",
+		selectDistinct, fromSQL, whereSQL,
+	)
+	queryArgs := append(args, opts.Limit, opts.Offset)
+
+	rows, err := s.db.QueryContext(ctx, query, queryArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query filtered transactions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	items, err := s.scanTransactions(rows)
+	if err != nil {
+		return nil, err
+	}
+	if items == nil {
+		items = []*model.Transaction{}
+	}
+	result.Items = items
+	return result, nil
 }

--- a/internal/store/sqlite_transaction.go
+++ b/internal/store/sqlite_transaction.go
@@ -608,8 +608,9 @@ func (s *Store) FilterTransactions(ctx context.Context, filter model.Transaction
 		args = append(args, *filter.EndTime)
 	}
 	if filter.Description != nil {
-		whereClauses = append(whereClauses, "t.description LIKE ?")
-		args = append(args, "%"+*filter.Description+"%")
+		escaped := strings.NewReplacer("%", `\%`, "_", `\_`).Replace(*filter.Description)
+		whereClauses = append(whereClauses, `t.description LIKE ? ESCAPE '\'`)
+		args = append(args, "%"+escaped+"%")
 	}
 
 	whereSQL := ""

--- a/internal/store/sqlite_transaction_filter_test.go
+++ b/internal/store/sqlite_transaction_filter_test.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hance08/kea/internal/model"
+)
+
+func TestFilterTransactions(t *testing.T) {
+	s := setupTestDB(t)
+	ctx := context.Background()
+
+	// Seed accounts
+	accBank, _ := s.CreateAccount(ctx, "Assets:Bank", model.AccountTypeAsset, "USD", "", nil)
+	accFood, _ := s.CreateAccount(ctx, "Expenses:Food", model.AccountTypeExpense, "USD", "", nil)
+	accSalary, _ := s.CreateAccount(ctx, "Revenue:Salary", model.AccountTypeRevenue, "USD", "", nil)
+
+	// Seed transactions
+	// tx1: Expense, Cleared, timestamp 1000
+	s.CreateTransactionWithSplits(ctx, model.Transaction{
+		Timestamp: 1000, Description: "Groceries", Status: model.StatusCleared, Type: model.TxTypeExpense,
+	}, []model.Split{
+		{AccountID: accBank, Amount: -5000, Currency: "USD"},
+		{AccountID: accFood, Amount: 5000, Currency: "USD"},
+	})
+	// tx2: Income, Pending, timestamp 2000
+	s.CreateTransactionWithSplits(ctx, model.Transaction{
+		Timestamp: 2000, Description: "Paycheck Jan", Status: model.StatusPending, Type: model.TxTypeIncome,
+	}, []model.Split{
+		{AccountID: accBank, Amount: 100000, Currency: "USD"},
+		{AccountID: accSalary, Amount: -100000, Currency: "USD"},
+	})
+	// tx3: Expense, Cleared, timestamp 3000
+	s.CreateTransactionWithSplits(ctx, model.Transaction{
+		Timestamp: 3000, Description: "Restaurant dinner", Status: model.StatusCleared, Type: model.TxTypeExpense,
+	}, []model.Split{
+		{AccountID: accBank, Amount: -3000, Currency: "USD"},
+		{AccountID: accFood, Amount: 3000, Currency: "USD"},
+	})
+
+	t.Run("no filters returns all", func(t *testing.T) {
+		result, err := s.FilterTransactions(ctx, model.TransactionFilter{}, model.ListOptions{Limit: 10, IncludeCount: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.TotalCount != 3 {
+			t.Errorf("expected 3 total, got %d", result.TotalCount)
+		}
+		if len(result.Items) != 3 {
+			t.Errorf("expected 3 items, got %d", len(result.Items))
+		}
+	})
+
+	t.Run("filter by account", func(t *testing.T) {
+		result, err := s.FilterTransactions(ctx, model.TransactionFilter{AccountID: &accFood}, model.ListOptions{Limit: 10, IncludeCount: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.TotalCount != 2 {
+			t.Errorf("expected 2, got %d", result.TotalCount)
+		}
+	})
+
+	t.Run("filter by type", func(t *testing.T) {
+		txType := model.TxTypeIncome
+		result, err := s.FilterTransactions(ctx, model.TransactionFilter{Type: &txType}, model.ListOptions{Limit: 10, IncludeCount: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.TotalCount != 1 {
+			t.Errorf("expected 1, got %d", result.TotalCount)
+		}
+		if result.Items[0].Description != "Paycheck Jan" {
+			t.Errorf("expected Paycheck Jan, got %s", result.Items[0].Description)
+		}
+	})
+
+	t.Run("filter by status", func(t *testing.T) {
+		status := model.StatusCleared
+		result, err := s.FilterTransactions(ctx, model.TransactionFilter{Status: &status}, model.ListOptions{Limit: 10, IncludeCount: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.TotalCount != 2 {
+			t.Errorf("expected 2, got %d", result.TotalCount)
+		}
+	})
+
+	t.Run("filter by date range", func(t *testing.T) {
+		start := int64(1500)
+		end := int64(2500)
+		result, err := s.FilterTransactions(ctx, model.TransactionFilter{StartTime: &start, EndTime: &end}, model.ListOptions{Limit: 10, IncludeCount: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.TotalCount != 1 {
+			t.Errorf("expected 1, got %d", result.TotalCount)
+		}
+	})
+
+	t.Run("filter by description", func(t *testing.T) {
+		desc := "dinner"
+		result, err := s.FilterTransactions(ctx, model.TransactionFilter{Description: &desc}, model.ListOptions{Limit: 10, IncludeCount: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.TotalCount != 1 {
+			t.Errorf("expected 1, got %d", result.TotalCount)
+		}
+		if result.Items[0].Description != "Restaurant dinner" {
+			t.Errorf("expected Restaurant dinner, got %s", result.Items[0].Description)
+		}
+	})
+
+	t.Run("combined filters", func(t *testing.T) {
+		status := model.StatusCleared
+		txType := model.TxTypeExpense
+		result, err := s.FilterTransactions(ctx, model.TransactionFilter{
+			AccountID: &accFood,
+			Status:    &status,
+			Type:      &txType,
+		}, model.ListOptions{Limit: 10, IncludeCount: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.TotalCount != 2 {
+			t.Errorf("expected 2, got %d", result.TotalCount)
+		}
+	})
+
+	t.Run("pagination with filter", func(t *testing.T) {
+		status := model.StatusCleared
+		page1, err := s.FilterTransactions(ctx, model.TransactionFilter{Status: &status}, model.ListOptions{Limit: 1, Offset: 0, IncludeCount: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(page1.Items) != 1 {
+			t.Fatalf("expected 1 item, got %d", len(page1.Items))
+		}
+		if page1.TotalCount != 2 {
+			t.Errorf("expected total 2, got %d", page1.TotalCount)
+		}
+		if page1.Items[0].Timestamp != 3000 {
+			t.Errorf("expected timestamp 3000, got %d", page1.Items[0].Timestamp)
+		}
+
+		page2, err := s.FilterTransactions(ctx, model.TransactionFilter{Status: &status}, model.ListOptions{Limit: 1, Offset: 1, IncludeCount: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(page2.Items) != 1 {
+			t.Fatalf("expected 1 item, got %d", len(page2.Items))
+		}
+		if page2.Items[0].Timestamp != 1000 {
+			t.Errorf("expected timestamp 1000, got %d", page2.Items[0].Timestamp)
+		}
+	})
+
+	t.Run("no matches returns empty", func(t *testing.T) {
+		txType := model.TxTypeTransfer
+		result, err := s.FilterTransactions(ctx, model.TransactionFilter{Type: &txType}, model.ListOptions{Limit: 10, IncludeCount: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.TotalCount != 0 {
+			t.Errorf("expected 0, got %d", result.TotalCount)
+		}
+		if len(result.Items) != 0 {
+			t.Errorf("expected empty items, got %d", len(result.Items))
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Add `TransactionFilter` struct with optional fields for account, type, status, date range, and description text search
- Implement `FilterTransactions` in the store layer with dynamic SQL WHERE clause construction (joins splits table only when filtering by account)
- Add `FilterTransactions` and `FilterTransactionsByAccountName` service methods
- Update CLI `transaction list` command with `--status`, `--type`, `--from`, `--to`, and `--description` flags

Closes #114

## Test Plan
- [x] Store integration tests: 9 subtests covering each filter dimension, combined filters, pagination, and empty results
- [x] Service unit tests: filter delegation, error propagation, account name resolution
- [x] Full test suite passes (`go test ./... -count=1`)
- [x] `go vet ./...` clean
- [x] Manual: `kea transaction list --status cleared --type expense --from 2026-01-01`

🤖 Generated with [Claude Code](https://claude.com/claude-code)