### PR TITLE
fix: refactor RenameAccount to use DBTX interface (#110)

### DIFF
--- a/docs/superpowers/plans/2026-05-24-rename-account-exectx.md
+++ b/docs/superpowers/plans/2026-05-24-rename-account-exectx.md
@@ -1,0 +1,205 @@
+# RenameAccount ExecTx Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `Store.RenameAccount` use the `DBTX` interface so it can participate in `ExecTx` calls, then wrap the service-layer rename in `ExecTx` for atomicity.
+
+**Architecture:** Remove the self-managed transaction from the store method and use `s.db` (the `DBTX` interface) like every other store method. The service layer wraps the rename + read-back in `ExecTx`.
+
+**Tech Stack:** Go, SQLite, testify
+
+---
+
+## File Structure
+
+- **Modify:** `internal/store/sqlite_account.go` — refactor `RenameAccount` to use `s.db`
+- **Modify:** `internal/service/account_ops.go` — wrap rename in `ExecTx`
+- **Modify:** `internal/store/sqlite_account_test.go` — add composability test
+- **Modify:** `internal/service/account_ops_test.go` — verify `ExecTx` is used
+
+---
+
+### Task 1: Refactor store `RenameAccount` to use `s.db`
+
+**Files:**
+- Modify: `internal/store/sqlite_account.go:261-298`
+
+- [ ] **Step 1: Write failing store test for ExecTx composability**
+
+Add to `internal/store/sqlite_account_test.go`:
+
+```go
+func TestRenameAccount_InsideExecTx(t *testing.T) {
+	s := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := s.CreateAccount(ctx, "Assets:Bank", model.AccountTypeAsset, "USD", "", nil)
+	require.NoError(t, err)
+	_, err = s.CreateAccount(ctx, "Assets:Bank:Checking", model.AccountTypeAsset, "USD", "", nil)
+	require.NoError(t, err)
+
+	err = s.ExecTx(ctx, func(repo repository.Repository) error {
+		return repo.RenameAccount(ctx, "Assets:Bank", "Assets:CU")
+	})
+	require.NoError(t, err)
+
+	accounts, err := s.GetAllAccounts(ctx)
+	require.NoError(t, err)
+	names := accountNames(accounts)
+
+	assert.Contains(t, names, "Assets:CU")
+	assert.Contains(t, names, "Assets:CU:Checking")
+	assert.NotContains(t, names, "Assets:Bank")
+	assert.NotContains(t, names, "Assets:Bank:Checking")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/store/ -run TestRenameAccount_InsideExecTx -v`
+Expected: FAIL with "store is already in a transaction"
+
+- [ ] **Step 3: Refactor `RenameAccount` to use `s.db`**
+
+Replace `internal/store/sqlite_account.go` lines 261-298 with:
+
+```go
+// RenameAccount updates the name of an account and cascades the rename to all descendants.
+func (s *Store) RenameAccount(ctx context.Context, oldName, newName string) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	res, err := s.db.ExecContext(ctx, `UPDATE accounts SET name = ? WHERE name = ?`, newName, oldName)
+	if err != nil {
+		return fmt.Errorf("failed to rename account %q: %w", oldName, err)
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return fmt.Errorf("account %q not found: %w", oldName, ErrRecordNotFound)
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		`UPDATE accounts SET name = ? || substr(name, length(?) + 1)
+		 WHERE substr(name, 1, length(? || ':')) = ? || ':'`,
+		newName, oldName, oldName, oldName,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to cascade rename from %q to %q: %w", oldName, newName, err)
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 4: Run all RenameAccount store tests**
+
+Run: `go test ./internal/store/ -run TestRenameAccount -v`
+Expected: All 4 tests pass (LIKEWildcardsInName, DeepNesting, SiblingUnaffected, InsideExecTx)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/store/sqlite_account.go internal/store/sqlite_account_test.go
+git commit -m "fix: refactor RenameAccount to use DBTX interface (#110)
+
+Remove self-managed transaction from Store.RenameAccount. Use s.db
+(the DBTX interface) so the method can participate in ExecTx calls."
+```
+
+---
+
+### Task 2: Wrap service-layer `RenameAccount` in `ExecTx`
+
+**Files:**
+- Modify: `internal/service/account_ops.go:255-298`
+
+- [ ] **Step 1: Update `RenameAccount` to use `ExecTx`**
+
+Replace `internal/service/account_ops.go` lines 255-298 with:
+
+```go
+func (as *AccountService) RenameAccount(ctx context.Context, oldName, newFullName string) (*model.Account, error) {
+	acc, err := as.repo.GetAccountByName(ctx, oldName)
+	if err != nil {
+		return nil, err
+	}
+
+	if model.IsOpeningBalancesAccount(acc.Name) {
+		return nil, fmt.Errorf("account %q is a system account and cannot be edited: %w", acc.Name, ErrNotEditable)
+	}
+
+	oldPrefix := ""
+	if idx := strings.LastIndex(acc.Name, ":"); idx >= 0 {
+		oldPrefix = acc.Name[:idx+1]
+	}
+
+	newPrefix := ""
+	segment := newFullName
+	if idx := strings.LastIndex(newFullName, ":"); idx >= 0 {
+		newPrefix = newFullName[:idx+1]
+		segment = newFullName[idx+1:]
+	}
+
+	if newPrefix != oldPrefix {
+		return nil, validationErrorf("name", "rename cannot change parent path")
+	}
+
+	if err := as.ValidateAccountName(segment); err != nil {
+		return nil, validationWrap("name", "invalid account name", err)
+	}
+
+	exists, err := as.repo.AccountExists(ctx, newFullName)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		return nil, validationErrorf("name", "account %q already exists", newFullName)
+	}
+
+	var renamed *model.Account
+	err = as.tm.ExecTx(ctx, func(repo repository.Repository) error {
+		if err := repo.RenameAccount(ctx, acc.Name, newFullName); err != nil {
+			return err
+		}
+		got, err := repo.GetAccountByName(ctx, newFullName)
+		if err != nil {
+			return err
+		}
+		renamed = got
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return renamed, nil
+}
+```
+
+- [ ] **Step 2: Run existing service tests**
+
+Run: `go test ./internal/service/ -run TestRenameAccount -v`
+Expected: All 8 subtests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/service/account_ops.go
+git commit -m "fix: wrap service RenameAccount in ExecTx for atomicity (#110)
+
+The rename and read-back now run inside a single transaction,
+matching the pattern used by CreateAccountWithBalance."
+```
+
+---
+
+### Task 3: Run full test suite
+
+- [ ] **Step 1: Run all tests**
+
+Run: `go test ./...`
+Expected: All packages pass
+
+- [ ] **Step 2: Commit if any fixups were needed (skip if clean)**

--- a/docs/superpowers/specs/2026-05-24-rename-account-exectx-design.md
+++ b/docs/superpowers/specs/2026-05-24-rename-account-exectx-design.md
@@ -1,0 +1,71 @@
+# Refactor RenameAccount to use DBTX interface (#110)
+
+## Problem
+
+`Store.RenameAccount` in `internal/store/sqlite_account.go` manages its own
+transaction via `s.rawDB.BeginTx()` instead of using the `DBTX` interface
+(`s.db`). This prevents the method from participating in `ExecTx` calls,
+breaking composability. When called on a transaction-scoped store, `rawDB` is
+nil and the method returns an error.
+
+## Approach
+
+**Option A — Use `s.db` directly.** Remove the self-managed transaction and
+use `s.db.ExecContext()` for both SQL statements, matching every other store
+method. The caller (service layer) owns transaction boundaries via `ExecTx`.
+
+## Store layer changes
+
+File: `internal/store/sqlite_account.go`, method `RenameAccount`
+
+Remove:
+- `rawDB` nil check and the "already in a transaction" guard
+- `rawDB.BeginTx()`, `tx.Rollback()`, `tx.Commit()`
+- Mutex dance around `rawDB`
+
+Replace with:
+- `s.mu.RLock()` / `defer s.mu.RUnlock()` (same guard other methods use)
+- Two `s.db.ExecContext()` calls: rename self, then cascade descendants
+- Same SQL, same error handling, just operating on `s.db` instead of `tx`
+
+## Service layer changes
+
+File: `internal/service/account_ops.go`, method `RenameAccount`
+
+Wrap the mutating calls in `as.tm.ExecTx()`:
+
+```
+as.tm.ExecTx(ctx, func(repo repository.Repository) error {
+    if err := repo.RenameAccount(ctx, acc.Name, newFullName); err != nil {
+        return err
+    }
+    renamed, err = repo.GetAccountByName(ctx, newFullName)
+    return err
+})
+```
+
+Validation calls (`GetAccountByName`, `AccountExists`) stay outside the
+transaction — they are read-only checks. This matches the existing pattern
+in `CreateAccountWithOpeningBalance`.
+
+## Testing
+
+### Existing store tests (no changes expected)
+
+- `TestRenameAccount_LIKEWildcardsInName` — verifies cascade correctness
+- `TestRenameAccount_DeepNesting` — verifies multi-level cascade
+- `TestRenameAccount_SiblingUnaffected` — verifies prefix boundary
+
+These call `RenameAccount` on a top-level store where `s.db` is `*sql.DB`,
+so behavior is unchanged.
+
+### New store test
+
+`TestRenameAccount_InsideExecTx` — calls `RenameAccount` inside `ExecTx` to
+prove composability works. This is the core validation for issue #110.
+
+### Service tests
+
+Existing mock-based tests in `account_ops_test.go` continue to pass. Verify
+that `ExecTx` is called by the rename path (the mock `TransactionManager`
+already exists in `testhelper_test.go`).

--- a/internal/service/account_ops.go
+++ b/internal/service/account_ops.go
@@ -290,9 +290,20 @@ func (as *AccountService) RenameAccount(ctx context.Context, oldName, newFullNam
 		return nil, validationErrorf("name", "account %q already exists", newFullName)
 	}
 
-	if err := as.repo.RenameAccount(ctx, acc.Name, newFullName); err != nil {
+	var renamed *model.Account
+	err = as.tm.ExecTx(ctx, func(repo repository.Repository) error {
+		if err := repo.RenameAccount(ctx, acc.Name, newFullName); err != nil {
+			return err
+		}
+		got, err := repo.GetAccountByName(ctx, newFullName)
+		if err != nil {
+			return err
+		}
+		renamed = got
+		return nil
+	})
+	if err != nil {
 		return nil, err
 	}
-
-	return as.repo.GetAccountByName(ctx, newFullName)
+	return renamed, nil
 }

--- a/internal/service/account_ops_test.go
+++ b/internal/service/account_ops_test.go
@@ -797,6 +797,17 @@ func TestRenameAccount(t *testing.T) {
 
 		assert.Equal(t, model.OpeningBalancesAccountName("USD"), got.Name)
 	})
+
+	t.Run("ExecTx failure propagates error", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank", Type: model.AccountTypeAsset})
+		tm := &mockTransactionManager{accRepo: accRepo, txRepo: newMockTransactionRepo(), failTx: true}
+		svc := NewAccountService(accRepo, defaultConfig(), tm)
+
+		_, err := svc.RenameAccount(context.Background(), "Assets:Bank", "Assets:Savings")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "forced failure")
+	})
 }
 
 // ──────────────────────────────────────────────

--- a/internal/store/sqlite_account.go
+++ b/internal/store/sqlite_account.go
@@ -259,22 +259,11 @@ func (s *Store) AccountHasTransactions(ctx context.Context, accountID int64) (bo
 }
 
 // RenameAccount updates the name of an account and cascades the rename to all descendants.
-// Both updates run in a single transaction.
 func (s *Store) RenameAccount(ctx context.Context, oldName, newName string) error {
 	s.mu.RLock()
-	rawDB := s.rawDB
-	s.mu.RUnlock()
-	if rawDB == nil {
-		return fmt.Errorf("store is already in a transaction")
-	}
+	defer s.mu.RUnlock()
 
-	tx, err := rawDB.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	res, err := tx.ExecContext(ctx, `UPDATE accounts SET name = ? WHERE name = ?`, newName, oldName)
+	res, err := s.db.ExecContext(ctx, `UPDATE accounts SET name = ? WHERE name = ?`, newName, oldName)
 	if err != nil {
 		return fmt.Errorf("failed to rename account %q: %w", oldName, err)
 	}
@@ -286,7 +275,7 @@ func (s *Store) RenameAccount(ctx context.Context, oldName, newName string) erro
 		return fmt.Errorf("account %q not found: %w", oldName, ErrRecordNotFound)
 	}
 
-	_, err = tx.ExecContext(ctx,
+	_, err = s.db.ExecContext(ctx,
 		`UPDATE accounts SET name = ? || substr(name, length(?) + 1)
 		 WHERE substr(name, 1, length(? || ':')) = ? || ':'`,
 		newName, oldName, oldName, oldName,
@@ -295,7 +284,7 @@ func (s *Store) RenameAccount(ctx context.Context, oldName, newName string) erro
 		return fmt.Errorf("failed to cascade rename from %q to %q: %w", oldName, newName, err)
 	}
 
-	return tx.Commit()
+	return nil
 }
 
 // DeleteAccount removes an account record by ID.

--- a/internal/store/sqlite_account.go
+++ b/internal/store/sqlite_account.go
@@ -258,7 +258,9 @@ func (s *Store) AccountHasTransactions(ctx context.Context, accountID int64) (bo
 	return exists, nil
 }
 
-// RenameAccount updates the name of an account and cascades the rename to all descendants.
+// RenameAccount updates the name of an account and cascades the rename to all
+// descendants. The two UPDATEs are not wrapped in a transaction; callers should
+// use ExecTx when atomicity is required.
 func (s *Store) RenameAccount(ctx context.Context, oldName, newName string) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/store/sqlite_account_test.go
+++ b/internal/store/sqlite_account_test.go
@@ -111,6 +111,30 @@ func TestRenameAccount_SiblingUnaffected(t *testing.T) {
 	assert.NotContains(t, names, "Assets:Bank:Checking", "old child name should not exist")
 }
 
+func TestRenameAccount_InsideExecTx(t *testing.T) {
+	s := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := s.CreateAccount(ctx, "Assets:Bank", model.AccountTypeAsset, "USD", "", nil)
+	require.NoError(t, err)
+	_, err = s.CreateAccount(ctx, "Assets:Bank:Checking", model.AccountTypeAsset, "USD", "", nil)
+	require.NoError(t, err)
+
+	err = s.ExecTx(ctx, func(repo repository.Repository) error {
+		return repo.RenameAccount(ctx, "Assets:Bank", "Assets:CU")
+	})
+	require.NoError(t, err)
+
+	accounts, err := s.GetAllAccounts(ctx)
+	require.NoError(t, err)
+	names := accountNames(accounts)
+
+	assert.Contains(t, names, "Assets:CU")
+	assert.Contains(t, names, "Assets:CU:Checking")
+	assert.NotContains(t, names, "Assets:Bank")
+	assert.NotContains(t, names, "Assets:Bank:Checking")
+}
+
 func TestCreateAccount_And_GetByName(t *testing.T) {
 	s := setupTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- Refactored `Store.RenameAccount` to use the `DBTX` interface (`s.db`) instead of self-managing a transaction via `s.rawDB.BeginTx()`, enabling composability with `ExecTx`
- Wrapped service-layer `AccountService.RenameAccount` in `ExecTx` for atomicity (rename + read-back in one transaction)
- Added store-level composability test (`TestRenameAccount_InsideExecTx`) and service-level `ExecTx` failure test

Closes #110

## Test plan
- [x] `TestRenameAccount_InsideExecTx` — proves `RenameAccount` works inside `ExecTx`
- [x] Existing store tests pass (LIKEWildcardsInName, DeepNesting, SiblingUnaffected)
- [x] All service `TestRenameAccount` subtests pass (10 subtests including new ExecTx failure test)
- [x] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)