### PR TITLE
fix: reject child account creation when parent has transactions

### DIFF
--- a/cmd/account/create_actions.go
+++ b/cmd/account/create_actions.go
@@ -86,7 +86,22 @@ func (r *createRunner) promptParent(ctx context.Context) (*model.Account, error)
 		return nil, fmt.Errorf("failed to retrieve accounts: %w", err)
 	}
 
-	_, selectedAccount, err := prompts.PromptParentAccount(allAccounts)
+	var eligible []*model.Account
+	for _, acc := range allAccounts {
+		hasTx, err := r.accSvc.AccountHasTransactions(ctx, acc.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check transactions for %q: %w", acc.Name, err)
+		}
+		if !hasTx {
+			eligible = append(eligible, acc)
+		}
+	}
+
+	if len(eligible) == 0 {
+		return nil, fmt.Errorf("no eligible parent accounts found (all accounts have transactions)")
+	}
+
+	_, selectedAccount, err := prompts.PromptParentAccount(eligible)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/account/create_types.go
+++ b/cmd/account/create_types.go
@@ -20,6 +20,7 @@ type CreateProvider interface {
 	GetAccountByName(ctx context.Context, name string) (*model.Account, error)
 	GetRootNameByType(accType string) (string, error)
 	CheckAccountExists(ctx context.Context, name string) (bool, error)
+	AccountHasTransactions(ctx context.Context, accountID int64) (bool, error)
 	FormatAccountName(prefix string, name string) string
 	CreateAccountWithBalance(ctx context.Context, input model.CreateAccountInput) (*model.Account, error)
 	ValidateAccountName(name string) error

--- a/internal/service/account_ops.go
+++ b/internal/service/account_ops.go
@@ -117,6 +117,13 @@ func (as *AccountService) validateAccountFields(ctx context.Context, name string
 		if err != nil {
 			return fmt.Errorf("failed to look up parent account %d: %w", *parentID, err)
 		}
+		hasTransactions, err := as.repo.AccountHasTransactions(ctx, parent.ID)
+		if err != nil {
+			return fmt.Errorf("failed to check parent transactions for account %d: %w", parent.ID, err)
+		}
+		if hasTransactions {
+			return validationErrorf("parent", "account %q already has transactions; it cannot become a parent", parent.Name)
+		}
 		expectedPrefix := parent.Name + ":"
 		if !strings.HasPrefix(name, expectedPrefix) {
 			return validationErrorf("parent", "account name %q is not a child of parent %q", name, parent.Name)

--- a/internal/service/account_ops_test.go
+++ b/internal/service/account_ops_test.go
@@ -1094,3 +1094,85 @@ func TestCreateAccount_ParentNameConsistency(t *testing.T) {
 		assert.Equal(t, "Assets:Bank", acc.Name)
 	})
 }
+
+// ──────────────────────────────────────────────
+// Parent with transactions guard (#150)
+// ──────────────────────────────────────────────
+
+func TestCreateAccount_ParentHasTransactions(t *testing.T) {
+	t.Run("parent with transactions rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{
+			ID: 10, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD",
+		})
+		accRepo.txExistsMap[10] = true
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		_, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{
+			Name:     "Assets:Bank:Checking",
+			Type:     model.AccountTypeAsset,
+			Currency: "USD",
+			ParentID: int64Ptr(10),
+		})
+		require.Error(t, err)
+
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "parent", ve.Field)
+		assert.Contains(t, err.Error(), "transactions")
+	})
+
+	t.Run("parent without transactions accepted", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{
+			ID: 10, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD",
+		})
+		// txExistsMap[10] defaults to false
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		acc, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{
+			Name:     "Assets:Bank:Checking",
+			Type:     model.AccountTypeAsset,
+			Currency: "USD",
+			ParentID: int64Ptr(10),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "Assets:Bank:Checking", acc.Name)
+	})
+
+	t.Run("nil parent skips transaction check", func(t *testing.T) {
+		svc := newTestAccountService(newMockAccountRepo(), newMockTransactionRepo())
+
+		acc, err := svc.CreateAccount(context.Background(), model.CreateAccountInput{
+			Name:     "Assets:Bank",
+			Type:     model.AccountTypeAsset,
+			Currency: "USD",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "Assets:Bank", acc.Name)
+	})
+
+	t.Run("rejected via CreateAccountWithBalance too", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{
+			ID: 10, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD",
+		})
+		accRepo.txExistsMap[10] = true
+		addOpeningBalanceAccount(accRepo)
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		_, err := svc.CreateAccountWithBalance(context.Background(), model.CreateAccountInput{
+			Name:     "Assets:Bank:Checking",
+			Type:     model.AccountTypeAsset,
+			Currency: "USD",
+			ParentID: int64Ptr(10),
+			Balance:  1000,
+		})
+		require.Error(t, err)
+
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "parent", ve.Field)
+		assert.Contains(t, err.Error(), "transactions")
+	})
+}

--- a/internal/service/account_service.go
+++ b/internal/service/account_service.go
@@ -111,6 +111,10 @@ func (as *AccountService) CheckAccountExists(ctx context.Context, name string) (
 	return as.repo.AccountExists(ctx, name)
 }
 
+func (as *AccountService) AccountHasTransactions(ctx context.Context, accountID int64) (bool, error) {
+	return as.repo.AccountHasTransactions(ctx, accountID)
+}
+
 func (as *AccountService) ValidateSelectableAccount(ctx context.Context, name string, allowedTypes []string) error {
 	acc, err := as.repo.GetAccountByName(ctx, name)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add a guard in `validateAccountFields` that rejects creating a child account when the parent already has transactions, preventing leaf-to-parent conversion that violates the leaf-only transaction rule
- Filter accounts with transactions from the interactive parent selector in the TUI, so users only see eligible parent accounts
- Add `AccountHasTransactions` method to `AccountService` and `CreateProvider` interface

Closes #150

## Test plan
- [x] `TestCreateAccount_ParentHasTransactions/parent_with_transactions_rejected` — parent with transactions returns `ValidationError{Field: "parent"}`
- [x] `TestCreateAccount_ParentHasTransactions/parent_without_transactions_accepted` — parent without transactions allows creation
- [x] `TestCreateAccount_ParentHasTransactions/nil_parent_skips_transaction_check` — no parentID bypasses the check
- [x] `TestCreateAccount_ParentHasTransactions/rejected_via_CreateAccountWithBalance_too` — guard applies through both creation paths
- [x] Full test suite passes with zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)