### PR TITLE
fix: resolve split account types from repo, never trust caller (#153)

### DIFF
--- a/docs/superpowers/plans/2026-05-20-split-type-trust-boundary.md
+++ b/docs/superpowers/plans/2026-05-20-split-type-trust-boundary.md
@@ -1,0 +1,324 @@
+# Split Type Trust Boundary Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make all account-type resolution in `TransactionService` use the repository as the source of truth, never trusting caller-supplied `SplitDetail.AccountType`.
+
+**Architecture:** Extract a shared `resolveAccountType` helper that resolves by `AccountID` or `AccountName` from the repo. Replace the four inline `resolveType` closures in `transaction_classifier.go` with this helper. Update existing tests to provide accounts in the mock repo since the `AccountType` field is no longer read.
+
+**Tech Stack:** Go, testify (assert/require)
+
+---
+
+### Task 1: Add `resolveAccountType` helper and update `ValidateSplitsMatchType`
+
+**Files:**
+- Modify: `internal/service/transaction_classifier.go:318-328`
+
+- [ ] **Step 1: Write the `resolveAccountType` method**
+
+Add this method above `ValidateSplitsMatchType` in `internal/service/transaction_classifier.go`:
+
+```go
+func (ts *TransactionService) resolveAccountType(ctx context.Context, s model.SplitDetail) (model.AccountType, error) {
+	if s.AccountID > 0 {
+		acc, err := ts.accRepo.GetAccountByID(ctx, s.AccountID)
+		if err != nil {
+			return "", err
+		}
+		return acc.Type, nil
+	}
+	if s.AccountName != "" {
+		acc, err := ts.accRepo.GetAccountByName(ctx, s.AccountName)
+		if err != nil {
+			return "", err
+		}
+		return acc.Type, nil
+	}
+	return "", fmt.Errorf("split has neither AccountID nor AccountName")
+}
+```
+
+- [ ] **Step 2: Replace the `resolveType` closure in `ValidateSplitsMatchType`**
+
+In `ValidateSplitsMatchType` (line ~318), remove the inline `resolveType` closure (lines 319-328) and replace all calls to `resolveType(s)` with `ts.resolveAccountType(ctx, s)`.
+
+The function should look like:
+
+```go
+func (ts *TransactionService) ValidateSplitsMatchType(ctx context.Context, txType model.TransactionType, splits []model.SplitDetail) error {
+	switch txType {
+	case model.TxTypeOpening, model.TxTypeOther, model.TxTypeDeposit, model.TxTypeWithdrawal:
+		return nil
+
+	case model.TxTypeExpense:
+		var hasExpense, hasAssetOrLiab bool
+		for _, s := range splits {
+			accType, err := ts.resolveAccountType(ctx, s)
+			if err != nil {
+				return err
+			}
+			// ... rest unchanged
+```
+
+- [ ] **Step 3: Verify build compiles**
+
+Run: `cd /Users/hance/programming/kea && go build ./...`
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/service/transaction_classifier.go
+git commit -m "refactor: extract resolveAccountType and update ValidateSplitsMatchType (#153)"
+```
+
+---
+
+### Task 2: Update `DetermineType`, `GetDisplayAccount`, and `GetDisplayOffsetAccount`
+
+**Files:**
+- Modify: `internal/service/transaction_classifier.go:14-41` (DetermineType)
+- Modify: `internal/service/transaction_classifier.go:109-128` (GetDisplayAccount)
+- Modify: `internal/service/transaction_classifier.go:202-217` (GetDisplayOffsetAccount)
+
+- [ ] **Step 1: Update `DetermineType`**
+
+Replace the inline resolution block (lines 34-41):
+
+```go
+		accType := split.AccountType
+		if accType == "" {
+			acc, err := ts.accRepo.GetAccountByID(ctx, split.AccountID)
+			if err != nil {
+				return model.TxTypeOther, err
+			}
+			accType = acc.Type
+		}
+```
+
+With:
+
+```go
+		accType, err := ts.resolveAccountType(ctx, split)
+		if err != nil {
+			return model.TxTypeOther, err
+		}
+```
+
+- [ ] **Step 2: Update `GetDisplayAccount`**
+
+Remove the inline `resolveType` closure (lines 114-122) and replace all `resolveType(split)` calls with `ts.resolveAccountType(ctx, split)`.
+
+- [ ] **Step 3: Update `GetDisplayOffsetAccount`**
+
+Remove the inline `resolveAccountType` closure (lines 207-216) and replace all `resolveAccountType(split)` calls with `ts.resolveAccountType(ctx, split)`.
+
+- [ ] **Step 4: Verify build compiles**
+
+Run: `cd /Users/hance/programming/kea && go build ./...`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/transaction_classifier.go
+git commit -m "refactor: use resolveAccountType in DetermineType and display helpers (#153)"
+```
+
+---
+
+### Task 3: Fix existing tests to provide accounts in mock repos
+
+After the changes, existing tests that rely on `SplitDetail.AccountType` being trusted will fail because the resolver now queries the repo. Tests that use the `split()` helper with an empty mock repo need accounts added.
+
+**Files:**
+- Modify: `internal/service/transaction_classifier_test.go`
+
+- [ ] **Step 1: Create a shared test helper that builds a mock repo with standard accounts**
+
+Add a helper function near the top of `transaction_classifier_test.go` (after the existing `split`/`splitWithMemo` helpers):
+
+```go
+func classifierAccRepo() *mockAccountRepo {
+	repo := newMockAccountRepo()
+	repo.addAccount(&model.Account{ID: 1, Name: "Expenses:Food", Type: model.AccountTypeExpense})
+	repo.addAccount(&model.Account{ID: 2, Name: "Assets:Bank", Type: model.AccountTypeAsset})
+	repo.addAccount(&model.Account{ID: 3, Name: "Revenue:Salary", Type: model.AccountTypeRevenue})
+	repo.addAccount(&model.Account{ID: 4, Name: "Liabilities:Card", Type: model.AccountTypeLiability})
+	repo.addAccount(&model.Account{ID: 5, Name: model.OpeningBalancesAccountName("USD"), Type: model.AccountTypeEquity})
+	repo.addAccount(&model.Account{ID: 6, Name: "Assets:Cash", Type: model.AccountTypeAsset})
+	repo.addAccount(&model.Account{ID: 7, Name: "Assets:Savings", Type: model.AccountTypeAsset})
+	repo.addAccount(&model.Account{ID: 8, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	repo.addAccount(&model.Account{ID: 9, Name: "Equity:Retained", Type: model.AccountTypeEquity})
+	repo.addAccount(&model.Account{ID: 10, Name: "Expenses:Drink", Type: model.AccountTypeExpense})
+	repo.addAccount(&model.Account{ID: 11, Name: "Revenue:Bonus", Type: model.AccountTypeRevenue})
+	repo.addAccount(&model.Account{ID: 12, Name: "Expenses:Tax", Type: model.AccountTypeExpense})
+	repo.addAccount(&model.Account{ID: 13, Name: "Expenses:A", Type: model.AccountTypeExpense})
+	repo.addAccount(&model.Account{ID: 14, Name: "Expenses:B", Type: model.AccountTypeExpense})
+	repo.addAccount(&model.Account{ID: 15, Name: "Assets:Investments:00878", Type: model.AccountTypeAsset})
+	repo.addAccount(&model.Account{ID: 16, Name: "Expenses:Fees:Stocks", Type: model.AccountTypeExpense})
+	repo.addAccount(&model.Account{ID: 17, Name: "Assets:Bank:DAWHO", Type: model.AccountTypeAsset})
+	repo.addAccount(&model.Account{ID: 18, Name: "Expenses:Food:Drink", Type: model.AccountTypeExpense})
+	repo.addAccount(&model.Account{ID: 19, Name: "Assets:Receivable:Friends", Type: model.AccountTypeAsset})
+	repo.addAccount(&model.Account{ID: 20, Name: "Assets:Ewallet:LinePayMoney", Type: model.AccountTypeAsset})
+	repo.addAccount(&model.Account{ID: 21, Name: model.OpeningBalancesAccountName("TWD"), Type: model.AccountTypeEquity})
+	repo.addAccount(&model.Account{ID: 22, Name: "Assets:Card", Type: model.AccountTypeAsset})
+	return repo
+}
+```
+
+- [ ] **Step 2: Update `TestDetermineType` to use `classifierAccRepo()`**
+
+Change line:
+```go
+svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
+```
+To:
+```go
+svc := newTestTransactionService(classifierAccRepo(), newMockTransactionRepo())
+```
+
+- [ ] **Step 3: Update `TestValidateSplitsMatchType` to use `classifierAccRepo()`**
+
+Same change — replace `newMockAccountRepo()` with `classifierAccRepo()`.
+
+- [ ] **Step 4: Update `TestGetDisplayOffsetAccount` subtests that use inline `AccountType`**
+
+The subtests "Expense: single offset", "Expense: multiple offsets", "Transfer: excludes primary", and "no offset accounts" create an empty mock and rely on `AccountType`. Update each to use `classifierAccRepo()` and remove the `AccountType` field from splits (or leave it — it's now ignored, but removing it makes the test clearer).
+
+For example, the first subtest becomes:
+```go
+t.Run("Expense: single offset (asset account)", func(t *testing.T) {
+    svc := newTestTransactionService(classifierAccRepo(), newMockTransactionRepo())
+    splits := []model.SplitDetail{
+        {AccountName: "Expenses:Food", Amount: 500},
+        {AccountName: "Assets:Cash", Amount: -500},
+    }
+    got, err := svc.GetDisplayOffsetAccount(context.Background(), splits, "Expense", "Expenses:Food")
+    require.NoError(t, err)
+    assert.Equal(t, "Assets:Cash", got)
+})
+```
+
+- [ ] **Step 5: Update `TestBuildTransactionListItems` tests**
+
+The `TestBuildTransactionListItems`, `TestBuildTransactionListItems_MultipleTransactions` tests already have accounts in the mock for name resolution. However, the splits use the `split()` helper which sets `AccountType`. These tests should still pass since `AccountName` is set and the accounts are in the mock. Verify by running:
+
+Run: `go test ./internal/service/ -run TestBuildTransactionListItems -v`
+Expected: All PASS.
+
+- [ ] **Step 6: Run all tests**
+
+Run: `go test ./internal/service/ -v`
+Expected: All PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/service/transaction_classifier_test.go
+git commit -m "test: update classifier tests to use repo-backed account resolution (#153)"
+```
+
+---
+
+### Task 4: Add tests proving fake `AccountType` is rejected
+
+**Files:**
+- Modify: `internal/service/transaction_classifier_test.go`
+
+- [ ] **Step 1: Write test for `ValidateSplitsMatchType` rejecting a lying `AccountType`**
+
+Add after the existing `TestValidateSplitsMatchType` function:
+
+```go
+func TestValidateSplitsMatchType_IgnoresCallerAccountType(t *testing.T) {
+	accRepo := classifierAccRepo()
+	svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+	t.Run("lying AccountType on expense tx is rejected", func(t *testing.T) {
+		splits := []model.SplitDetail{
+			{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: -1000},
+			{AccountName: "Revenue:Salary", AccountType: model.AccountTypeExpense, Amount: 1000},
+		}
+		err := svc.ValidateSplitsMatchType(context.Background(), model.TxTypeExpense, splits)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Expense account")
+	})
+
+	t.Run("lying AccountType on income tx is rejected", func(t *testing.T) {
+		splits := []model.SplitDetail{
+			{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: 1000},
+			{AccountName: "Expenses:Food", AccountType: model.AccountTypeRevenue, Amount: -1000},
+		}
+		err := svc.ValidateSplitsMatchType(context.Background(), model.TxTypeIncome, splits)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Revenue account")
+	})
+
+	t.Run("lying AccountType on transfer tx is rejected", func(t *testing.T) {
+		splits := []model.SplitDetail{
+			{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: 500},
+			{AccountName: "Expenses:Food", AccountType: model.AccountTypeAsset, Amount: -500},
+		}
+		err := svc.ValidateSplitsMatchType(context.Background(), model.TxTypeTransfer, splits)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Asset and Liability")
+	})
+
+	t.Run("correct AccountType still passes (repo is truth)", func(t *testing.T) {
+		splits := []model.SplitDetail{
+			{AccountName: "Expenses:Food", AccountType: model.AccountTypeExpense, Amount: 500},
+			{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: -500},
+		}
+		err := svc.ValidateSplitsMatchType(context.Background(), model.TxTypeExpense, splits)
+		require.NoError(t, err)
+	})
+}
+```
+
+- [ ] **Step 2: Write test for `DetermineType` ignoring fake `AccountType`**
+
+```go
+func TestDetermineType_IgnoresCallerAccountType(t *testing.T) {
+	accRepo := classifierAccRepo()
+	svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+	t.Run("Revenue account claimed as Expense resolves correctly", func(t *testing.T) {
+		splits := []model.SplitDetail{
+			{AccountName: "Revenue:Salary", AccountType: model.AccountTypeExpense, Amount: -1000},
+			{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: 1000},
+		}
+		got, err := svc.DetermineType(context.Background(), splits)
+		require.NoError(t, err)
+		assert.Equal(t, model.TxTypeIncome, got)
+	})
+
+	t.Run("resolves by AccountID when both ID and name are set", func(t *testing.T) {
+		splits := []model.SplitDetail{
+			{AccountID: 1, AccountName: "Expenses:Food", AccountType: model.AccountTypeRevenue, Amount: 500},
+			{AccountID: 2, AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: -500},
+		}
+		got, err := svc.DetermineType(context.Background(), splits)
+		require.NoError(t, err)
+		assert.Equal(t, model.TxTypeExpense, got)
+	})
+}
+```
+
+- [ ] **Step 3: Run the new tests**
+
+Run: `go test ./internal/service/ -run "IgnoresCallerAccountType" -v`
+Expected: All PASS.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `go test ./...`
+Expected: All PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/transaction_classifier_test.go
+git commit -m "test: add tests proving fake AccountType is rejected (#153)"
+```

--- a/docs/superpowers/specs/2026-05-20-split-type-trust-boundary-design.md
+++ b/docs/superpowers/specs/2026-05-20-split-type-trust-boundary-design.md
@@ -1,0 +1,58 @@
+# Split Account Type Trust Boundary Fix
+
+**Date:** 2026-05-20
+**Issue:** #153
+
+## Problem
+
+`ValidateSplitsMatchType` and three other functions (`DetermineType`, `GetDisplayAccount`, `GetDisplayOffsetAccount`) trust `SplitDetail.AccountType` when it is non-empty instead of resolving the actual account type from the repository. A direct service caller can supply a fake `AccountType` and bypass type validation, creating transactions whose declared type does not match the real accounts in the database.
+
+Additionally, `CreateTransaction` passes the original caller-supplied `input.Splits` to `ValidateSplitsMatchType` rather than using already-resolved account data.
+
+## Approach
+
+Always resolve account types from the repository. Never treat `SplitDetail.AccountType` as authoritative for business logic.
+
+## Design
+
+### Shared helper: `resolveAccountType`
+
+Add an unexported method on `TransactionService`:
+
+```go
+func (ts *TransactionService) resolveAccountType(ctx context.Context, s model.SplitDetail) (model.AccountType, error)
+```
+
+Resolution order:
+1. If `s.AccountID > 0`: resolve via `accRepo.GetAccountByID(ctx, s.AccountID)`
+2. Else if `s.AccountName != ""`: resolve via `accRepo.GetAccountByName(ctx, s.AccountName)`
+3. Else: return an error (no identifier provided)
+
+The `s.AccountType` field is never read.
+
+### Functions updated
+
+1. **`ValidateSplitsMatchType`** (transaction_classifier.go) — replace inline `resolveType` closure with `ts.resolveAccountType`.
+2. **`DetermineType`** (transaction_classifier.go) — replace the inline resolution block with `ts.resolveAccountType`.
+3. **`GetDisplayAccount`** (transaction_classifier.go) — replace inline `resolveType` closure with `ts.resolveAccountType`.
+4. **`GetDisplayOffsetAccount`** (transaction_classifier.go) — replace inline `resolveAccountType` closure with `ts.resolveAccountType`.
+
+### No caller changes
+
+`CreateTransaction` and `UpdateTransactionComplete` remain unchanged. The validation function itself is now trustworthy regardless of what the caller passes in the splits.
+
+## Testing
+
+Service-layer tests using existing mock infrastructure:
+
+- A split with a **lying `AccountType`** (e.g., Revenue account claimed as Expense) is rejected when it doesn't match the declared transaction type.
+- A split with the **correct `AccountType`** still passes validation (repo is source of truth, field is ignored).
+- Both `AccountID`-based and `AccountName`-based resolution paths are exercised.
+- `DetermineType` returns the correct type based on repo data, not caller-supplied types.
+
+## Scope
+
+- No model changes.
+- No repository interface changes.
+- No caller/command changes.
+- Only `internal/service/transaction_classifier.go` and its test file are modified.

--- a/internal/service/transaction_classifier.go
+++ b/internal/service/transaction_classifier.go
@@ -32,13 +32,9 @@ func (ts *TransactionService) DetermineType(ctx context.Context, splits []model.
 	)
 
 	for _, split := range splits {
-		accType := split.AccountType
-		if accType == "" {
-			acc, err := ts.accRepo.GetAccountByID(ctx, split.AccountID)
-			if err != nil {
-				return model.TxTypeOther, err
-			}
-			accType = acc.Type
+		accType, err := ts.resolveAccountType(ctx, split)
+		if err != nil {
+			return model.TxTypeOther, err
 		}
 
 		if split.Memo == model.OpeningAccountMemo {
@@ -112,22 +108,11 @@ func (ts *TransactionService) GetDisplayAccount(ctx context.Context, splits []mo
 		return "-", nil
 	}
 
-	resolveType := func(split model.SplitDetail) (model.AccountType, error) {
-		if split.AccountType != "" {
-			return split.AccountType, nil
-		}
-		account, err := ts.accRepo.GetAccountByName(ctx, split.AccountName)
-		if err != nil {
-			return "", err
-		}
-		return account.Type, nil
-	}
-
 	switch txType {
 	case "Expense":
 		// Find and return the Expense account (E type)
 		for _, split := range splits {
-			accType, err := resolveType(split)
+			accType, err := ts.resolveAccountType(ctx, split)
 			if err == nil && accType == model.AccountTypeExpense {
 				return split.AccountName, nil
 			}
@@ -136,7 +121,7 @@ func (ts *TransactionService) GetDisplayAccount(ctx context.Context, splits []mo
 	case "Income":
 		// Find and return the Revenue account (R type)
 		for _, split := range splits {
-			accType, err := resolveType(split)
+			accType, err := ts.resolveAccountType(ctx, split)
 			if err == nil && accType == model.AccountTypeRevenue {
 				return split.AccountName, nil
 			}
@@ -146,7 +131,7 @@ func (ts *TransactionService) GetDisplayAccount(ctx context.Context, splits []mo
 		// Find and return the Asset/Liability account with positive amount (receiving account)
 		for _, split := range splits {
 			if split.Amount > 0 {
-				accType, err := resolveType(split)
+				accType, err := ts.resolveAccountType(ctx, split)
 				if err == nil && (accType == model.AccountTypeAsset || accType == model.AccountTypeLiability) {
 					return split.AccountName, nil
 				}
@@ -156,7 +141,7 @@ func (ts *TransactionService) GetDisplayAccount(ctx context.Context, splits []mo
 	case "Opening":
 		// For opening transactions, return the non-equity account
 		for _, split := range splits {
-			accType, err := resolveType(split)
+			accType, err := ts.resolveAccountType(ctx, split)
 			if err == nil && accType != model.AccountTypeEquity {
 				return split.AccountName, nil
 			}
@@ -205,17 +190,6 @@ func (ts *TransactionService) GetDisplayOffsetAccount(ctx context.Context, split
 		return "-", nil
 	}
 
-	resolveAccountType := func(split model.SplitDetail) (model.AccountType, error) {
-		if split.AccountType != "" {
-			return split.AccountType, nil
-		}
-		account, err := ts.accRepo.GetAccountByName(ctx, split.AccountName)
-		if err != nil {
-			return "", err
-		}
-		return account.Type, nil
-	}
-
 	seen := map[string]struct{}{}
 
 	switch txType {
@@ -228,7 +202,7 @@ func (ts *TransactionService) GetDisplayOffsetAccount(ctx context.Context, split
 		}
 
 		for _, split := range splits {
-			typeVal, err := resolveAccountType(split)
+			typeVal, err := ts.resolveAccountType(ctx, split)
 			if err != nil {
 				return "", err
 			}

--- a/internal/service/transaction_classifier.go
+++ b/internal/service/transaction_classifier.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/hance08/kea/internal/model"
@@ -315,18 +316,25 @@ func (ts *TransactionService) GetAllowedAccounts(txType model.TransactionType, c
 	}
 }
 
-func (ts *TransactionService) ValidateSplitsMatchType(ctx context.Context, txType model.TransactionType, splits []model.SplitDetail) error {
-	resolveType := func(s model.SplitDetail) (model.AccountType, error) {
-		if s.AccountType != "" {
-			return s.AccountType, nil
+func (ts *TransactionService) resolveAccountType(ctx context.Context, s model.SplitDetail) (model.AccountType, error) {
+	if s.AccountID > 0 {
+		acc, err := ts.accRepo.GetAccountByID(ctx, s.AccountID)
+		if err != nil {
+			return "", err
 		}
+		return acc.Type, nil
+	}
+	if s.AccountName != "" {
 		acc, err := ts.accRepo.GetAccountByName(ctx, s.AccountName)
 		if err != nil {
 			return "", err
 		}
 		return acc.Type, nil
 	}
+	return "", fmt.Errorf("split has neither AccountID nor AccountName")
+}
 
+func (ts *TransactionService) ValidateSplitsMatchType(ctx context.Context, txType model.TransactionType, splits []model.SplitDetail) error {
 	switch txType {
 	case model.TxTypeOpening, model.TxTypeOther, model.TxTypeDeposit, model.TxTypeWithdrawal:
 		return nil
@@ -334,7 +342,7 @@ func (ts *TransactionService) ValidateSplitsMatchType(ctx context.Context, txTyp
 	case model.TxTypeExpense:
 		var hasExpense, hasAssetOrLiab bool
 		for _, s := range splits {
-			accType, err := resolveType(s)
+			accType, err := ts.resolveAccountType(ctx, s)
 			if err != nil {
 				return err
 			}
@@ -355,7 +363,7 @@ func (ts *TransactionService) ValidateSplitsMatchType(ctx context.Context, txTyp
 	case model.TxTypeIncome:
 		var hasRevenue, hasAssetOrLiab bool
 		for _, s := range splits {
-			accType, err := resolveType(s)
+			accType, err := ts.resolveAccountType(ctx, s)
 			if err != nil {
 				return err
 			}
@@ -375,7 +383,7 @@ func (ts *TransactionService) ValidateSplitsMatchType(ctx context.Context, txTyp
 
 	case model.TxTypeTransfer:
 		for _, s := range splits {
-			accType, err := resolveType(s)
+			accType, err := ts.resolveAccountType(ctx, s)
 			if err != nil {
 				return err
 			}

--- a/internal/service/transaction_classifier_test.go
+++ b/internal/service/transaction_classifier_test.go
@@ -594,6 +594,75 @@ func TestValidateSplitsMatchType(t *testing.T) {
 	}
 }
 
+func TestValidateSplitsMatchType_IgnoresCallerAccountType(t *testing.T) {
+	accRepo := classifierAccRepo()
+	svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+	t.Run("lying AccountType on expense tx is rejected", func(t *testing.T) {
+		splits := []model.SplitDetail{
+			{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: -1000},
+			{AccountName: "Revenue:Salary", AccountType: model.AccountTypeExpense, Amount: 1000},
+		}
+		err := svc.ValidateSplitsMatchType(context.Background(), model.TxTypeExpense, splits)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Expense account")
+	})
+
+	t.Run("lying AccountType on income tx is rejected", func(t *testing.T) {
+		splits := []model.SplitDetail{
+			{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: 1000},
+			{AccountName: "Expenses:Food", AccountType: model.AccountTypeRevenue, Amount: -1000},
+		}
+		err := svc.ValidateSplitsMatchType(context.Background(), model.TxTypeIncome, splits)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Revenue account")
+	})
+
+	t.Run("lying AccountType on transfer tx is rejected", func(t *testing.T) {
+		splits := []model.SplitDetail{
+			{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: 500},
+			{AccountName: "Expenses:Food", AccountType: model.AccountTypeAsset, Amount: -500},
+		}
+		err := svc.ValidateSplitsMatchType(context.Background(), model.TxTypeTransfer, splits)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Asset and Liability")
+	})
+
+	t.Run("correct AccountType still passes (repo is truth)", func(t *testing.T) {
+		splits := []model.SplitDetail{
+			{AccountName: "Expenses:Food", AccountType: model.AccountTypeExpense, Amount: 500},
+			{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: -500},
+		}
+		err := svc.ValidateSplitsMatchType(context.Background(), model.TxTypeExpense, splits)
+		require.NoError(t, err)
+	})
+}
+
+func TestDetermineType_IgnoresCallerAccountType(t *testing.T) {
+	accRepo := classifierAccRepo()
+	svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+	t.Run("Revenue account claimed as Expense resolves correctly", func(t *testing.T) {
+		splits := []model.SplitDetail{
+			{AccountName: "Revenue:Salary", AccountType: model.AccountTypeExpense, Amount: -1000},
+			{AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: 1000},
+		}
+		got, err := svc.DetermineType(context.Background(), splits)
+		require.NoError(t, err)
+		assert.Equal(t, model.TxTypeIncome, got)
+	})
+
+	t.Run("resolves by AccountID when both ID and name are set", func(t *testing.T) {
+		splits := []model.SplitDetail{
+			{AccountID: 1, AccountName: "Expenses:Food", AccountType: model.AccountTypeRevenue, Amount: 500},
+			{AccountID: 2, AccountName: "Assets:Bank", AccountType: model.AccountTypeAsset, Amount: -500},
+		}
+		got, err := svc.DetermineType(context.Background(), splits)
+		require.NoError(t, err)
+		assert.Equal(t, model.TxTypeExpense, got)
+	})
+}
+
 func TestBuildTransactionListItems(t *testing.T) {
 	accRepo := newMockAccountRepo()
 	txRepo := newMockTransactionRepo()

--- a/internal/service/transaction_classifier_test.go
+++ b/internal/service/transaction_classifier_test.go
@@ -32,12 +32,42 @@ func splitWithMemo(accName string, accType model.AccountType, amount int64, memo
 	return s
 }
 
+// classifierAccRepo returns a mock account repository pre-populated with all
+// accounts referenced by classifier tests, allowing resolveAccountType to
+// look up types by name without hitting a real database.
+func classifierAccRepo() *mockAccountRepo {
+	repo := newMockAccountRepo()
+	repo.addAccount(&model.Account{ID: 1, Name: "Expenses:Food", Type: model.AccountTypeExpense})
+	repo.addAccount(&model.Account{ID: 2, Name: "Assets:Bank", Type: model.AccountTypeAsset})
+	repo.addAccount(&model.Account{ID: 3, Name: "Revenue:Salary", Type: model.AccountTypeRevenue})
+	repo.addAccount(&model.Account{ID: 4, Name: "Liabilities:Card", Type: model.AccountTypeLiability})
+	repo.addAccount(&model.Account{ID: 5, Name: model.OpeningBalancesAccountName("USD"), Type: model.AccountTypeEquity})
+	repo.addAccount(&model.Account{ID: 6, Name: "Assets:Cash", Type: model.AccountTypeAsset})
+	repo.addAccount(&model.Account{ID: 7, Name: "Assets:Savings", Type: model.AccountTypeAsset})
+	repo.addAccount(&model.Account{ID: 8, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	repo.addAccount(&model.Account{ID: 9, Name: "Equity:Retained", Type: model.AccountTypeEquity})
+	repo.addAccount(&model.Account{ID: 10, Name: "Expenses:Drink", Type: model.AccountTypeExpense})
+	repo.addAccount(&model.Account{ID: 11, Name: "Revenue:Bonus", Type: model.AccountTypeRevenue})
+	repo.addAccount(&model.Account{ID: 12, Name: "Expenses:Tax", Type: model.AccountTypeExpense})
+	repo.addAccount(&model.Account{ID: 13, Name: "Expenses:A", Type: model.AccountTypeExpense})
+	repo.addAccount(&model.Account{ID: 14, Name: "Expenses:B", Type: model.AccountTypeExpense})
+	repo.addAccount(&model.Account{ID: 15, Name: "Assets:Investments:00878", Type: model.AccountTypeAsset})
+	repo.addAccount(&model.Account{ID: 16, Name: "Expenses:Fees:Stocks", Type: model.AccountTypeExpense})
+	repo.addAccount(&model.Account{ID: 17, Name: "Assets:Bank:DAWHO", Type: model.AccountTypeAsset})
+	repo.addAccount(&model.Account{ID: 18, Name: "Expenses:Food:Drink", Type: model.AccountTypeExpense})
+	repo.addAccount(&model.Account{ID: 19, Name: "Assets:Receivable:Friends", Type: model.AccountTypeAsset})
+	repo.addAccount(&model.Account{ID: 20, Name: "Assets:Ewallet:LinePayMoney", Type: model.AccountTypeAsset})
+	repo.addAccount(&model.Account{ID: 21, Name: model.OpeningBalancesAccountName("TWD"), Type: model.AccountTypeEquity})
+	repo.addAccount(&model.Account{ID: 22, Name: "Assets:Card", Type: model.AccountTypeAsset})
+	return repo
+}
+
 // ──────────────────────────────────────────────
 // DetermineType
 // ──────────────────────────────────────────────
 
 func TestDetermineType(t *testing.T) {
-	svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
+	svc := newTestTransactionService(classifierAccRepo(), newMockTransactionRepo())
 
 	tests := []struct {
 		name   string
@@ -329,7 +359,7 @@ func TestGetDisplayAccount(t *testing.T) {
 
 func TestGetDisplayOffsetAccount(t *testing.T) {
 	t.Run("Expense: single offset (asset account)", func(t *testing.T) {
-		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
+		svc := newTestTransactionService(classifierAccRepo(), newMockTransactionRepo())
 		splits := []model.SplitDetail{
 			{AccountName: "Expenses:Food", AccountType: model.AccountTypeExpense, Amount: 500},
 			{AccountName: "Assets:Cash", AccountType: model.AccountTypeAsset, Amount: -500},
@@ -340,7 +370,7 @@ func TestGetDisplayOffsetAccount(t *testing.T) {
 	})
 
 	t.Run("Expense: multiple offsets returns (multiple)", func(t *testing.T) {
-		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
+		svc := newTestTransactionService(classifierAccRepo(), newMockTransactionRepo())
 		splits := []model.SplitDetail{
 			{AccountName: "Expenses:Food", AccountType: model.AccountTypeExpense, Amount: 500},
 			{AccountName: "Assets:Cash", AccountType: model.AccountTypeAsset, Amount: -300},
@@ -352,7 +382,7 @@ func TestGetDisplayOffsetAccount(t *testing.T) {
 	})
 
 	t.Run("Transfer: excludes primary account by name", func(t *testing.T) {
-		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
+		svc := newTestTransactionService(classifierAccRepo(), newMockTransactionRepo())
 		splits := []model.SplitDetail{
 			{AccountName: "Assets:Savings", AccountType: model.AccountTypeAsset, Amount: 1000},
 			{AccountName: "Assets:Checking", AccountType: model.AccountTypeAsset, Amount: -1000},
@@ -363,7 +393,7 @@ func TestGetDisplayOffsetAccount(t *testing.T) {
 	})
 
 	t.Run("no offset accounts returns -", func(t *testing.T) {
-		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
+		svc := newTestTransactionService(classifierAccRepo(), newMockTransactionRepo())
 		splits := []model.SplitDetail{
 			{AccountName: "Expenses:Food", AccountType: model.AccountTypeExpense, Amount: 500},
 		}
@@ -373,7 +403,7 @@ func TestGetDisplayOffsetAccount(t *testing.T) {
 	})
 
 	t.Run("empty splits returns -", func(t *testing.T) {
-		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
+		svc := newTestTransactionService(classifierAccRepo(), newMockTransactionRepo())
 		got, err := svc.GetDisplayOffsetAccount(context.Background(), nil, "Expense", "")
 		require.NoError(t, err)
 		assert.Equal(t, "-", got)
@@ -444,7 +474,7 @@ func TestGetAllowedAccounts(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestValidateSplitsMatchType(t *testing.T) {
-	svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
+	svc := newTestTransactionService(classifierAccRepo(), newMockTransactionRepo())
 
 	tests := []struct {
 		name    string

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -157,8 +157,8 @@ func (ts *TransactionService) CreateSimpleTransaction(ctx context.Context, input
 			return model.TransactionDetail{}, fmt.Errorf("failed to resolve to account: %w", err)
 		}
 		inferred, err := ts.DetermineType(ctx, []model.SplitDetail{
-			{AccountType: toAcc.Type, Amount: input.Amount},
-			{AccountType: fromAcc.Type, Amount: -input.Amount},
+			{AccountID: toAcc.ID, AccountName: input.ToAccount, AccountType: toAcc.Type, Amount: input.Amount},
+			{AccountID: fromAcc.ID, AccountName: input.FromAccount, AccountType: fromAcc.Type, Amount: -input.Amount},
 		})
 		if err != nil {
 			return model.TransactionDetail{}, err


### PR DESCRIPTION
## Summary

- Extracted shared `resolveAccountType` helper on `TransactionService` that always resolves account types from the repository by `AccountID` or `AccountName`, never reading `SplitDetail.AccountType`
- Replaced four inline `resolveType` closures in `ValidateSplitsMatchType`, `DetermineType`, `GetDisplayAccount`, and `GetDisplayOffsetAccount` with the shared helper
- Fixed `CreateSimpleTransaction` to pass `AccountID`/`AccountName` when calling `DetermineType` for type inference
- Added tests proving that lying `AccountType` values are ignored and the repo is the source of truth

Closes #153

## Test plan
- [x] Existing classifier tests updated to use repo-backed mock accounts
- [x] New tests verify fake `AccountType` is rejected for expense, income, and transfer validation
- [x] New tests verify `DetermineType` ignores caller-supplied `AccountType`
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>