### PR TITLE
fix: remove SystemTransactionID to unblock normal transaction ID 1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ migrations/       golang-migrate SQL files embedded via FS
 - Asset account: asset split = +amount, equity split = -amount
 - Liability account: liability split = -amount, equity split = +amount
 
-**Protected records:** Transaction ID 1 (`model.SystemTransactionID`) and reconciled transactions are immutable. Operations on them return `ErrNotEditable` or `ErrReconciled` (both wrapped with `%w` — check with `errors.Is`).
+**Protected records:** Reconciled transactions are immutable. Operations on them return `ErrReconciled` (wrapped with `%w` — check with `errors.Is`).
 
 **System account:** per-currency, named `Equity:OpeningBalances_<CCY>` (e.g. `Equity:OpeningBalances_USD`). Use `model.OpeningBalancesAccountName(currency)` to build the name and `model.IsOpeningBalancesAccount(name)` to detect one. The legacy single name `Equity:OpeningBalances` is auto-renamed at startup by `migrateLegacySysAcc` (`cmd/root.go`). System accounts must not be deleted.
 

--- a/cmd/transaction/edit.go
+++ b/cmd/transaction/edit.go
@@ -57,8 +57,6 @@ func (r *editRunner) Run(ctx context.Context, args []string) error {
 	isEditable, reason := r.txSvc.IsEditable(detail)
 	if !isEditable {
 		switch reason {
-		case service.NotEditableSystemTx:
-			r.view.ShowWarning("This transaction cannot be edited (System Transaction)")
 		case service.NotEditableReconciled:
 			r.view.ShowWarning("This transaction cannot be edited (Reconciled Transaction)")
 		}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -150,9 +150,8 @@ const (
 )
 
 const (
-	DateFormat                = "2006-01-02"
-	SystemTransactionID int64 = 1
-	MinSplitsCount            = 2
+	DateFormat  = "2006-01-02"
+	MinSplitsCount = 2
 
 	LegacyOpeningBalancesName = "Equity:OpeningBalances"
 )

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -209,10 +209,6 @@ func (ts *TransactionService) CreateTransactionFromSplits(
 
 // DeleteTransaction deletes a transaction
 func (ts *TransactionService) DeleteTransaction(ctx context.Context, txID int64) error {
-	if txID == model.SystemTransactionID {
-		return fmt.Errorf("cannot delete the initial opening transaction: %w", ErrNotEditable)
-	}
-
 	tx, err := ts.txRepo.GetTransactionByID(ctx, txID)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
@@ -236,10 +232,6 @@ func (ts *TransactionService) UpdateTransactionStatus(ctx context.Context, txID 
 		return validationErrorf("status", "invalid status: must be 0 (Pending) or 1 (Cleared)")
 	}
 
-	if txID == model.SystemTransactionID {
-		return fmt.Errorf("transaction #%d cannot be modified: %w", txID, ErrNotEditable)
-	}
-
 	oldTx, err := ts.txRepo.GetTransactionByID(ctx, txID)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
@@ -260,10 +252,6 @@ func (ts *TransactionService) UpdateTransactionStatus(ctx context.Context, txID 
 func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, input model.UpdateTransactionInput) error {
 	if input.Status != model.StatusPending && input.Status != model.StatusCleared {
 		return validationErrorf("status", "invalid status: must be Pending or Cleared")
-	}
-
-	if input.ID == model.SystemTransactionID {
-		return fmt.Errorf("cannot modify the initial opening transaction: %w", ErrNotEditable)
 	}
 
 	oldTx, err := ts.txRepo.GetTransactionByID(ctx, input.ID)
@@ -387,19 +375,13 @@ type NotEditableReason int
 
 const (
 	EditableOK            NotEditableReason = 0 // transaction may be edited
-	NotEditableSystemTx   NotEditableReason = 1 // opening-balance system transaction
-	NotEditableReconciled NotEditableReason = 2 // already reconciled
+	NotEditableReconciled NotEditableReason = 1 // already reconciled
 )
 
 func (ts *TransactionService) IsEditable(detail *model.TransactionDetail) (bool, NotEditableReason) {
-	if detail.ID == model.SystemTransactionID {
-		return false, NotEditableSystemTx
-	}
-
 	if detail.Status == model.StatusReconciled {
 		return false, NotEditableReconciled
 	}
-
 	return true, EditableOK
 }
 

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -425,11 +425,13 @@ func TestDeleteTransaction(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("opening balance transaction (ID=1) rejected", func(t *testing.T) {
-		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		err := svc.DeleteTransaction(context.Background(), model.SystemTransactionID)
-		require.Error(t, err)
-		assert.True(t, errors.Is(err, ErrNotEditable), "expected ErrNotEditable, got: %v", err)
+	t.Run("transaction ID=1 is deletable when not reconciled", func(t *testing.T) {
+		txRepo := newMockTransactionRepo()
+		txRepo.addTransaction(&model.Transaction{ID: 1, Status: model.StatusCleared}, nil)
+		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
+
+		err := svc.DeleteTransaction(context.Background(), 1)
+		require.NoError(t, err)
 	})
 
 	t.Run("non-existent transaction returns ErrNotFound", func(t *testing.T) {
@@ -515,11 +517,14 @@ func TestUpdateTransactionStatus(t *testing.T) {
 		assert.True(t, errors.Is(err, ErrReconciled))
 	})
 
-	t.Run("system transaction (ID=1) rejected", func(t *testing.T) {
-		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
-		err := svc.UpdateTransactionStatus(context.Background(), model.SystemTransactionID, model.StatusCleared)
-		require.Error(t, err)
-		assert.True(t, errors.Is(err, ErrNotEditable), "expected ErrNotEditable, got: %v", err)
+	t.Run("transaction ID=1 status can be updated", func(t *testing.T) {
+		txRepo := newMockTransactionRepo()
+		txRepo.addTransaction(&model.Transaction{ID: 1, Status: model.StatusPending}, nil)
+		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
+
+		err := svc.UpdateTransactionStatus(context.Background(), 1, model.StatusCleared)
+		require.NoError(t, err)
+		assert.Equal(t, model.StatusCleared, txRepo.transactions[1].Status)
 	})
 
 	t.Run("non-existent transaction returns ErrNotFound", func(t *testing.T) {
@@ -906,15 +911,8 @@ func TestIsEditable(t *testing.T) {
 		assert.Equal(t, EditableOK, reason)
 	})
 
-	t.Run("opening balance transaction (ID=1) is not editable", func(t *testing.T) {
-		detail := &model.TransactionDetail{ID: model.SystemTransactionID}
-		editable, reason := svc.IsEditable(detail)
-		assert.False(t, editable)
-		assert.Equal(t, NotEditableSystemTx, reason)
-	})
-
-	t.Run("ID=2 is editable", func(t *testing.T) {
-		detail := &model.TransactionDetail{ID: 2}
+	t.Run("transaction ID=1 is editable", func(t *testing.T) {
+		detail := &model.TransactionDetail{ID: 1}
 		editable, reason := svc.IsEditable(detail)
 		assert.True(t, editable)
 		assert.Equal(t, EditableOK, reason)


### PR DESCRIPTION
## Summary
- Remove the hardcoded `SystemTransactionID = 1` constant from `model/types.go` and all ID-based guard checks in `DeleteTransaction`, `UpdateTransactionStatus`, `UpdateTransactionComplete`, and `IsEditable`
- Opening-balance transactions are no longer special — only reconciliation status protects transactions from modification
- Update CLAUDE.md to reflect the new domain rules

Fixes #152

## Test Plan
- [x] Rewritten tests verify transaction ID=1 is deletable, status-updatable, and editable
- [x] Reconciled transaction protection remains intact
- [x] Full test suite passes (`go test ./...`)
- [x] Binary builds successfully (`make build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)