### PR TITLE
fix: reject duplicate reconcile transaction IDs (#154)

### DIFF
--- a/cmd/reconcile_actions.go
+++ b/cmd/reconcile_actions.go
@@ -181,6 +181,7 @@ func parseIDs(s string) ([]int64, error) {
 		return nil, fmt.Errorf("empty ID list")
 	}
 	parts := strings.Split(s, ",")
+	seen := make(map[int64]bool, len(parts))
 	ids := make([]int64, 0, len(parts))
 	for _, p := range parts {
 		p = strings.TrimSpace(p)
@@ -188,6 +189,10 @@ func parseIDs(s string) ([]int64, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid ID %q: %w", p, err)
 		}
+		if seen[id] {
+			return nil, fmt.Errorf("duplicate transaction ID %d", id)
+		}
+		seen[id] = true
 		ids = append(ids, id)
 	}
 	return ids, nil

--- a/cmd/reconcile_actions_test.go
+++ b/cmd/reconcile_actions_test.go
@@ -10,6 +10,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseIDs_ValidInput(t *testing.T) {
+	ids, err := parseIDs("1, 2, 3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 3 {
+		t.Fatalf("expected 3 IDs, got %d", len(ids))
+	}
+	if ids[0] != 1 || ids[1] != 2 || ids[2] != 3 {
+		t.Errorf("expected [1 2 3], got %v", ids)
+	}
+}
+
+func TestParseIDs_DuplicateIDs_ReturnsError(t *testing.T) {
+	_, err := parseIDs("10,10")
+	if err == nil {
+		t.Fatal("expected error for duplicate IDs, got nil")
+	}
+}
+
+func TestParseIDs_DuplicateIDs_NonAdjacent_ReturnsError(t *testing.T) {
+	_, err := parseIDs("10,20,10")
+	if err == nil {
+		t.Fatal("expected error for duplicate IDs, got nil")
+	}
+}
+
+func TestParseIDs_EmptyInput_ReturnsError(t *testing.T) {
+	_, err := parseIDs("")
+	if err == nil {
+		t.Fatal("expected error for empty input, got nil")
+	}
+}
+
+func TestParseIDs_InvalidNumber_ReturnsError(t *testing.T) {
+	_, err := parseIDs("10,abc,20")
+	if err == nil {
+		t.Fatal("expected error for invalid number, got nil")
+	}
+}
+
 func TestResolveMode(t *testing.T) {
 	t.Run("no flags means interactive", func(t *testing.T) {
 		mode, err := resolveMode(false, false, false)

--- a/internal/service/reconcile_ops.go
+++ b/internal/service/reconcile_ops.go
@@ -121,7 +121,12 @@ func (ts *TransactionService) ReconcileTransactions(ctx context.Context, account
 
 	// 4. Validate every requested ID and accumulate the cleared balance.
 	var clearedBalance int64
+	seen := make(map[int64]bool, len(txIDs))
 	for _, id := range txIDs {
+		if seen[id] {
+			return 0, validationErrorf("transactions", "duplicate transaction ID %d", id)
+		}
+		seen[id] = true
 		amount, ok := validAmounts[id]
 		if !ok {
 			return 0, validationErrorf("transactions", "transaction ID %d is not in the unreconciled set for this account", id)

--- a/internal/service/reconcile_ops.go
+++ b/internal/service/reconcile_ops.go
@@ -61,7 +61,12 @@ func (ts *TransactionService) PreviewReconcile(ctx context.Context, accountID in
 	}
 
 	var clearedBalance int64
+	seen := make(map[int64]bool, len(txIDs))
 	for _, id := range txIDs {
+		if seen[id] {
+			return 0, validationErrorf("transactions", "duplicate transaction ID %d", id)
+		}
+		seen[id] = true
 		amount, ok := validAmounts[id]
 		if !ok {
 			return 0, validationErrorf("transactions", "transaction ID %d is not in the unreconciled set for this account", id)

--- a/internal/service/reconcile_ops_test.go
+++ b/internal/service/reconcile_ops_test.go
@@ -478,6 +478,36 @@ func TestPreviewReconcile_DuplicateIDs_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestReconcileTransactions_DuplicateIDs_ReturnsError(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
+		{ID: 10, Amount: 100000},
+	})
+
+	_, err := svc.ReconcileTransactions(context.Background(), 1, 200000, []int64{10, 10})
+
+	if err == nil {
+		t.Fatal("expected error for duplicate transaction IDs, got nil")
+	}
+	var ve *ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+	if ve.Field != "transactions" {
+		t.Errorf("expected field 'transactions', got %q", ve.Field)
+	}
+	if len(txRepo.markSplitsReconciledCalls) != 0 {
+		t.Error("MarkSplitsReconciledByAccount must not be called when validation fails")
+	}
+	if len(txRepo.setLastReconciledBalCalls) != 0 {
+		t.Error("SetLastReconciledBalance must not be called when validation fails")
+	}
+}
+
 func TestPreviewReconcile_DoesNotMutate(t *testing.T) {
 	accRepo := newMockAccountRepo()
 	txRepo := newMockTransactionRepo()

--- a/internal/service/reconcile_ops_test.go
+++ b/internal/service/reconcile_ops_test.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -450,6 +451,30 @@ func TestPreviewReconcile_WithPriorBalance(t *testing.T) {
 	}
 	if diff != 0 {
 		t.Errorf("expected diff 0, got %d", diff)
+	}
+}
+
+func TestPreviewReconcile_DuplicateIDs_ReturnsError(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
+		{ID: 10, Amount: 100000},
+	})
+
+	_, err := svc.PreviewReconcile(context.Background(), 1, 200000, []int64{10, 10})
+
+	if err == nil {
+		t.Fatal("expected error for duplicate transaction IDs, got nil")
+	}
+	var ve *ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+	if ve.Field != "transactions" {
+		t.Errorf("expected field 'transactions', got %q", ve.Field)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add duplicate transaction ID detection in `PreviewReconcile` and `ReconcileTransactions` service methods, returning a `ValidationError` before computing `clearedBalance`
- Add duplicate ID rejection in `parseIDs` CLI helper for immediate user-facing error at the CLI layer
- Defense-in-depth: service layer guards data integrity even if callers bypass the CLI

Closes #154

## Test Plan
- [x] `TestPreviewReconcile_DuplicateIDs_ReturnsError` — duplicate IDs return `ValidationError`
- [x] `TestReconcileTransactions_DuplicateIDs_ReturnsError` — duplicate IDs return `ValidationError`, no DB writes occur
- [x] `TestParseIDs_DuplicateIDs_ReturnsError` — adjacent duplicates rejected
- [x] `TestParseIDs_DuplicateIDs_NonAdjacent_ReturnsError` — non-adjacent duplicates rejected
- [x] All existing reconcile and parseIDs tests pass (no regressions)
- [x] `go test ./...` — full suite green
- [x] `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)