### PR TITLE
fix: use online backup API when db is nil for WAL safety

### DIFF
--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -8,7 +8,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -147,39 +146,4 @@ func doBackup(dbPath, dst string, db *sql.DB) error {
 	}
 
 	return backupOnline(context.Background(), tmpDB, dst)
-}
-
-// copyFile copies src to dst atomically via a .tmp intermediate file.
-// The parent directory of dst must already exist.
-func copyFile(src, dst string) error {
-	tmp := dst + ".tmp"
-
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	out, err := os.Create(tmp)
-	if err != nil {
-		return err
-	}
-
-	if _, err := io.Copy(out, in); err != nil {
-		out.Close()
-		os.Remove(tmp)
-		return err
-	}
-
-	if err := out.Close(); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-
-	if err := os.Rename(tmp, dst); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-
-	return nil
 }

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -135,7 +135,18 @@ func doBackup(dbPath, dst string, db *sql.DB) error {
 	if db != nil {
 		return backupOnline(context.Background(), db, dst)
 	}
-	return copyFile(dbPath, dst)
+
+	tmpDB, err := sql.Open("sqlite3", dbPath+"?_busy_timeout=5000")
+	if err != nil {
+		return fmt.Errorf("open for backup: %w", err)
+	}
+	defer tmpDB.Close()
+
+	if err := tmpDB.Ping(); err != nil {
+		return fmt.Errorf("ping for backup: %w", err)
+	}
+
+	return backupOnline(context.Background(), tmpDB, dst)
 }
 
 // copyFile copies src to dst atomically via a .tmp intermediate file.

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -24,10 +24,9 @@ type realClock struct{}
 func (realClock) Now() time.Time { return time.Now() }
 
 // Run backs up dbPath if any tier is due. It is a no-op when dbPath does not
-// exist. When db is non-nil, the SQLite online backup API is used for a
-// consistent snapshot; when nil, the DB file is copied directly (CLI startup
-// path where the database is not yet open). Errors are non-fatal: the caller
-// should log and continue startup.
+// exist. When db is non-nil, that connection is reused; when nil, a temporary
+// connection is opened. Both paths use the SQLite online backup API for a
+// consistent snapshot safe under concurrent access.
 func Run(dbPath string, db *sql.DB) error {
 	return run(dbPath, realClock{}, db)
 }
@@ -127,9 +126,9 @@ func rotate(backupDir, dbBase, tierName, ext string, retention int) error {
 	return nil
 }
 
