### PR TITLE
fix: return ErrNotFound from GetAccountBalance for nonexistent accounts

### DIFF
--- a/internal/service/account_ops_test.go
+++ b/internal/service/account_ops_test.go
@@ -6,6 +6,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -648,9 +649,37 @@ func TestGetAccountBalance(t *testing.T) {
 	})
 
 	t.Run("propagates repo error", func(t *testing.T) {
-		repo.getBalanceErr[99] = errors.New("not found")
+		repo.addAccount(&model.Account{ID: 99, Name: "Assets:Test", Type: model.AccountTypeAsset})
+		repo.getBalanceErr[99] = errors.New("balance fetch failed")
 		_, err := svc.GetAccountBalance(context.Background(), 99)
 		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "balance fetch failed")
+	})
+
+	t.Run("returns ErrNotFound for nonexistent account", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		bal, err := svc.GetAccountBalance(context.Background(), 999)
+
+		assert.Equal(t, int64(0), bal)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotFound))
+		assert.Contains(t, err.Error(), "999")
+	})
+
+	t.Run("passes through other errors from GetAccountByID", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		dbErr := fmt.Errorf("connection refused")
+		accRepo.getByIDErr[42] = dbErr
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		bal, err := svc.GetAccountBalance(context.Background(), 42)
+
+		assert.Equal(t, int64(0), bal)
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, ErrNotFound))
+		assert.Equal(t, dbErr, err)
 	})
 }
 

--- a/internal/service/account_service.go
+++ b/internal/service/account_service.go
@@ -87,10 +87,22 @@ func (as *AccountService) GetAccountsByType(ctx context.Context, accType model.A
 }
 
 func (as *AccountService) GetAccountBalance(ctx context.Context, accountID int64) (int64, error) {
+	if _, err := as.repo.GetAccountByID(ctx, accountID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return 0, fmt.Errorf("account #%d: %w", accountID, ErrNotFound)
+		}
+		return 0, err
+	}
 	return as.repo.GetAccountBalance(ctx, accountID)
 }
 
 func (as *AccountService) GetAccountBalanceFormatted(ctx context.Context, accountID int64) (string, error) {
+	if _, err := as.repo.GetAccountByID(ctx, accountID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return "", fmt.Errorf("account #%d: %w", accountID, ErrNotFound)
+		}
+		return "", err
+	}
 	balance, err := as.repo.GetAccountBalance(ctx, accountID)
 	if err != nil {
 		return "", err

--- a/internal/service/account_service_test.go
+++ b/internal/service/account_service_test.go
@@ -108,3 +108,44 @@ func TestListAccounts(t *testing.T) {
 		assert.Len(t, accounts, 2)
 	})
 }
+
+func TestGetAccountBalanceFormatted(t *testing.T) {
+	t.Run("returns formatted balance for existing account", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Cash", Type: model.AccountTypeAsset, Currency: "USD"})
+		accRepo.balances[1] = 5000
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		bal, err := svc.GetAccountBalanceFormatted(context.Background(), 1)
+
+		require.NoError(t, err)
+		assert.Equal(t, "50", bal)
+	})
+
+	t.Run("returns ErrNotFound for nonexistent account", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		bal, err := svc.GetAccountBalanceFormatted(context.Background(), 999)
+
+		assert.Empty(t, bal)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNotFound))
+		assert.Contains(t, err.Error(), "999")
+	})
+
+	t.Run("passes through other errors from GetAccountByID", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		dbErr := fmt.Errorf("connection refused")
+		accRepo.getByIDErr[42] = dbErr
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		bal, err := svc.GetAccountBalanceFormatted(context.Background(), 42)
+
+		assert.Empty(t, bal)
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, ErrNotFound))
+		assert.Equal(t, dbErr, err)
+	})
+}
+


### PR DESCRIPTION
## Summary
- `GetAccountBalance` and `GetAccountBalanceFormatted` now verify account existence via `GetAccountByID` before querying the balance
- Nonexistent account IDs return `service.ErrNotFound` instead of silently returning balance 0
- Fixed pre-existing "propagates repo error" test that was no longer exercising the intended code path

Closes #122

## Test plan
- [x] Added `TestGetAccountBalance` subtests: ErrNotFound for nonexistent account, error passthrough from GetAccountByID
- [x] Added `TestGetAccountBalanceFormatted` subtests: happy path, ErrNotFound for nonexistent account, error passthrough
- [x] Fixed existing "propagates repo error" subtest to correctly inject balance-fetch error after existence check
- [x] Full test suite passes with no regressions (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)