### PR TITLE
Fix unbounded IN clauses in store layer (#125)

### DIFF
--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -60,9 +60,9 @@ type TransactionRepository interface {
 	// net split amount for that account. Ordered by timestamp ASC.
 	GetUnreconciledTransactionsByAccount(ctx context.Context, accountID int64) ([]*model.ReconcileEntry, error)
 
-	// BulkUpdateTransactionStatus sets status on all listed transaction IDs
-	// in a single atomic UPDATE. Returns an error if the affected row count
-	// does not match len(txIDs).
+	// BulkUpdateTransactionStatus sets status on all listed transaction IDs.
+	// Large ID lists are chunked internally. Returns an error if the affected
+	// row count does not match len(txIDs).
 	BulkUpdateTransactionStatus(ctx context.Context, txIDs []int64, status model.TransactionStatus) error
 
 	// MarkSplitsReconciledByAccount marks the splits for accountID in each of

--- a/internal/store/chunk.go
+++ b/internal/store/chunk.go
@@ -6,6 +6,9 @@ package store
 const sqliteChunkSize = 500
 
 func chunkInt64(ids []int64, size int) [][]int64 {
+	if size <= 0 {
+		panic("chunkInt64: size must be positive")
+	}
 	if len(ids) == 0 {
 		return nil
 	}

--- a/internal/store/chunk.go
+++ b/internal/store/chunk.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package store
+
+const sqliteChunkSize = 500
+
+func chunkInt64(ids []int64, size int) [][]int64 {
+	if len(ids) == 0 {
+		return nil
+	}
+	chunks := make([][]int64, 0, (len(ids)+size-1)/size)
+	for i := 0; i < len(ids); i += size {
+		end := i + size
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunks = append(chunks, ids[i:end])
+	}
+	return chunks
+}

--- a/internal/store/chunk_test.go
+++ b/internal/store/chunk_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChunkInt64_Empty(t *testing.T) {
+	chunks := chunkInt64(nil, 500)
+	assert.Empty(t, chunks)
+}
+
+func TestChunkInt64_UnderLimit(t *testing.T) {
+	ids := []int64{1, 2, 3}
+	chunks := chunkInt64(ids, 500)
+	assert.Equal(t, [][]int64{{1, 2, 3}}, chunks)
+}
+
+func TestChunkInt64_ExactLimit(t *testing.T) {
+	ids := make([]int64, 500)
+	for i := range ids {
+		ids[i] = int64(i + 1)
+	}
+	chunks := chunkInt64(ids, 500)
+	assert.Len(t, chunks, 1)
+	assert.Len(t, chunks[0], 500)
+}
+
+func TestChunkInt64_OverLimit(t *testing.T) {
+	ids := make([]int64, 1300)
+	for i := range ids {
+		ids[i] = int64(i + 1)
+	}
+	chunks := chunkInt64(ids, 500)
+	assert.Len(t, chunks, 3)
+	assert.Len(t, chunks[0], 500)
+	assert.Len(t, chunks[1], 500)
+	assert.Len(t, chunks[2], 300)
+	assert.Equal(t, int64(1), chunks[0][0])
+	assert.Equal(t, int64(501), chunks[1][0])
+	assert.Equal(t, int64(1001), chunks[2][0])
+}

--- a/internal/store/sqlite_reconcile.go
+++ b/internal/store/sqlite_reconcile.go
@@ -86,30 +86,32 @@ func (s *Store) MarkSplitsReconciledByAccount(ctx context.Context, accountID int
 		return 0, nil
 	}
 
-	placeholders := strings.Repeat("?,", len(txIDs))
-	placeholders = placeholders[:len(placeholders)-1]
+	var totalAffected int64
+	for _, chunk := range chunkInt64(txIDs, sqliteChunkSize) {
+		placeholders := strings.Repeat("?,", len(chunk))
+		placeholders = placeholders[:len(placeholders)-1]
 
-	// 1. Mark the account's splits as reconciled.
-	splitArgs := make([]any, 0, len(txIDs)+1)
-	splitArgs = append(splitArgs, accountID)
-	for _, id := range txIDs {
-		splitArgs = append(splitArgs, id)
-	}
-	splitQuery := fmt.Sprintf(
-		"UPDATE splits SET reconciled = 1 WHERE account_id = ? AND transaction_id IN (%s)",
-		placeholders,
-	)
-	result, err := s.db.ExecContext(ctx, splitQuery, splitArgs...)
-	if err != nil {
-		return 0, fmt.Errorf("failed to mark splits as reconciled: %w", err)
-	}
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return 0, fmt.Errorf("failed to get rows affected from splits update: %w", err)
+		splitArgs := make([]any, 0, len(chunk)+1)
+		splitArgs = append(splitArgs, accountID)
+		for _, id := range chunk {
+			splitArgs = append(splitArgs, id)
+		}
+		splitQuery := fmt.Sprintf(
+			"UPDATE splits SET reconciled = 1 WHERE account_id = ? AND transaction_id IN (%s)",
+			placeholders,
+		)
+		result, err := s.db.ExecContext(ctx, splitQuery, splitArgs...)
+		if err != nil {
+			return 0, fmt.Errorf("failed to mark splits as reconciled: %w", err)
+		}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return 0, fmt.Errorf("failed to get rows affected from splits update: %w", err)
+		}
+		totalAffected += rowsAffected
 	}
 
-	// 2. Upgrade all affected transactions to StatusReconciled.
-	return rowsAffected, s.bulkUpdateTransactionStatus(ctx, txIDs, model.StatusReconciled)
+	return totalAffected, s.bulkUpdateTransactionStatus(ctx, txIDs, model.StatusReconciled)
 }
 
 // BulkUpdateTransactionStatus sets the status of all listed transaction IDs

--- a/internal/store/sqlite_reconcile.go
+++ b/internal/store/sqlite_reconcile.go
@@ -114,9 +114,9 @@ func (s *Store) MarkSplitsReconciledByAccount(ctx context.Context, accountID int
 	return totalAffected, s.bulkUpdateTransactionStatus(ctx, txIDs, model.StatusReconciled)
 }
 
-// BulkUpdateTransactionStatus sets the status of all listed transaction IDs
-// in a single UPDATE statement. Returns an error if the affected row count
-// does not match len(txIDs) — indicating one or more IDs did not exist.
+// BulkUpdateTransactionStatus sets the status of all listed transaction IDs,
+// chunked to respect SQLite's variable limit. Returns an error if the affected
+// row count does not match len(txIDs) — indicating one or more IDs did not exist.
 func (s *Store) BulkUpdateTransactionStatus(ctx context.Context, txIDs []int64, status model.TransactionStatus) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -128,31 +128,35 @@ func (s *Store) bulkUpdateTransactionStatus(ctx context.Context, txIDs []int64, 
 		return nil
 	}
 
-	placeholders := strings.Repeat("?,", len(txIDs))
-	placeholders = placeholders[:len(placeholders)-1] // trim trailing comma
+	var totalAffected int64
+	for _, chunk := range chunkInt64(txIDs, sqliteChunkSize) {
+		placeholders := strings.Repeat("?,", len(chunk))
+		placeholders = placeholders[:len(placeholders)-1]
 
-	query := fmt.Sprintf(
-		"UPDATE transactions SET status = ? WHERE id IN (%s)",
-		placeholders,
-	)
+		query := fmt.Sprintf(
+			"UPDATE transactions SET status = ? WHERE id IN (%s)",
+			placeholders,
+		)
 
-	args := make([]any, 0, len(txIDs)+1)
-	args = append(args, status)
-	for _, id := range txIDs {
-		args = append(args, id)
+		args := make([]any, 0, len(chunk)+1)
+		args = append(args, status)
+		for _, id := range chunk {
+			args = append(args, id)
+		}
+
+		result, err := s.db.ExecContext(ctx, query, args...)
+		if err != nil {
+			return fmt.Errorf("failed to bulk update transaction status: %w", err)
+		}
+
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to get rows affected: %w", err)
+		}
+		totalAffected += rowsAffected
 	}
-
-	result, err := s.db.ExecContext(ctx, query, args...)
-	if err != nil {
-		return fmt.Errorf("failed to bulk update transaction status: %w", err)
-	}
-
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("failed to get rows affected: %w", err)
-	}
-	if rowsAffected != int64(len(txIDs)) {
-		return fmt.Errorf("expected to update %d transactions, updated %d", len(txIDs), rowsAffected)
+	if totalAffected != int64(len(txIDs)) {
+		return fmt.Errorf("expected to update %d transactions, updated %d", len(txIDs), totalAffected)
 	}
 	return nil
 }

