### PR TITLE
fix: reject account creation when name contradicts parent path (#155)

### DIFF
--- a/internal/service/account_ops.go
+++ b/internal/service/account_ops.go
@@ -109,14 +109,26 @@ func (as *AccountService) validateAccountFields(ctx context.Context, name string
 	if !accType.IsValid() {
 		return validationErrorf("type", "invalid account type: %s", accType)
 	}
-	root := strings.SplitN(name, ":", 2)[0]
-	if expected, ok := model.AccountTypeFromRootName(root); ok && expected != accType {
-		return validationErrorf("type", "account type %q conflicts with root %q (expected %q)", accType, root, expected)
-	}
 	if parentID != nil {
 		if err := as.validateParentChain(ctx, 0, parentID); err != nil {
 			return err
 		}
+		parent, err := as.repo.GetAccountByID(ctx, *parentID)
+		if err != nil {
+			return fmt.Errorf("failed to look up parent account %d: %w", *parentID, err)
+		}
+		expectedPrefix := parent.Name + ":"
+		if !strings.HasPrefix(name, expectedPrefix) {
+			return validationErrorf("parent", "account name %q is not a child of parent %q", name, parent.Name)
+		}
+		childSegment := strings.TrimPrefix(name, expectedPrefix)
+		if strings.Contains(childSegment, ":") {
+			return validationErrorf("parent", "account name %q is not a direct child of parent %q (nested segments found)", name, parent.Name)
+		}
+	}
+	root := strings.SplitN(name, ":", 2)[0]
+	if expected, ok := model.AccountTypeFromRootName(root); ok && expected != accType {
+		return validationErrorf("type", "account type %q conflicts with root %q (expected %q)", accType, root, expected)
 	}
 	return nil
 }

--- a/internal/service/account_ops_test.go
+++ b/internal/service/account_ops_test.go
@@ -1000,3 +1000,97 @@ func TestCreateAccount_ParentTypeMismatch(t *testing.T) {
 		assert.Equal(t, model.AccountTypeRevenue, acc.Type)
 	})
 }
+
+func TestCreateAccount_ParentNameConsistency(t *testing.T) {
+	t.Run("name under different branch than parent rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{
+			ID: 10, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD",
+		})
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		_, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{
+			Name:     "Expenses:Food",
+			Type:     model.AccountTypeAsset,
+			Currency: "USD",
+			ParentID: int64Ptr(10),
+		})
+		require.Error(t, err)
+
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "parent", ve.Field)
+		assert.Contains(t, err.Error(), "Assets:Bank")
+	})
+
+	t.Run("name shares prefix but adds extra nesting rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{
+			ID: 10, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD",
+		})
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		_, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{
+			Name:     "Assets:Bank:Sub:Deep",
+			Type:     model.AccountTypeAsset,
+			Currency: "USD",
+			ParentID: int64Ptr(10),
+		})
+		require.Error(t, err)
+
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "parent", ve.Field)
+	})
+
+	t.Run("correct child name accepted", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{
+			ID: 10, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD",
+		})
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		acc, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{
+			Name:     "Assets:Bank:Checking",
+			Type:     model.AccountTypeAsset,
+			Currency: "USD",
+			ParentID: int64Ptr(10),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "Assets:Bank:Checking", acc.Name)
+	})
+
+	t.Run("mismatch rejected via CreateAccountWithBalance", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{
+			ID: 10, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD",
+		})
+		addOpeningBalanceAccount(accRepo)
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		_, err := svc.CreateAccountWithBalance(context.Background(), model.CreateAccountInput{
+			Name:     "Assets:Cash",
+			Type:     model.AccountTypeAsset,
+			Currency: "USD",
+			ParentID: int64Ptr(10),
+			Balance:  1000,
+		})
+		require.Error(t, err)
+
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "parent", ve.Field)
+	})
+
+	t.Run("nil parent skips name consistency check", func(t *testing.T) {
+		svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
+
+		acc, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{
+			Name:     "Assets:Bank",
+			Type:     model.AccountTypeAsset,
+			Currency: "USD",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "Assets:Bank", acc.Name)
+	})
+}


### PR DESCRIPTION
## Summary
- Adds parent-name consistency validation in `validateAccountFields`: when `parentID` is set, the account name must start with `parent.Name + ":"` and have exactly one child segment (no nested paths)
- Returns a `ValidationError` with field `"parent"` on mismatch, covering both `CreateAccount` and `CreateAccountWithBalance`
- Adds 5 test cases in `TestCreateAccount_ParentNameConsistency` (wrong branch, extra nesting, valid child, mismatch via balance path, nil parent)

Closes #155

## Test Plan
- [x] All 5 new sub-tests pass
- [x] Full test suite passes with no regressions (`go test ./...`)
- [x] Existing `TestCreateAccount_ParentValidation` tests (valid parent, deep chain, cycles) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)