### PR TITLE
feat: add account search with partial name matching

### DIFF
--- a/cmd/account/account.go
+++ b/cmd/account/account.go
@@ -20,6 +20,7 @@ func NewAccountCmd(svc *service.Service) *cobra.Command {
 	accountCmd.AddCommand(NewEditCmd(svc))
 	accountCmd.AddCommand(NewListCmd(svc))
 	accountCmd.AddCommand(NewDeleteCmd(svc))
+	accountCmd.AddCommand(NewSearchCmd(svc))
 
 	return accountCmd
 }

--- a/cmd/account/search.go
+++ b/cmd/account/search.go
@@ -56,7 +56,7 @@ Hidden accounts and system accounts are excluded from results.`,
 	}
 
 	cmd.Flags().StringVarP(&flags.Type, "type", "t", "", "Filter by account type (A, L, C, R, E)")
-	cmd.Flags().StringVarP(&flags.Currency, "currency", "c", "", "Filter by currency code")
+	cmd.Flags().StringVar(&flags.Currency, "currency", "", "Filter by currency code")
 	cmd.Flags().IntVarP(&flags.Limit, "limit", "n", 20, "Maximum number of results")
 	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output as JSON")
 

--- a/cmd/account/search.go
+++ b/cmd/account/search.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package account
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hance08/kea/internal/model"
+	"github.com/hance08/kea/internal/service"
+	"github.com/hance08/kea/ui/views"
+	"github.com/spf13/cobra"
+)
+
+type searchFlags struct {
+	Query    string
+	Type     string
+	Currency string
+	Limit    int
+	JSON     bool
+}
+
+type AccountSearchProvider interface {
+	SearchAccounts(ctx context.Context, filter model.AccountFilter, opts model.ListOptions) (*model.ListResult[*model.Account], error)
+	GetAccountBalance(ctx context.Context, id int64) (int64, error)
+	GetAccountBalanceFormatted(ctx context.Context, id int64) (string, error)
+}
+
+type searchRunner struct {
+	svc   AccountSearchProvider
+	flags *searchFlags
+}
+
+func NewSearchCmd(svc *service.Service) *cobra.Command {
+	flags := &searchFlags{}
+
+	cmd := &cobra.Command{
+		Use:     "search <query>",
+		Aliases: []string{"s", "find"},
+		Short:   "Search accounts by partial name match.",
+		Long: `Search for accounts whose name contains the given query string.
+The search is case-insensitive and matches anywhere in the account name.
+Hidden accounts and system accounts are excluded from results.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				flags.Query = args[0]
+			}
+			runner := &searchRunner{
+				svc:   svc.Account(),
+				flags: flags,
+			}
+			return runner.Run(cmd.Context())
+		},
+	}
+
+	cmd.Flags().StringVarP(&flags.Type, "type", "t", "", "Filter by account type (A, L, C, R, E)")
+	cmd.Flags().StringVarP(&flags.Currency, "currency", "c", "", "Filter by currency code")
+	cmd.Flags().IntVarP(&flags.Limit, "limit", "n", 20, "Maximum number of results")
+	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "Output as JSON")
+
+	return cmd
+}
+
+func (r *searchRunner) Run(ctx context.Context) error {
+	filter := model.AccountFilter{}
+	if r.flags.Query != "" {
+		filter.Query = &r.flags.Query
+	}
+	if r.flags.Type != "" {
+		at := model.AccountType(r.flags.Type)
+		filter.Type = &at
+	}
+	if r.flags.Currency != "" {
+		filter.Currency = &r.flags.Currency
+	}
+
+	opts := model.ListOptions{
+		Limit:        r.flags.Limit,
+		IncludeCount: true,
+	}
+
+	result, err := r.svc.SearchAccounts(ctx, filter, opts)
+	if err != nil {
+		return fmt.Errorf("failed to search accounts: %w", err)
+	}
+
+	if r.flags.JSON {
+		items := make([]views.JSONAccount, 0, len(result.Items))
+		for _, acc := range result.Items {
+			bal, err := r.svc.GetAccountBalance(ctx, acc.ID)
+			if err != nil {
+				return fmt.Errorf("failed to get balance for %s: %w", acc.Name, err)
+			}
+			items = append(items, views.ToJSONAccount(acc, bal))
+		}
+		return views.WriteJSON(items)
+	}
+
+	if len(result.Items) == 0 {
+		fmt.Println("No accounts found.")
+		return nil
+	}
+
+	return views.NewAccountListView().Render(result.Items, func(id int64) (string, error) {
+		return r.svc.GetAccountBalanceFormatted(ctx, id)
+	})
+}