--- a/internal/store/sqlite_reconcile_test.go
+++ b/internal/store/sqlite_reconcile_test.go
@@ -5,6 +5,7 @@ package store_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hance08/kea/internal/model"
@@ -251,6 +252,40 @@ func TestBulkUpdateTransactionStatus_MismatchedRowCount(t *testing.T) {
 
 	err = s.BulkUpdateTransactionStatus(ctx, []int64{txID, 99999}, model.StatusCleared)
 	require.Error(t, err)
+}
+
+func TestMarkSplitsReconciledByAccount_LargeBatch(t *testing.T) {
+	s := setupTestDB(t)
+	ctx := context.Background()
+
+	assetID, err := s.CreateAccount(ctx, "Assets:Bank", model.AccountTypeAsset, "USD", "", nil)
+	require.NoError(t, err)
+	expenseID, err := s.CreateAccount(ctx, "Expenses:Food", model.AccountTypeExpense, "USD", "", nil)
+	require.NoError(t, err)
+
+	const n = 600
+	txIDs := make([]int64, n)
+	for i := 0; i < n; i++ {
+		txID, err := s.CreateTransactionWithSplits(ctx, model.Transaction{
+			Timestamp:   int64(1000 + i),
+			Description: fmt.Sprintf("tx-%d", i),
+			Status:      model.StatusPending,
+			Type:        model.TxTypeExpense,
+		}, []model.Split{
+			{AccountID: assetID, Amount: -100, Currency: "USD"},
+			{AccountID: expenseID, Amount: 100, Currency: "USD"},
+		})
+		require.NoError(t, err)
+		txIDs[i] = txID
+	}
+
+	rowsAffected, err := s.MarkSplitsReconciledByAccount(ctx, assetID, txIDs)
+	require.NoError(t, err)
+	assert.Equal(t, int64(n), rowsAffected)
+
+	entries, err := s.GetUnreconciledTransactionsByAccount(ctx, assetID)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
 }
 
 func TestGetSetLastReconciledBalance(t *testing.T) {

--- a/internal/store/sqlite_reconcile_test.go
+++ b/internal/store/sqlite_reconcile_test.go
@@ -288,6 +288,41 @@ func TestMarkSplitsReconciledByAccount_LargeBatch(t *testing.T) {
 	assert.Empty(t, entries)
 }
 
+func TestBulkUpdateTransactionStatus_LargeBatch(t *testing.T) {
+	s := setupTestDB(t)
+	ctx := context.Background()
+
+	assetID, err := s.CreateAccount(ctx, "Assets:Bank", model.AccountTypeAsset, "USD", "", nil)
+	require.NoError(t, err)
+	expenseID, err := s.CreateAccount(ctx, "Expenses:Food", model.AccountTypeExpense, "USD", "", nil)
+	require.NoError(t, err)
+
+	const n = 600
+	txIDs := make([]int64, n)
+	for i := 0; i < n; i++ {
+		txID, err := s.CreateTransactionWithSplits(ctx, model.Transaction{
+			Timestamp:   int64(1000 + i),
+			Description: fmt.Sprintf("tx-%d", i),
+			Status:      model.StatusPending,
+			Type:        model.TxTypeExpense,
+		}, []model.Split{
+			{AccountID: assetID, Amount: -100, Currency: "USD"},
+			{AccountID: expenseID, Amount: 100, Currency: "USD"},
+		})
+		require.NoError(t, err)
+		txIDs[i] = txID
+	}
+
+	err = s.BulkUpdateTransactionStatus(ctx, txIDs, model.StatusCleared)
+	require.NoError(t, err)
+
+	for _, txID := range txIDs {
+		tx, err := s.GetTransactionByID(ctx, txID)
+		require.NoError(t, err)
+		assert.Equal(t, model.StatusCleared, tx.Status)
+	}
+}
+
 func TestGetSetLastReconciledBalance(t *testing.T) {
 	s := setupTestDB(t)
 	ctx := context.Background()

--- a/internal/store/sqlite_transaction.go
+++ b/internal/store/sqlite_transaction.go
@@ -407,9 +407,8 @@ func (s *Store) GetSplitsWithAccountsByTransaction(ctx context.Context, txID int
 	return result, nil
 }
 
-// GetSplitsWithAccountsByTransactionIDs assumes len(txIDs) is bounded by the
-// list command's --limit flag (default 20). SQLite's SQLITE_MAX_VARIABLE_NUMBER
-// is 999 by default, so this is safe for practical list sizes.
+// GetSplitsWithAccountsByTransactionIDs returns splits grouped by transaction ID.
+// Large ID slices are chunked to stay within SQLite's variable limit.
 func (s *Store) GetSplitsWithAccountsByTransactionIDs(ctx context.Context, txIDs []int64) (map[int64][]model.SplitDetail, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -418,45 +417,49 @@ func (s *Store) GetSplitsWithAccountsByTransactionIDs(ctx context.Context, txIDs
 		return make(map[int64][]model.SplitDetail), nil
 	}
 
-	placeholders := make([]byte, 0, len(txIDs)*2-1)
-	args := make([]any, len(txIDs))
-	for i, id := range txIDs {
-		if i > 0 {
-			placeholders = append(placeholders, ',')
-		}
-		placeholders = append(placeholders, '?')
-		args[i] = id
-	}
-
-	query := `
-        SELECT
-            s.id, s.transaction_id, s.account_id, s.amount, s.currency, s.memo,
-            a.name, a.type
-        FROM splits s
-        JOIN accounts a ON s.account_id = a.id
-        WHERE s.transaction_id IN (` + string(placeholders) + `)
-        ORDER BY s.transaction_id, s.id`
-
-	rows, err := s.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query splits by transaction IDs: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
 	result := make(map[int64][]model.SplitDetail)
-	for rows.Next() {
-		var d model.SplitDetail
-		var txID int64
-		if err := rows.Scan(
-			&d.ID, &txID, &d.AccountID, &d.Amount, &d.Currency, &d.Memo,
-			&d.AccountName, &d.AccountType,
-		); err != nil {
-			return nil, fmt.Errorf("failed to scan split with account: %w", err)
+	for _, chunk := range chunkInt64(txIDs, sqliteChunkSize) {
+		placeholders := make([]byte, 0, len(chunk)*2-1)
+		args := make([]any, len(chunk))
+		for i, id := range chunk {
+			if i > 0 {
+				placeholders = append(placeholders, ',')
+			}
+			placeholders = append(placeholders, '?')
+			args[i] = id
 		}
-		result[txID] = append(result[txID], d)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("rows iteration error: %w", err)
+
+		query := `
+            SELECT
+                s.id, s.transaction_id, s.account_id, s.amount, s.currency, s.memo,
+                a.name, a.type
+            FROM splits s
+            JOIN accounts a ON s.account_id = a.id
+            WHERE s.transaction_id IN (` + string(placeholders) + `)
+            ORDER BY s.transaction_id, s.id`
+
+		rows, err := s.db.QueryContext(ctx, query, args...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query splits by transaction IDs: %w", err)
+		}
+
+		for rows.Next() {
+			var d model.SplitDetail
+			var txID int64
+			if err := rows.Scan(
+				&d.ID, &txID, &d.AccountID, &d.Amount, &d.Currency, &d.Memo,
+				&d.AccountName, &d.AccountType,
+			); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("failed to scan split with account: %w", err)
+			}
+			result[txID] = append(result[txID], d)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("rows iteration error: %w", err)
+		}
+		_ = rows.Close()
 	}
 	return result, nil
 }

--- a/internal/store/sqlite_transaction_test.go
+++ b/internal/store/sqlite_transaction_test.go
@@ -5,6 +5,7 @@ package store_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hance08/kea/internal/model"
@@ -446,4 +447,37 @@ func TestGetSplitsWithAccountsByTransactionIDs(t *testing.T) {
 	empty, err := s.GetSplitsWithAccountsByTransactionIDs(ctx, []int64{})
 	require.NoError(t, err)
 	assert.Empty(t, empty)
+}
+
+func TestGetSplitsWithAccountsByTransactionIDs_LargeBatch(t *testing.T) {
+	s := setupTestDB(t)
+	ctx := context.Background()
+
+	assetID, err := s.CreateAccount(ctx, "Assets:Bank", model.AccountTypeAsset, "USD", "", nil)
+	require.NoError(t, err)
+	expenseID, err := s.CreateAccount(ctx, "Expenses:Food", model.AccountTypeExpense, "USD", "", nil)
+	require.NoError(t, err)
+
+	const n = 600
+	txIDs := make([]int64, n)
+	for i := 0; i < n; i++ {
+		txID, err := s.CreateTransactionWithSplits(ctx, model.Transaction{
+			Timestamp:   int64(1000 + i),
+			Description: fmt.Sprintf("tx-%d", i),
+			Status:      model.StatusPending,
+			Type:        model.TxTypeExpense,
+		}, []model.Split{
+			{AccountID: assetID, Amount: -100, Currency: "USD"},
+			{AccountID: expenseID, Amount: 100, Currency: "USD"},
+		})
+		require.NoError(t, err)
+		txIDs[i] = txID
+	}
+
+	result, err := s.GetSplitsWithAccountsByTransactionIDs(ctx, txIDs)
+	require.NoError(t, err)
+	assert.Len(t, result, n)
+	for _, txID := range txIDs {
+		assert.Len(t, result[txID], 2, "each transaction should have 2 splits")
+	}
 }


### PR DESCRIPTION
## Summary

- Added a `chunkInt64` helper that splits large `[]int64` slices into batches of 500 (safely under SQLite's `SQLITE_MAX_VARIABLE_NUMBER` default of 999)
- Chunked `GetSplitsWithAccountsByTransactionIDs` to iterate over batches and merge result maps
- Chunked `MarkSplitsReconciledByAccount` to accumulate affected rows across batches
- Chunked `bulkUpdateTransactionStatus` to accumulate affected rows and verify total count after all batches

Closes #125

## Test plan

- [x] Unit tests for `chunkInt64` (empty, under-limit, exact-limit, over-limit)
- [x] Integration test for `GetSplitsWithAccountsByTransactionIDs` with 600 IDs (spans 2 chunks)
- [x] Integration test for `MarkSplitsReconciledByAccount` with 600 IDs
- [x] Integration test for `BulkUpdateTransactionStatus` with 600 IDs
- [x] Existing `MismatchedRowCount` test still passes (row-count check preserved across chunks)
- [x] Full test suite (`go test ./...`) green with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)