-// doBackup dispatches to the appropriate backup strategy. When db is non-nil
-// the SQLite online backup API is used for a consistent snapshot; otherwise
-// the source file is copied directly.
+// doBackup creates a backup using the SQLite online backup API. When db is
+// non-nil the existing connection is used; otherwise a temporary connection
+// is opened and closed after the backup completes.
 func doBackup(dbPath, dst string, db *sql.DB) error {
 	if db != nil {
 		return backupOnline(context.Background(), db, dst)

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -67,37 +67,6 @@ func TestBackupFilename(t *testing.T) {
 	assert.Equal(t, "kea_monthly_2026-04.db", backupFilename("kea", "monthly", "2026-04", ".db"))
 }
 
-func TestCopyFile(t *testing.T) {
-	dir := t.TempDir()
-
-	src := filepath.Join(dir, "kea.db")
-	require.NoError(t, os.WriteFile(src, []byte("db-contents"), 0644))
-
-	dst := filepath.Join(dir, "backups", "kea_daily_2026-04-14.db")
-	require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0755))
-
-	require.NoError(t, copyFile(src, dst))
-
-	got, err := os.ReadFile(dst)
-	require.NoError(t, err)
-	assert.Equal(t, []byte("db-contents"), got)
-}
-
-func TestCopyFile_LeavesNoTmpOnFailure(t *testing.T) {
-	dir := t.TempDir()
-	// Source does not exist — copy must fail and leave no .tmp behind.
-	src := filepath.Join(dir, "missing.db")
-	dst := filepath.Join(dir, "backups", "out.db")
-	require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0755))
-
-	err := copyFile(src, dst)
-	assert.Error(t, err)
-
-	// No .tmp file left behind.
-	_, statErr := os.Stat(dst + ".tmp")
-	assert.True(t, errors.Is(statErr, os.ErrNotExist))
-}
-
 func TestRotate_PrunesOldestBeyondRetention(t *testing.T) {
 	dir := t.TempDir()
 	backupDir := filepath.Join(dir, "backups")

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -429,7 +429,7 @@ func TestDoBackup_NilDB_ProducesConsistentSnapshot(t *testing.T) {
 	var count int
 	err = backupDB.QueryRow("SELECT COUNT(*) FROM items").Scan(&count)
 	require.NoError(t, err)
-	assert.GreaterOrEqual(t, count, 2, "backup should contain at least the committed rows")
+	assert.Equal(t, 3, count, "backup should contain all committed rows")
 }
 
 // assertFileExists is a helper that checks a file exists in dir.

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -426,6 +426,43 @@ func TestRun_WithDB_UsesOnlineBackup(t *testing.T) {
 	assert.Equal(t, "hello", val)
 }
 
+func TestDoBackup_NilDB_ProducesConsistentSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "kea.db")
+
+	srcDB, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	require.NoError(t, err)
+
+	_, err = srcDB.Exec("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)")
+	require.NoError(t, err)
+	_, err = srcDB.Exec("INSERT INTO items (name) VALUES ('alpha'), ('beta')")
+	require.NoError(t, err)
+
+	// Leave data in WAL by NOT closing or checkpointing.
+	// Write to WAL then keep the connection open to simulate a running web server.
+	_, err = srcDB.Exec("INSERT INTO items (name) VALUES ('gamma')")
+	require.NoError(t, err)
+	defer srcDB.Close()
+
+	dst := filepath.Join(dir, "backup.db")
+	err = doBackup(dbPath, dst, nil)
+	require.NoError(t, err)
+
+	backupDB, err := sql.Open("sqlite3", dst)
+	require.NoError(t, err)
+	defer backupDB.Close()
+
+	var result string
+	err = backupDB.QueryRow("PRAGMA integrity_check").Scan(&result)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result)
+
+	var count int
+	err = backupDB.QueryRow("SELECT COUNT(*) FROM items").Scan(&count)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, count, 2, "backup should contain at least the committed rows")
+}
+
 // assertFileExists is a helper that checks a file exists in dir.
 func assertFileExists(t *testing.T, dir, name string) {
 	t.Helper()

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -169,10 +169,14 @@ func TestRotate_OnlyTouchesMatchingTier(t *testing.T) {
 	assert.NoError(t, err, "weekly backup must not be deleted by daily rotation")
 }
 
-// mkDB creates a fake DB file at dbPath with contents "fake-db".
+// mkDB creates a real SQLite database file at dbPath.
 func mkDB(t *testing.T, dbPath string) {
 	t.Helper()
-	require.NoError(t, os.WriteFile(dbPath, []byte("fake-db"), 0644))
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec("CREATE TABLE _backup_marker (id INTEGER PRIMARY KEY)")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
 }
 
 func TestRun_FirstRun_AllThreeTiersCreated(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #111.

- When `doBackup` receives `db=nil`, it now opens a temporary `*sql.DB` connection and uses `backupOnline` (SQLite online backup API) instead of falling back to an unsafe raw file copy via `copyFile`
- Removed the dead `copyFile` function and its tests
- Updated `mkDB` test helper to create real SQLite databases instead of fake byte blobs

## Test Plan

- [x] New `TestDoBackup_NilDB_ProducesConsistentSnapshot` verifies the nil-db path produces a valid, queryable backup with integrity check
- [x] All 23 backup package tests pass
- [x] Full test suite passes across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)