--- a/cmd/account/search.go
+++ b/cmd/account/search.go
@@ -58,7 +58,7 @@ Hidden accounts and system accounts are excluded from results.`,
 	cmd.Flags().StringVarP(&flags.Type, "type", "t", "", "Filter by account type (A, L, C, R, E)")
 	cmd.Flags().StringVarP(&flags.Currency, "currency", "c", "", "Filter by currency code")
 	cmd.Flags().IntVarP(&flags.Limit, "limit", "n", 20, "Maximum number of results")
-	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "Output as JSON")
+	cmd.Flags().BoolVarP(&flags.JSON, "json", "j", false, "output as JSON")
 
 	return cmd
 }
@@ -70,6 +70,9 @@ func (r *searchRunner) Run(ctx context.Context) error {
 	}
 	if r.flags.Type != "" {
 		at := model.AccountType(r.flags.Type)
+		if !at.IsValid() {
+			return fmt.Errorf("invalid account type %q: must be one of A, L, C, R, E", r.flags.Type)
+		}
 		filter.Type = &at
 	}
 	if r.flags.Currency != "" {

--- a/internal/model/account_filter.go
+++ b/internal/model/account_filter.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package model
+
+type AccountFilter struct {
+	Query    *string
+	Type     *AccountType
+	Currency *string
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -23,6 +23,7 @@ type AccountRepository interface {
 	DeleteAccount(ctx context.Context, accountID int64) error
 	RenameAccount(ctx context.Context, oldName, newName string) error
 	UpdateAccountMetadata(ctx context.Context, accountID int64, description string, isHidden bool) error
+	SearchAccounts(ctx context.Context, filter model.AccountFilter, opts model.ListOptions) (*model.ListResult[*model.Account], error)
 }
 
 type TransactionRepository interface {

--- a/internal/service/account_search_test.go
+++ b/internal/service/account_search_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hance08/kea/internal/model"
+)
+
+func TestSearchAccounts(t *testing.T) {
+	t.Run("filters by query substring", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		svc := newTestAccountService(accRepo, txRepo)
+
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank:Checking", Type: model.AccountTypeAsset, Currency: "USD"})
+		accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Bank:Savings", Type: model.AccountTypeAsset, Currency: "USD"})
+		accRepo.addAccount(&model.Account{ID: 3, Name: "Expenses:Food", Type: model.AccountTypeExpense, Currency: "USD"})
+
+		query := "Bank"
+		result, err := svc.SearchAccounts(context.Background(), model.AccountFilter{Query: &query}, model.ListOptions{Limit: 10})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Items) != 2 {
+			t.Fatalf("expected 2 results, got %d", len(result.Items))
+		}
+	})
+
+	t.Run("filters hidden and system accounts by default", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		svc := newTestAccountService(accRepo, txRepo)
+
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank:Checking", Type: model.AccountTypeAsset, Currency: "USD"})
+		accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Hidden", Type: model.AccountTypeAsset, Currency: "USD", IsHidden: true})
+		accRepo.addAccount(&model.Account{ID: 3, Name: "Equity:OpeningBalances_USD", Type: model.AccountTypeEquity, Currency: "USD"})
+
+		query := ""
+		result, err := svc.SearchAccounts(context.Background(), model.AccountFilter{Query: &query}, model.ListOptions{Limit: 10})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Items) != 1 {
+			t.Fatalf("expected 1 result (hidden and system excluded), got %d", len(result.Items))
+		}
+		if result.Items[0].Name != "Assets:Bank:Checking" {
+			t.Fatalf("expected Assets:Bank:Checking, got %s", result.Items[0].Name)
+		}
+	})
+
+	t.Run("returns repo error", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		svc := newTestAccountService(accRepo, txRepo)
+		accRepo.searchErr = errors.New("db error")
+
+		result, err := svc.SearchAccounts(context.Background(), model.AccountFilter{}, model.ListOptions{Limit: 10})
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if result != nil {
+			t.Fatalf("expected nil result on error")
+		}
+	})
+}

--- a/internal/service/account_service.go
+++ b/internal/service/account_service.go
@@ -146,20 +146,7 @@ func (as *AccountService) ValidateSelectableAccount(ctx context.Context, name st
 }
 
 func (as *AccountService) SearchAccounts(ctx context.Context, filter model.AccountFilter, opts model.ListOptions) (*model.ListResult[*model.Account], error) {
-	result, err := as.repo.SearchAccounts(ctx, filter, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	filtered := make([]*model.Account, 0, len(result.Items))
-	for _, acc := range result.Items {
-		if acc.IsHidden || model.IsOpeningBalancesAccount(acc.Name) {
-			continue
-		}
-		filtered = append(filtered, acc)
-	}
-	result.Items = filtered
-	return result, nil
+	return as.repo.SearchAccounts(ctx, filter, opts)
 }
 
 func (as *AccountService) UpdateAccountMetadata(ctx context.Context, accountID int64, description string, isHidden bool) (*model.Account, error) {

--- a/internal/service/account_service.go
+++ b/internal/service/account_service.go
@@ -145,6 +145,23 @@ func (as *AccountService) ValidateSelectableAccount(ctx context.Context, name st
 	return nil
 }
 
+func (as *AccountService) SearchAccounts(ctx context.Context, filter model.AccountFilter, opts model.ListOptions) (*model.ListResult[*model.Account], error) {
+	result, err := as.repo.SearchAccounts(ctx, filter, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make([]*model.Account, 0, len(result.Items))
+	for _, acc := range result.Items {
+		if acc.IsHidden || model.IsOpeningBalancesAccount(acc.Name) {
+			continue
+		}
+		filtered = append(filtered, acc)
+	}
+	result.Items = filtered
+	return result, nil
+}
+
 func (as *AccountService) UpdateAccountMetadata(ctx context.Context, accountID int64, description string, isHidden bool) (*model.Account, error) {
 	acc, err := as.repo.GetAccountByID(ctx, accountID)
 	if err != nil {

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -219,7 +219,13 @@ func (m *mockAccountRepo) SearchAccounts(_ context.Context, filter model.Account
 	}
 	var items []*model.Account
 	for _, acc := range m.accountsByID {
-		if filter.Query != nil && !strings.Contains(strings.ToLower(acc.Name), strings.ToLower(*filter.Query)) {
+		if acc.IsHidden {
+			continue
+		}
+		if model.IsOpeningBalancesAccount(acc.Name) {
+			continue
+		}
+		if filter.Query != nil && *filter.Query != "" && !strings.Contains(strings.ToLower(acc.Name), strings.ToLower(*filter.Query)) {
 			continue
 		}
 		if filter.Type != nil && acc.Type != *filter.Type {

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -46,6 +46,7 @@ type mockAccountRepo struct {
 		isHidden    bool
 	}
 	updateMetadataErr error
+	searchErr         error
 }
 
 func newMockAccountRepo() *mockAccountRepo {
@@ -202,6 +203,48 @@ func (m *mockAccountRepo) UpdateAccountMetadata(_ context.Context, accountID int
 	acc.Description = description
 	acc.IsHidden = isHidden
 	return nil
+}
+
+func (m *mockAccountRepo) SearchAccounts(_ context.Context, filter model.AccountFilter, opts model.ListOptions) (*model.ListResult[*model.Account], error) {
+	if m.searchErr != nil {
+		return nil, m.searchErr
+	}
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	offset := opts.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	var items []*model.Account
+	for _, acc := range m.accountsByID {
+		if filter.Query != nil && !strings.Contains(strings.ToLower(acc.Name), strings.ToLower(*filter.Query)) {
+			continue
+		}
+		if filter.Type != nil && acc.Type != *filter.Type {
+			continue
+		}
+		if filter.Currency != nil && acc.Currency != *filter.Currency {
+			continue
+		}
+		items = append(items, acc)
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+	total := len(items)
+	if offset > len(items) {
+		offset = len(items)
+	}
+	end := offset + limit
+	if end > len(items) {
+		end = len(items)
+	}
+	return &model.ListResult[*model.Account]{
+		Items:      items[offset:end],
+		TotalCount: total,
+		Limit:      limit,
+		Offset:     offset,
+	}, nil
 }
 
 // ──────────────────────────────────────────────

--- a/internal/store/sqlite_account.go
+++ b/internal/store/sqlite_account.go
@@ -349,10 +349,10 @@ func (s *Store) SearchAccounts(ctx context.Context, filter model.AccountFilter, 
 	var whereClauses []string
 	var args []any
 
-	if filter.Query != nil {
+	if filter.Query != nil && *filter.Query != "" {
 		escaped := strings.NewReplacer("%", `\%`, "_", `\_`).Replace(*filter.Query)
-		whereClauses = append(whereClauses, `LOWER(name) LIKE '%' || LOWER(?) || '%' ESCAPE '\'`)
-		args = append(args, escaped)
+		whereClauses = append(whereClauses, `name LIKE ? ESCAPE '\'`)
+		args = append(args, "%"+escaped+"%")
 	}
 	if filter.Type != nil {
 		whereClauses = append(whereClauses, "type = ?")
@@ -362,6 +362,8 @@ func (s *Store) SearchAccounts(ctx context.Context, filter model.AccountFilter, 
 		whereClauses = append(whereClauses, "currency = ?")
 		args = append(args, *filter.Currency)
 	}
+	whereClauses = append(whereClauses, "is_hidden = 0")
+	whereClauses = append(whereClauses, "name NOT LIKE 'Equity:OpeningBalances_%'")
 
 	whereSQL := ""
 	if len(whereClauses) > 0 {

--- a/internal/store/sqlite_account.go
+++ b/internal/store/sqlite_account.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hance08/kea/internal/model"
 	sqlite "github.com/mattn/go-sqlite3"
@@ -337,4 +338,67 @@ func (s *Store) UpdateAccountMetadata(ctx context.Context, accountID int64, desc
 		return fmt.Errorf("account with ID %d not found: %w", accountID, ErrRecordNotFound)
 	}
 	return nil
+}
+
+func (s *Store) SearchAccounts(ctx context.Context, filter model.AccountFilter, opts model.ListOptions) (*model.ListResult[*model.Account], error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	opts = normalizeListOpts(opts)
+
+	var whereClauses []string
+	var args []any
+
+	if filter.Query != nil {
+		escaped := strings.NewReplacer("%", `\%`, "_", `\_`).Replace(*filter.Query)
+		whereClauses = append(whereClauses, `LOWER(name) LIKE '%' || LOWER(?) || '%' ESCAPE '\'`)
+		args = append(args, escaped)
+	}
+	if filter.Type != nil {
+		whereClauses = append(whereClauses, "type = ?")
+		args = append(args, string(*filter.Type))
+	}
+	if filter.Currency != nil {
+		whereClauses = append(whereClauses, "currency = ?")
+		args = append(args, *filter.Currency)
+	}
+
+	whereSQL := ""
+	if len(whereClauses) > 0 {
+		whereSQL = "WHERE " + strings.Join(whereClauses, " AND ")
+	}
+
+	result := &model.ListResult[*model.Account]{
+		Limit:  opts.Limit,
+		Offset: opts.Offset,
+	}
+
+	if opts.IncludeCount {
+		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM accounts %s", whereSQL)
+		if err := s.db.QueryRowContext(ctx, countQuery, args...).Scan(&result.TotalCount); err != nil {
+			return nil, fmt.Errorf("failed to count search results: %w", err)
+		}
+	}
+
+	query := fmt.Sprintf(
+		"SELECT id, name, type, parent_id, currency, description, is_hidden FROM accounts %s ORDER BY name LIMIT ? OFFSET ?",
+		whereSQL,
+	)
+	queryArgs := append(args, opts.Limit, opts.Offset)
+
+	rows, err := s.db.QueryContext(ctx, query, queryArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search accounts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	items, err := s.scanAccounts(rows)
+	if err != nil {
+		return nil, err
+	}
+	if items == nil {
+		items = []*model.Account{}
+	}
+	result.Items = items
+	return result, nil
 }


### PR DESCRIPTION
## Summary
- Adds `SearchAccounts` method through the full stack (model → repository → store → service → CLI) to support partial-name account lookup with pagination
- Case-insensitive substring matching via SQL `LIKE`, with optional type and currency filters
- Hidden accounts and system accounts (`Equity:OpeningBalances_*`) are excluded at the SQL layer so `TotalCount` stays accurate for pagination
- New `kea account search <query>` command with `--type`, `--currency`, `--limit`, `--json` flags

Closes #115

## Test plan
- [x] Service-layer tests: query substring filtering, hidden/system exclusion, error propagation
- [x] Full test suite passes (`go test ./...`)
- [x] Build passes (`make build`)
- [x] Manual smoke test: `kea account search Bank`, `kea account search --type A --json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)