### PR TITLE
feat(config): add ServerConfig with host, port, CORS origins

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -348,9 +348,10 @@ func expandPath(path string) (string, error) {
 }
 
 func setServerDefaults(v *viper.Viper) {
-	v.SetDefault("server.host", "localhost")
-	v.SetDefault("server.port", 8080)
-	v.SetDefault("server.cors_origins", []string{"http://localhost:5173"})
+	def := config.NewDefault()
+	v.SetDefault("server.host", def.Server.Host)
+	v.SetDefault("server.port", def.Server.Port)
+	v.SetDefault("server.cors_origins", def.Server.CORSOrigins)
 }
 
 func createDefaultConfig(appDir string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -284,6 +284,8 @@ func initConfig(cfgFile string) (*config.Config, error) {
 		}
 	}
 
+	setServerDefaults(viper.GetViper())
+
 	viper.SetEnvPrefix("KEA")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv() // allow using environment variables to override
@@ -343,6 +345,12 @@ func expandPath(path string) (string, error) {
 		return "", fmt.Errorf("unsupported path format %q: ~username syntax is not supported, use an absolute path or ~/", path)
 	}
 	return path, nil
+}
+
+func setServerDefaults(v *viper.Viper) {
+	v.SetDefault("server.host", "localhost")
+	v.SetDefault("server.port", 8080)
+	v.SetDefault("server.cors_origins", []string{"http://localhost:5173"})
 }
 
 func createDefaultConfig(appDir string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,15 @@ database:
 defaults:
   # Default currency code (ISO 4217), e.g. USD, TWD, JPY, EUR
   currency: ""
+
+server:
+  # Host to bind the web server to
+  host: "localhost"
+  # Port to listen on
+  port: 8080
+  # Allowed CORS origins
+  cors_origins:
+    - "http://localhost:5173"
 `
 
 func Execute(migrations fs.FS) {

--- a/cmd/root_server_config_test.go
+++ b/cmd/root_server_config_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestInitConfig_ServerDefaults(t *testing.T) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+
+	setServerDefaults(v)
+
+	if v.GetString("server.host") != "localhost" {
+		t.Errorf("expected server.host %q, got %q", "localhost", v.GetString("server.host"))
+	}
+	if v.GetInt("server.port") != 8080 {
+		t.Errorf("expected server.port %d, got %d", 8080, v.GetInt("server.port"))
+	}
+	origins := v.GetStringSlice("server.cors_origins")
+	if len(origins) != 1 || origins[0] != "http://localhost:5173" {
+		t.Errorf("expected server.cors_origins [http://localhost:5173], got %v", origins)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,8 +6,15 @@ package config
 type Config struct {
 	Database     DatabaseConfig `mapstructure:"database"`
 	Defaults     DefaultsConfig `mapstructure:"defaults"`
+	Server       ServerConfig   `mapstructure:"server"`
 	ConfigPath   string         `mapstructure:"-"`
 	ActiveLedger string         `mapstructure:"-"` // name of the active ledger, set at startup
+}
+
+type ServerConfig struct {
+	Host        string   `mapstructure:"host"`
+	Port        int      `mapstructure:"port"`
+	CORSOrigins []string `mapstructure:"cors_origins"`
 }
 
 type DatabaseConfig struct {
@@ -22,5 +29,10 @@ func NewDefault() *Config {
 	return &Config{
 		Database: DatabaseConfig{Path: ""},
 		Defaults: DefaultsConfig{},
+		Server: ServerConfig{
+			Host:        "localhost",
+			Port:        8080,
+			CORSOrigins: []string{"http://localhost:5173"},
+		},
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,17 @@
+package config
+
+import "testing"
+
+func TestNewDefault_ServerConfig(t *testing.T) {
+	cfg := NewDefault()
+
+	if cfg.Server.Host != "localhost" {
+		t.Errorf("expected default host %q, got %q", "localhost", cfg.Server.Host)
+	}
+	if cfg.Server.Port != 8080 {
+		t.Errorf("expected default port %d, got %d", 8080, cfg.Server.Port)
+	}
+	if len(cfg.Server.CORSOrigins) != 1 || cfg.Server.CORSOrigins[0] != "http://localhost:5173" {
+		t.Errorf("expected default CORS origins [http://localhost:5173], got %v", cfg.Server.CORSOrigins)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
 package config
 
 import "testing"


### PR DESCRIPTION
## Summary
- Add `ServerConfig` struct (host, port, CORS origins) to `Config` with defaults: `localhost:8080`, CORS `["http://localhost:5173"]`
- Wire Viper defaults derived from `config.NewDefault()` so env vars (`KEA_SERVER_HOST`, `KEA_SERVER_PORT`, `KEA_SERVER_CORS_ORIGINS`) work automatically
- Update default config template with documented server section

Closes #117

## Test Plan
- [x] `TestNewDefault_ServerConfig` verifies struct defaults
- [x] `TestInitConfig_ServerDefaults` verifies Viper defaults
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)