### PR TITLE
fix: handle SIGTERM for graceful shutdown

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"unicode"
 
 	"github.com/hance08/kea/cmd/account"
@@ -133,7 +134,7 @@ func Execute(migrations fs.FS) {
 			return 1
 		}
 
-		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
 
 		if err := initSysAcc(ctx, application.Service, cfg); err != nil {


### PR DESCRIPTION
## Summary
- Add `syscall.SIGTERM` to `signal.NotifyContext` in `cmd/root.go` so process managers (systemd, Docker, launchd) trigger graceful shutdown instead of a hard kill
- Previously only `os.Interrupt` (SIGINT / Ctrl+C) was handled

Closes #129

## Test Plan
- [x] `make build` compiles successfully
- [x] `go test ./...` passes all tests
- [x] Manual: run KEA, send SIGTERM (`kill <pid>`), confirm clean exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>