### PR TITLE
fix: move reconcile validation reads inside ExecTx (#127)

### DIFF
--- a/internal/service/reconcile_ops.go
+++ b/internal/service/reconcile_ops.go
@@ -97,48 +97,50 @@ func (ts *TransactionService) ReconcileTransactions(ctx context.Context, account
 		return 0, validationErrorf("transactions", "no transactions selected for reconciliation")
 	}
 
-	// 1. Verify account exists.
+	// Fast-fail: verify account exists before opening a transaction.
 	if _, err := ts.accRepo.GetAccountByID(ctx, accountID); err != nil {
 		return 0, fmt.Errorf("account not found: %w", err)
 	}
 
-	// 2. Fetch last reconciled balance.
-	lastBalance, err := ts.txRepo.GetLastReconciledBalance(ctx, accountID)
-	if err != nil {
-		return 0, fmt.Errorf("failed to load last reconciled balance: %w", err)
-	}
-
-	// 3. Fetch unreconciled transactions and build a valid-ID → amount map.
-	entries, err := ts.txRepo.GetUnreconciledTransactionsByAccount(ctx, accountID)
-	if err != nil {
-		return 0, fmt.Errorf("failed to load unreconciled transactions: %w", err)
-	}
-
-	validAmounts := make(map[int64]int64, len(entries))
-	for _, e := range entries {
-		validAmounts[e.ID] = e.Amount
-	}
-
-	// 4. Validate every requested ID and accumulate the cleared balance.
-	var clearedBalance int64
+	// Duplicate-ID check is pure input validation — no DB needed.
 	seen := make(map[int64]bool, len(txIDs))
 	for _, id := range txIDs {
 		if seen[id] {
 			return 0, validationErrorf("transactions", "duplicate transaction ID %d", id)
 		}
 		seen[id] = true
-		amount, ok := validAmounts[id]
-		if !ok {
-			return 0, validationErrorf("transactions", "transaction ID %d is not in the unreconciled set for this account", id)
-		}
-		clearedBalance += amount
 	}
 
-	// 5-6. Atomically mark splits reconciled and persist the new running balance.
-	// Both writes run in the same DB transaction so a rows guard or a balance
-	// persistence error rolls back the splits UPDATE too.
-	newBalance := lastBalance + clearedBalance
+	// Everything else runs atomically inside a single DB transaction:
+	// read last balance → read unreconciled set → validate IDs → mark splits → persist balance.
+	var diff int64
 	if err := ts.tm.ExecTx(ctx, func(repo repository.Repository) error {
+		lastBalance, err := repo.GetLastReconciledBalance(ctx, accountID)
+		if err != nil {
+			return fmt.Errorf("failed to load last reconciled balance: %w", err)
+		}
+
+		entries, err := repo.GetUnreconciledTransactionsByAccount(ctx, accountID)
+		if err != nil {
+			return fmt.Errorf("failed to load unreconciled transactions: %w", err)
+		}
+
+		validAmounts := make(map[int64]int64, len(entries))
+		for _, e := range entries {
+			validAmounts[e.ID] = e.Amount
+		}
+
+		var clearedBalance int64
+		for _, id := range txIDs {
+			amount, ok := validAmounts[id]
+			if !ok {
+				return validationErrorf("transactions", "transaction ID %d is not in the unreconciled set for this account", id)
+			}
+			clearedBalance += amount
+		}
+
+		newBalance := lastBalance + clearedBalance
+
 		rowsAffected, err := repo.MarkSplitsReconciledByAccount(ctx, accountID, txIDs)
 		if err != nil {
 			return fmt.Errorf("failed to reconcile transactions: %w", err)
@@ -149,13 +151,16 @@ func (ts *TransactionService) ReconcileTransactions(ctx context.Context, account
 				len(txIDs), rowsAffected,
 			)
 		}
+
 		if err := repo.SetLastReconciledBalance(ctx, accountID, newBalance); err != nil {
 			return fmt.Errorf("failed to persist reconciled balance: %w", err)
 		}
+
+		diff = statementBalance - newBalance
 		return nil
 	}); err != nil {
 		return 0, err
 	}
 
-	return statementBalance - newBalance, nil
+	return diff, nil
 }

--- a/internal/service/reconcile_ops_test.go
+++ b/internal/service/reconcile_ops_test.go
@@ -555,3 +555,32 @@ func TestReconcileTransactions_ReadsInsideExecTx(t *testing.T) {
 		t.Errorf("expected persisted balance 50000, got %d", txRepo.lastReconciledBalances[1])
 	}
 }
+
+func TestReconcileTransactions_UnknownID_InsideExecTx_NoWrites(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
+		{ID: 10, Amount: 50000},
+	})
+	txRepo.lastReconciledBalances[1] = 20000
+
+	_, err := svc.ReconcileTransactions(context.Background(), 1, 70000, []int64{10, 99})
+
+	if err == nil {
+		t.Fatal("expected error for unknown transaction ID, got nil")
+	}
+	// Validation error from inside ExecTx must roll back: no marks, no balance change.
+	if len(txRepo.markSplitsReconciledCalls) != 0 {
+		t.Error("MarkSplitsReconciledByAccount must not persist when validation fails inside ExecTx")
+	}
+	if len(txRepo.setLastReconciledBalCalls) != 0 {
+		t.Error("SetLastReconciledBalance must not persist when validation fails inside ExecTx")
+	}
+	// Original balance must be unchanged.
+	if txRepo.lastReconciledBalances[1] != 20000 {
+		t.Errorf("expected last reconciled balance unchanged at 20000, got %d", txRepo.lastReconciledBalances[1])
+	}
+}

--- a/internal/service/reconcile_ops_test.go
+++ b/internal/service/reconcile_ops_test.go
@@ -532,3 +532,26 @@ func TestPreviewReconcile_DoesNotMutate(t *testing.T) {
 		t.Errorf("expected last reconciled balance unchanged at 0, got %d", bal)
 	}
 }
+
+func TestReconcileTransactions_ReadsInsideExecTx(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Checking", Type: model.AccountTypeAsset})
+	seedUnreconciled(txRepo, 1, []*model.ReconcileEntry{
+		{ID: 10, Amount: 50000},
+	})
+
+	diff, err := svc.ReconcileTransactions(context.Background(), 1, 50000, []int64{10})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff != 0 {
+		t.Errorf("expected diff 0, got %d", diff)
+	}
+	if txRepo.lastReconciledBalances[1] != 50000 {
+		t.Errorf("expected persisted balance 50000, got %d", txRepo.lastReconciledBalances[1])
+	}
+}


### PR DESCRIPTION
## Summary
- Moves `GetLastReconciledBalance` and `GetUnreconciledTransactionsByAccount` inside the `ExecTx` callback in `ReconcileTransactions` so the entire read-validate-write cycle is atomic
- Eliminates a TOCTOU race where concurrent reconcile requests could read the same unreconciled set, both validate, and both attempt to reconcile
- Duplicate-ID check and account-existence check remain outside as fast-fail guards (pure input validation, no DB dependency)

## Test Plan
- [x] Baseline test verifying reconcile works with reads inside ExecTx
- [x] Validation failure (unknown tx ID) inside ExecTx correctly rolls back — no splits marked, no balance persisted
- [x] All existing reconcile tests pass (15 tests)
- [x] Full test suite passes (`go test ./...`)

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)