### PR TITLE
fix: guard ParseAmount against int64 overflow (#128)

### DIFF
--- a/internal/utils/amount.go
+++ b/internal/utils/amount.go
@@ -12,6 +12,10 @@ import (
 	"github.com/hance08/kea/internal/model"
 )
 
+var ErrAmountOverflow = fmt.Errorf("amount too large: exceeds int64 range")
+
+const maxDollars = math.MaxInt64 / int64(model.CentsPerUnit)
+
 func FormatAmount(cents int64) string {
 	if cents == math.MinInt64 {
 		panic("utils.FormatAmount: undefined for math.MinInt64 (overflow)")
@@ -124,7 +128,15 @@ func ParseAmount(amountStr string) (int64, error) {
 		}
 	}
 
-	total := (dollars+dollarCarry)*int64(model.CentsPerUnit) + cents
+	dollars += dollarCarry
+	if dollars > maxDollars {
+		return 0, ErrAmountOverflow
+	}
+
+	total := dollars*int64(model.CentsPerUnit) + cents
+	if total < 0 {
+		return 0, ErrAmountOverflow
+	}
 
 	if isNegative {
 		total = -total

--- a/internal/utils/amount_test.go
+++ b/internal/utils/amount_test.go
@@ -82,6 +82,8 @@ func TestParseAmount_Valid(t *testing.T) {
 		{"3 decimals no carry", "0.994", 99},
 		// "1.0099": dollars=1, centStr="0099", firstTwo=00, third='9'>=5 → cents=1, total=1*100+1=101
 		{"4 decimals truncated with round-up", "1.0099", 101},
+		{"max safe positive", "92233720368547758.07", 9223372036854775807},
+		{"max safe negative", "-92233720368547758.07", -9223372036854775807},
 	}
 
 	for _, tt := range tests {
@@ -110,6 +112,10 @@ func TestParseAmount_Invalid(t *testing.T) {
 		{"whitespace", " "},
 		{"empty string", ""},
 		{"just -", "-"},
+		{"overflow positive dollars", "92233720368547759"},
+		{"overflow negative dollars", "-92233720368547759"},
+		{"overflow from cents addition", "92233720368547758.08"},
+		{"overflow from dollarCarry", "92233720368547758.995"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Add overflow guards to `ParseAmount` preventing silent int64 wraparound on large dollar values (e.g., `"92233720368547759"` would overflow when multiplied by 100)
- Add `ErrAmountOverflow` sentinel error and `maxDollars` constant for clear overflow detection
- Two-stage guard: pre-multiplication check (`dollars > maxDollars`) and post-addition check (`total < 0` catches cents pushing past `MaxInt64`)

Closes #128

## Test Plan
- [x] Added 4 invalid overflow test cases (positive, negative, cents overflow, dollarCarry overflow)
- [x] Added 2 valid boundary test cases (`math.MaxInt64` exact boundary)
- [x] All existing tests pass — no regressions
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)