### PR TITLE
fix: strip commas from amount before ParseFloat in ToJSONTxListItem (#133)

### DIFF
--- a/ui/views/json_test.go
+++ b/ui/views/json_test.go
@@ -96,6 +96,16 @@ func TestToJSONTxListItem(t *testing.T) {
 	assert.Equal(t, "Cleared", got.Status)
 }
 
+func TestToJSONTxListItem_commaAmount(t *testing.T) {
+	item := TransactionListItem{
+		ID: 10, Date: "2024-03-24", Type: "Income",
+		Account: "Assets:Bank", Offset: "Revenue:Salary",
+		Description: "salary", Amount: "1,234.56", Currency: "TWD", Status: "Cleared",
+	}
+	got := ToJSONTxListItem(item)
+	assert.Equal(t, 1234.56, got.Amount)
+}
+
 func TestWriteJSON_validOutput(t *testing.T) {
 	// Redirect stdout
 	old := os.Stdout

--- a/ui/views/json_test.go
+++ b/ui/views/json_test.go
@@ -106,6 +106,26 @@ func TestToJSONTxListItem_commaAmount(t *testing.T) {
 	assert.Equal(t, 1234.56, got.Amount)
 }
 
+func TestToJSONTxListItem_negativeCommaAmount(t *testing.T) {
+	item := TransactionListItem{
+		ID: 11, Date: "2024-03-24", Type: "Expense",
+		Account: "Assets:Bank", Offset: "Expenses:Rent",
+		Description: "rent", Amount: "-1,234.56", Currency: "TWD", Status: "Cleared",
+	}
+	got := ToJSONTxListItem(item)
+	assert.Equal(t, -1234.56, got.Amount)
+}
+
+func TestToJSONTxListItem_largeCommaAmount(t *testing.T) {
+	item := TransactionListItem{
+		ID: 12, Date: "2024-03-24", Type: "Income",
+		Account: "Assets:Bank", Offset: "Revenue:Salary",
+		Description: "bonus", Amount: "1,234,567.89", Currency: "TWD", Status: "Cleared",
+	}
+	got := ToJSONTxListItem(item)
+	assert.Equal(t, 1234567.89, got.Amount)
+}
+
 func TestWriteJSON_validOutput(t *testing.T) {
 	// Redirect stdout
 	old := os.Stdout

--- a/ui/views/json_types.go
+++ b/ui/views/json_types.go
@@ -5,6 +5,7 @@ package views
 
 import (
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hance08/kea/internal/model"
@@ -109,7 +110,7 @@ func ToJSONTxDetail(d *model.TransactionDetail) JSONTxDetail {
 }
 
 func ToJSONTxListItem(item TransactionListItem) JSONTxListItem {
-	amount, _ := strconv.ParseFloat(item.Amount, 64)
+	amount, _ := strconv.ParseFloat(strings.ReplaceAll(item.Amount, ",", ""), 64)
 	return JSONTxListItem{
 		ID:          item.ID,
 		Date:        item.Date,


### PR DESCRIPTION
## Summary
- `ToJSONTxListItem` called `strconv.ParseFloat` on comma-formatted amount strings (e.g. `"1,234.56"`), which silently returned 0 for any amount >= 1,000
- Fix: strip commas with `strings.ReplaceAll` before parsing
- Added tests for comma-formatted, negative comma-formatted, and large multi-comma amounts

Closes #133

## Test Plan
- [x] `TestToJSONTxListItem_commaAmount` — verifies `"1,234.56"` parses to `1234.56`
- [x] `TestToJSONTxListItem_negativeCommaAmount` — verifies `"-1,234.56"` parses to `-1234.56`
- [x] `TestToJSONTxListItem_largeCommaAmount` — verifies `"1,234,567.89"` parses to `1234567.89`
- [x] Existing `TestToJSONTxListItem` still passes (no regression)
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)