### PR TITLE
fix: wrap duplicate external_id error with sentinel for API detection (#126)

### DIFF
--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -99,6 +99,9 @@ func (ts *TransactionService) CreateTransaction(ctx context.Context, input model
 
 		newTxID, err = repo.CreateTransactionWithSplits(ctx, tx, splits)
 		if err != nil {
+			if errors.Is(err, repository.ErrAlreadyExists) {
+				return fmt.Errorf("transaction already exists: %w", ErrAlreadyExists)
+			}
 			return fmt.Errorf("failed to create transaction: %w", err)
 		}
 		return nil

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -6,10 +6,12 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/hance08/kea/internal/model"
+	"github.com/hance08/kea/internal/repository"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -310,6 +312,27 @@ func TestCreateTransaction(t *testing.T) {
 		var ve *ValidationError
 		assert.True(t, errors.As(err, &ve))
 		assert.Equal(t, "status", ve.Field)
+	})
+
+	t.Run("duplicate external_id returns ErrAlreadyExists", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		txRepo.createErr = fmt.Errorf("duplicate external_id: %w", repository.ErrAlreadyExists)
+
+		input := model.TransactionDetail{
+			Description: "Lunch",
+			Type:        model.TxTypeExpense,
+			Splits: []model.SplitDetail{
+				{AccountName: "Expenses:Food", Amount: 500},
+				{AccountName: "Assets:Bank", Amount: -500},
+			},
+		}
+		_, err := svc.CreateTransaction(context.Background(), input)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrAlreadyExists), "expected ErrAlreadyExists, got: %v", err)
 	})
 }
 

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	ErrAccountExists       = fmt.Errorf("account already exists: %w", repository.ErrAlreadyExists)
+	ErrTransactionExists   = fmt.Errorf("transaction already exists: %w", repository.ErrAlreadyExists)
 	ErrRecordNotFound      = fmt.Errorf("record not found: %w", repository.ErrNotFound)
 	ErrConstraintViolation = fmt.Errorf("database constraint violation")
 	ErrInvalidAccountType  = fmt.Errorf("invalid account type")

--- a/internal/store/sqlite_transaction.go
+++ b/internal/store/sqlite_transaction.go
@@ -39,7 +39,7 @@ func (s *Store) CreateTransactionWithSplits(ctx context.Context, tx model.Transa
 		var sqliteErr sqlite.Error
 		if errors.As(err, &sqliteErr) {
 			if errors.Is(sqliteErr.Code, sqlite.ErrConstraint) || errors.Is(sqliteErr.ExtendedCode, sqlite.ErrConstraintUnique) {
-				return 0, fmt.Errorf("transaction already exists (duplicate external_id)")
+				return 0, fmt.Errorf("duplicate external_id: %w", ErrTransactionExists)
 			}
 		}
 		return 0, fmt.Errorf("failed to insert transaction: %w", err)


### PR DESCRIPTION
## Summary
- Add `ErrTransactionExists` sentinel in `store/errors.go` wrapping `repository.ErrAlreadyExists` (mirrors `ErrAccountExists`)
- Wrap the duplicate `external_id` constraint error in `sqlite_transaction.go` with the new sentinel instead of a plain string
- Translate `repository.ErrAlreadyExists` to `service.ErrAlreadyExists` in `CreateTransaction`, matching the pattern in `CreateAccount`

Closes #126

## Test plan
- [x] New test: `TestCreateTransaction/duplicate_external_id_returns_ErrAlreadyExists`
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)