### PR TITLE
feat: add Description and Memo field validation (#123)

### DIFF
--- a/docs/superpowers/plans/2026-05-24-description-memo-validation.md
+++ b/docs/superpowers/plans/2026-05-24-description-memo-validation.md
@@ -1,0 +1,655 @@
+# Description & Memo Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add length and emptiness validation for Description and Memo fields in the service layer to prevent DB bloat and provide defense-in-depth (issue #123).
+
+**Architecture:** Inline `validationErrorf()` checks in each affected service method, following the existing pattern used for `AccountNameMaxLength`. Two new constants in `model/types.go`. Transaction descriptions are required (non-empty); account descriptions and split memos are optional (length-only).
+
+**Tech Stack:** Go, testify (assert/require)
+
+---
+
+### Task 1: Add constants to model
+
+**Files:**
+- Modify: `internal/model/types.go:26-31`
+
+- [ ] **Step 1: Write the failing test**
+
+Create file `internal/model/types_test.go`:
+
+```go
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDescriptionMaxLength(t *testing.T) {
+	assert.Equal(t, 500, DescriptionMaxLength)
+}
+
+func TestMemoMaxLength(t *testing.T) {
+	assert.Equal(t, 200, MemoMaxLength)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/model/ -run "TestDescriptionMaxLength|TestMemoMaxLength" -v`
+Expected: FAIL — `DescriptionMaxLength` and `MemoMaxLength` undefined
+
+- [ ] **Step 3: Add the constants**
+
+In `internal/model/types.go`, add to the existing constant block at line 26:
+
+```go
+const (
+	AccountNameMaxLength  = 100
+	DescriptionMaxLength  = 500
+	MemoMaxLength         = 200
+	MaxSafeBalanceFloat   = 9223372036854775.0
+	OpeningAccountMemo    = "Opening Balance"
+	TypeEquity            = "C"
+)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/model/ -run "TestDescriptionMaxLength|TestMemoMaxLength" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/model/types.go internal/model/types_test.go
+git commit -m "feat: add DescriptionMaxLength and MemoMaxLength constants (#123)"
+```
+
+---
+
+### Task 2: Validate Description and Memo in CreateTransaction
+
+**Files:**
+- Modify: `internal/service/transaction_ops.go:6-14` (add `"strings"` import)
+- Modify: `internal/service/transaction_ops.go:32-39` (add description validation after type check)
+- Modify: `internal/service/transaction_ops.go:50-73` (add memo validation in split loop)
+- Test: `internal/service/transaction_ops_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+First, add `"strings"` to the import block in `internal/service/transaction_ops_test.go`:
+
+```go
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hance08/kea/internal/model"
+	"github.com/hance08/kea/internal/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+```
+
+Then add new test function:
+
+```go
+func TestCreateTransaction_DescriptionValidation(t *testing.T) {
+	makeInput := func(desc string, memo string) model.TransactionDetail {
+		return model.TransactionDetail{
+			Description: desc,
+			Type:        model.TxTypeExpense,
+			Splits: []model.SplitDetail{
+				{AccountName: "Expenses:Food", Amount: 500, Memo: memo},
+				{AccountName: "Assets:Bank", Amount: -500},
+			},
+		}
+	}
+
+	t.Run("empty description rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+		_, err := svc.CreateTransaction(context.Background(), makeInput("", ""))
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+		assert.Contains(t, ve.Message, "required")
+	})
+
+	t.Run("whitespace-only description rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+		_, err := svc.CreateTransaction(context.Background(), makeInput("   ", ""))
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+	})
+
+	t.Run("over-length description rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+		longDesc := strings.Repeat("a", model.DescriptionMaxLength+1)
+		_, err := svc.CreateTransaction(context.Background(), makeInput(longDesc, ""))
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+		assert.Contains(t, ve.Message, "too long")
+	})
+
+	t.Run("exactly max-length description accepted", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		exactDesc := strings.Repeat("a", model.DescriptionMaxLength)
+		id, err := svc.CreateTransaction(context.Background(), makeInput(exactDesc, ""))
+		require.NoError(t, err)
+		assert.Greater(t, id, int64(0))
+	})
+
+	t.Run("over-length memo on split rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+		longMemo := strings.Repeat("m", model.MemoMaxLength+1)
+		_, err := svc.CreateTransaction(context.Background(), makeInput("Valid desc", longMemo))
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "memo", ve.Field)
+		assert.Contains(t, ve.Message, "too long")
+	})
+
+	t.Run("exactly max-length memo accepted", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		exactMemo := strings.Repeat("m", model.MemoMaxLength)
+		id, err := svc.CreateTransaction(context.Background(), makeInput("Valid desc", exactMemo))
+		require.NoError(t, err)
+		assert.Greater(t, id, int64(0))
+	})
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/service/ -run TestCreateTransaction_DescriptionValidation -v`
+Expected: FAIL — empty description and over-length tests pass when they should fail (no validation yet)
+
+- [ ] **Step 3: Add validation to CreateTransaction**
+
+In `internal/service/transaction_ops.go`:
+
+1. Add `"strings"` to the import block:
+
+```go
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hance08/kea/internal/model"
+	"github.com/hance08/kea/internal/repository"
+)
+```
+
+2. After the status validation (line 39), add description validation:
+
+```go
+	if strings.TrimSpace(input.Description) == "" {
+		return 0, validationErrorf("description", "description is required")
+	}
+	if len(input.Description) > model.DescriptionMaxLength {
+		return 0, validationErrorf("description", "description too long (max %d characters)", model.DescriptionMaxLength)
+	}
+```
+
+3. Inside the split loop (after building the `model.Split` struct around line 68-73), add memo validation before appending:
+
+```go
+		if len(splitInput.Memo) > model.MemoMaxLength {
+			return 0, validationErrorf("memo", "split #%d memo too long (max %d characters)", i+1, model.MemoMaxLength)
+		}
+
+		splits = append(splits, model.Split{
+```
+
+- [ ] **Step 4: Fix existing tests that use empty Description**
+
+Many existing `TestCreateTransaction` tests omit Description (which defaults to `""`). These will now fail because description is required. Add `Description: "test"` to every `TransactionDetail` and `CreateSimpleTransactionInput` in the test file that currently has an empty description. Specifically, update these test inputs (search for `model.TransactionDetail{` and `model.CreateSimpleTransactionInput{` without a `Description` field or with `Description: ""`):
+
+- `fewer than 2 splits rejected` — add `Description: "test"` (won't reach description validation but keeps the input valid)
+- `empty splits rejected` — add `Description: "test"`
+- `error: missing type` — add `Description: "test"`
+- `unbalanced splits rejected` — add `Description: "test"`
+- `unknown account rejected` — add `Description: "test"`
+- `zero timestamp is set to current time` — add `Description: "test"`
+- `account currency overrides system default` — add `Description: "test"`
+- `mixed currency splits rejected` — add `Description: "test"`
+- `account without currency uses system default` — add `Description: "test"`
+- And any other `CreateTransaction`/`UpdateTransactionComplete` test inputs with empty descriptions
+
+For `UpdateTransactionComplete` tests: update all inputs that have `Description: ""` to `Description: "test"` — EXCEPT the "invalid status" test (line ~597) which fails before reaching description validation.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/service/ -run "TestCreateTransaction|TestUpdateTransactionComplete" -v`
+Expected: ALL PASS (new validation tests + existing tests with fixed descriptions)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/service/transaction_ops.go internal/service/transaction_ops_test.go
+git commit -m "feat: validate Description and Memo in CreateTransaction (#123)"
+```
+
+---
+
+### Task 3: Validate Description and Memo in UpdateTransactionComplete
+
+**Files:**
+- Modify: `internal/service/transaction_ops.go:255-283` (add validation after status check)
+- Test: `internal/service/transaction_ops_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/service/transaction_ops_test.go`:
+
+```go
+func TestUpdateTransactionComplete_DescriptionValidation(t *testing.T) {
+	setupForUpdate := func() (*mockAccountRepo, *mockTransactionRepo, *TransactionService) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		txRepo.addTransaction(
+			&model.Transaction{ID: 1, Description: "Old", Status: model.StatusPending, Type: model.TxTypeExpense},
+			[]*model.Split{
+				{ID: 10, TransactionID: 1, AccountID: 2, Amount: 500, Currency: "USD"},
+				{ID: 11, TransactionID: 1, AccountID: 1, Amount: -500, Currency: "USD"},
+			},
+		)
+		svc := newTestTransactionService(accRepo, txRepo)
+		return accRepo, txRepo, svc
+	}
+
+	makeInput := func(desc string, memo string) model.UpdateTransactionInput {
+		return model.UpdateTransactionInput{
+			ID:          1,
+			Description: desc,
+			Timestamp:   time.Now().Unix(),
+			Status:      model.StatusPending,
+			Type:        model.TxTypeExpense,
+			Splits: []model.SplitDetail{
+				{ID: 10, AccountName: "Expenses:Food", Amount: 500, Memo: memo},
+				{ID: 11, AccountName: "Assets:Bank", Amount: -500},
+			},
+		}
+	}
+
+	t.Run("empty description rejected", func(t *testing.T) {
+		_, _, svc := setupForUpdate()
+		err := svc.UpdateTransactionComplete(context.Background(), makeInput("", ""))
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+		assert.Contains(t, ve.Message, "required")
+	})
+
+	t.Run("whitespace-only description rejected", func(t *testing.T) {
+		_, _, svc := setupForUpdate()
+		err := svc.UpdateTransactionComplete(context.Background(), makeInput("   ", ""))
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+	})
+
+	t.Run("over-length description rejected", func(t *testing.T) {
+		_, _, svc := setupForUpdate()
+		longDesc := strings.Repeat("a", model.DescriptionMaxLength+1)
+		err := svc.UpdateTransactionComplete(context.Background(), makeInput(longDesc, ""))
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+		assert.Contains(t, ve.Message, "too long")
+	})
+
+	t.Run("over-length memo on split rejected", func(t *testing.T) {
+		_, _, svc := setupForUpdate()
+		longMemo := strings.Repeat("m", model.MemoMaxLength+1)
+		err := svc.UpdateTransactionComplete(context.Background(), makeInput("Valid desc", longMemo))
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "memo", ve.Field)
+		assert.Contains(t, ve.Message, "too long")
+	})
+
+	t.Run("valid description and memo accepted", func(t *testing.T) {
+		_, _, svc := setupForUpdate()
+		err := svc.UpdateTransactionComplete(context.Background(), makeInput("Updated lunch", "some memo"))
+		require.NoError(t, err)
+	})
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/service/ -run TestUpdateTransactionComplete_DescriptionValidation -v`
+Expected: FAIL — empty description and over-length tests pass when they should fail
+
+- [ ] **Step 3: Add validation to UpdateTransactionComplete**
+
+In `internal/service/transaction_ops.go`, in the `UpdateTransactionComplete` method, after the status validation (line 257) and before the `GetTransactionByID` call (line 260), add:
+
+```go
+	if strings.TrimSpace(input.Description) == "" {
+		return validationErrorf("description", "description is required")
+	}
+	if len(input.Description) > model.DescriptionMaxLength {
+		return validationErrorf("description", "description too long (max %d characters)", model.DescriptionMaxLength)
+	}
+```
+
+After the `ValidateSplitsMatchType` call (line 281-283) and before the `ExecTx` call, add memo validation:
+
+```go
+	for i, s := range input.Splits {
+		if len(s.Memo) > model.MemoMaxLength {
+			return validationErrorf("memo", "split #%d memo too long (max %d characters)", i+1, model.MemoMaxLength)
+		}
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/service/ -run "TestUpdateTransactionComplete" -v`
+Expected: ALL PASS (new validation tests + existing tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/transaction_ops.go internal/service/transaction_ops_test.go
+git commit -m "feat: validate Description and Memo in UpdateTransactionComplete (#123)"
+```
+
+---
+
+### Task 4: Validate Description in CreateAccount and CreateAccountWithBalance
+
+**Files:**
+- Modify: `internal/service/account_ops.go:49-57` (add validation in CreateAccount)
+- Modify: `internal/service/account_ops.go:60-67` (add validation in CreateAccountWithBalance)
+- Test: `internal/service/account_ops_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/service/account_ops_test.go`:
+
+```go
+func TestCreateAccount_DescriptionValidation(t *testing.T) {
+	t.Run("empty description is allowed", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		input := model.CreateAccountInput{
+			Name:        "Checking",
+			Type:        model.AccountTypeAsset,
+			Currency:    "USD",
+			Description: "",
+		}
+		acc, err := svc.CreateAccount(context.Background(), input)
+		require.NoError(t, err)
+		assert.NotNil(t, acc)
+	})
+
+	t.Run("over-length description rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		input := model.CreateAccountInput{
+			Name:        "Checking",
+			Type:        model.AccountTypeAsset,
+			Currency:    "USD",
+			Description: strings.Repeat("d", model.DescriptionMaxLength+1),
+		}
+		acc, err := svc.CreateAccount(context.Background(), input)
+		assert.Nil(t, acc)
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+		assert.Contains(t, ve.Message, "too long")
+	})
+
+	t.Run("exactly max-length description accepted", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		input := model.CreateAccountInput{
+			Name:        "Checking",
+			Type:        model.AccountTypeAsset,
+			Currency:    "USD",
+			Description: strings.Repeat("d", model.DescriptionMaxLength),
+		}
+		acc, err := svc.CreateAccount(context.Background(), input)
+		require.NoError(t, err)
+		assert.NotNil(t, acc)
+	})
+}
+
+func TestCreateAccountWithBalance_DescriptionValidation(t *testing.T) {
+	t.Run("over-length description rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		addOpeningBalancesForCurrency(accRepo, "USD")
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		input := model.CreateAccountInput{
+			Name:        "Checking",
+			Type:        model.AccountTypeAsset,
+			Currency:    "USD",
+			Description: strings.Repeat("d", model.DescriptionMaxLength+1),
+			Balance:     10000,
+		}
+		acc, err := svc.CreateAccountWithBalance(context.Background(), input)
+		assert.Nil(t, acc)
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+	})
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/service/ -run "TestCreateAccount_DescriptionValidation|TestCreateAccountWithBalance_DescriptionValidation" -v`
+Expected: FAIL — over-length tests pass when they should fail
+
+- [ ] **Step 3: Add validation to both methods**
+
+In `internal/service/account_ops.go`:
+
+In `CreateAccount` (line 49), add before the `validateAccountFields` call:
+
+```go
+func (as *AccountService) CreateAccount(ctx context.Context, input model.CreateAccountInput) (*model.Account, error) {
+	input.Currency = strings.ToUpper(strings.TrimSpace(input.Currency))
+	if len(input.Description) > model.DescriptionMaxLength {
+		return nil, validationErrorf("description", "description too long (max %d characters)", model.DescriptionMaxLength)
+	}
+	if err := as.validateAccountFields(ctx, input.Name, input.Type, input.Currency, input.ParentID); err != nil {
+```
+
+In `CreateAccountWithBalance` (line 60), add the same check before `validateAccountFields`:
+
+```go
+func (as *AccountService) CreateAccountWithBalance(ctx context.Context, input model.CreateAccountInput) (*model.Account, error) {
+	input.Currency = strings.ToUpper(strings.TrimSpace(input.Currency))
+	if len(input.Description) > model.DescriptionMaxLength {
+		return nil, validationErrorf("description", "description too long (max %d characters)", model.DescriptionMaxLength)
+	}
+	if err := as.validateAccountFields(ctx, input.Name, input.Type, input.Currency, input.ParentID); err != nil {
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/service/ -run "TestCreateAccount|TestCreateAccountWithBalance" -v`
+Expected: ALL PASS (new validation tests + existing tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/account_ops.go internal/service/account_ops_test.go
+git commit -m "feat: validate Description in CreateAccount and CreateAccountWithBalance (#123)"
+```
+
+---
+
+### Task 5: Validate Description in UpdateAccountMetadata
+
+**Files:**
+- Modify: `internal/service/account_service.go:168-183` (add validation at method entry)
+- Modify: `internal/service/account_service_test.go:6-15` (add `"strings"` import)
+- Test: `internal/service/account_service_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+First, add `"strings"` to the import block in `internal/service/account_service_test.go`:
+
+```go
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hance08/kea/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+```
+
+Then add to `internal/service/account_service_test.go`:
+
+```go
+func TestUpdateAccountMetadata_DescriptionValidation(t *testing.T) {
+	t.Run("empty description is allowed", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Cash", Type: model.AccountTypeAsset, Currency: "USD"})
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		acc, err := svc.UpdateAccountMetadata(context.Background(), 1, "", false)
+		require.NoError(t, err)
+		assert.NotNil(t, acc)
+	})
+
+	t.Run("over-length description rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Cash", Type: model.AccountTypeAsset, Currency: "USD"})
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		longDesc := strings.Repeat("d", model.DescriptionMaxLength+1)
+		acc, err := svc.UpdateAccountMetadata(context.Background(), 1, longDesc, false)
+		assert.Nil(t, acc)
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+		assert.Contains(t, ve.Message, "too long")
+	})
+
+	t.Run("exactly max-length description accepted", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Cash", Type: model.AccountTypeAsset, Currency: "USD"})
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		exactDesc := strings.Repeat("d", model.DescriptionMaxLength)
+		acc, err := svc.UpdateAccountMetadata(context.Background(), 1, exactDesc, false)
+		require.NoError(t, err)
+		assert.NotNil(t, acc)
+	})
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/service/ -run TestUpdateAccountMetadata_DescriptionValidation -v`
+Expected: FAIL — over-length test passes when it should fail
+
+- [ ] **Step 3: Add validation to UpdateAccountMetadata**
+
+In `internal/service/account_service.go`, at the start of `UpdateAccountMetadata` (line 168), add before the `GetAccountByID` call:
+
+```go
+func (as *AccountService) UpdateAccountMetadata(ctx context.Context, accountID int64, description string, isHidden bool) (*model.Account, error) {
+	if len(description) > model.DescriptionMaxLength {
+		return nil, validationErrorf("description", "description too long (max %d characters)", model.DescriptionMaxLength)
+	}
+
+	acc, err := as.repo.GetAccountByID(ctx, accountID)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/service/ -run "TestUpdateAccountMetadata" -v`
+Expected: ALL PASS (new validation tests + existing tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/account_service.go internal/service/account_service_test.go
+git commit -m "feat: validate Description in UpdateAccountMetadata (#123)"
+```
+
+---
+
+### Task 6: Full regression test
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `go test ./...`
+Expected: ALL PASS — no regressions
+
+Note: Tests in `internal/service/errors_test.go` (lines 230-264) create `TransactionDetail` without Description but they fail on splits/type validation before reaching description validation, so they won't break.
+
+The `transaction_classifier_test.go` tests create `TransactionDetail` structs for classification logic (not passed to `CreateTransaction`), so those are unaffected.
+
+- [ ] **Step 2: Commit (if any fixups needed)**
+
+If any tests broke due to missing descriptions in test fixtures, fix them and commit:
+
+```bash
+git add -u
+git commit -m "fix: update test fixtures with valid descriptions (#123)"
+```

--- a/docs/superpowers/specs/2026-05-24-description-memo-validation-design.md
+++ b/docs/superpowers/specs/2026-05-24-description-memo-validation-design.md
@@ -1,0 +1,81 @@
+# Description & Memo Field Validation
+
+**Issue:** #123  
+**Date:** 2026-05-24  
+**Branch:** `fix/issue-123-description-memo-validation`
+
+## Problem
+
+`CreateTransaction`, `UpdateTransactionComplete`, `CreateAccount`, and `UpdateAccountMetadata` do not validate the length or content of Description or Memo fields. Account names have `AccountNameMaxLength` but descriptions and memos have none. This allows multi-MB strings via the API and provides no defense-in-depth against stored XSS payloads.
+
+The default description `"-"` is set only in `cmd/add_actions.go`, not in the service layer. API-created transactions can have truly empty descriptions.
+
+## Approach
+
+Inline validation in each service method using the existing `validationErrorf()` pattern (Approach A — no shared helpers, no model-layer `Validate()` methods).
+
+## Constants
+
+Added to `internal/model/types.go` alongside `AccountNameMaxLength`:
+
+| Constant             | Value | Rationale                                        |
+|----------------------|-------|--------------------------------------------------|
+| `DescriptionMaxLength` | 500   | Generous for human descriptions, prevents DB bloat |
+| `MemoMaxLength`        | 200   | Split-level notes, shorter than descriptions       |
+
+## Validation Rules
+
+### Description
+- **Required:** must not be empty after `strings.TrimSpace()`.
+- **Max length:** must not exceed `DescriptionMaxLength` (500) characters.
+- The `"-"` default remains a CLI convention in `cmd/add_actions.go`. The service rejects empty descriptions; each client decides its own default.
+
+### Memo
+- **Optional:** empty string is allowed (splits don't always need a memo).
+- **Max length:** must not exceed `MemoMaxLength` (200) characters when provided.
+
+## Affected Methods
+
+### 1. `CreateTransaction` (`internal/service/transaction_ops.go:24`)
+- Validate `input.Description` (required + max length) in the existing validation block (after split count check).
+- Validate each `splitInput.Memo` (max length only) in the existing split loop.
+
+### 2. `UpdateTransactionComplete` (`internal/service/transaction_ops.go:255`)
+- Validate `input.Description` (required + max length) in the existing validation block (after status check).
+- Validate each split's `Memo` (max length only) before entering the `ExecTx` block.
+
+### 3. `CreateAccount` (`internal/service/account_ops.go:49`)
+- Validate `input.Description` (required + max length) before `validateAccountFields`.
+
+### 4. `CreateAccountWithBalance` (`internal/service/account_ops.go:60`)
+- Same description validation as `CreateAccount`, before `validateAccountFields`.
+
+### 5. `UpdateAccountMetadata` (`internal/service/account_service.go:168`)
+- Validate `description` parameter (required + max length) at method entry, before the `GetAccountByID` call.
+
+## Error Format
+
+Uses the existing `validationErrorf()` helper, returning `*ValidationError`:
+
+```go
+validationErrorf("description", "description is required")
+validationErrorf("description", "description too long (max %d characters)", model.DescriptionMaxLength)
+validationErrorf("memo", "split #%d memo too long (max %d characters)", i+1, model.MemoMaxLength)
+```
+
+## Testing
+
+White-box tests using the existing mock infrastructure (`package service`). Each method gets tests for:
+
+- Empty description is rejected with `ValidationError{Field: "description"}`
+- Whitespace-only description is rejected
+- Over-length description is rejected
+- Over-length memo is rejected (for transaction methods)
+- Valid inputs at the boundary (exactly max length) pass
+- Existing tests continue to pass (no regressions)
+
+## Out of Scope
+
+- Moving the `"-"` default into the service layer (stays in `cmd/add_actions.go`).
+- Content-based validation (e.g., character allowlists). Max length is sufficient defense-in-depth; output escaping is the responsibility of the presentation layer.
+- Validating Description/Memo in store-layer methods (service is the validation boundary).

--- a/docs/superpowers/specs/2026-05-24-description-memo-validation-design.md
+++ b/docs/superpowers/specs/2026-05-24-description-memo-validation-design.md
@@ -25,10 +25,14 @@ Added to `internal/model/types.go` alongside `AccountNameMaxLength`:
 
 ## Validation Rules
 
-### Description
+### Transaction Description
 - **Required:** must not be empty after `strings.TrimSpace()`.
 - **Max length:** must not exceed `DescriptionMaxLength` (500) characters.
 - The `"-"` default remains a CLI convention in `cmd/add_actions.go`. The service rejects empty descriptions; each client decides its own default.
+
+### Account Description
+- **Optional:** empty string is allowed (accounts don't always need a description).
+- **Max length:** must not exceed `DescriptionMaxLength` (500) characters when provided.
 
 ### Memo
 - **Optional:** empty string is allowed (splits don't always need a memo).
@@ -45,13 +49,13 @@ Added to `internal/model/types.go` alongside `AccountNameMaxLength`:
 - Validate each split's `Memo` (max length only) before entering the `ExecTx` block.
 
 ### 3. `CreateAccount` (`internal/service/account_ops.go:49`)
-- Validate `input.Description` (required + max length) before `validateAccountFields`.
+- Validate `input.Description` (max length only — account descriptions are optional) before `validateAccountFields`.
 
 ### 4. `CreateAccountWithBalance` (`internal/service/account_ops.go:60`)
 - Same description validation as `CreateAccount`, before `validateAccountFields`.
 
 ### 5. `UpdateAccountMetadata` (`internal/service/account_service.go:168`)
-- Validate `description` parameter (required + max length) at method entry, before the `GetAccountByID` call.
+- Validate `description` parameter (max length only) at method entry, before the `GetAccountByID` call.
 
 ## Error Format
 
@@ -65,13 +69,20 @@ validationErrorf("memo", "split #%d memo too long (max %d characters)", i+1, mod
 
 ## Testing
 
-White-box tests using the existing mock infrastructure (`package service`). Each method gets tests for:
+White-box tests using the existing mock infrastructure (`package service`). 
 
+**Transaction methods** (`CreateTransaction`, `UpdateTransactionComplete`):
 - Empty description is rejected with `ValidationError{Field: "description"}`
 - Whitespace-only description is rejected
 - Over-length description is rejected
-- Over-length memo is rejected (for transaction methods)
+- Over-length memo on a split is rejected
 - Valid inputs at the boundary (exactly max length) pass
+
+**Account methods** (`CreateAccount`, `CreateAccountWithBalance`, `UpdateAccountMetadata`):
+- Empty description is allowed (account descriptions are optional)
+- Over-length description is rejected
+- Valid inputs at the boundary (exactly max length) pass
+
 - Existing tests continue to pass (no regressions)
 
 ## Out of Scope

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -24,10 +24,12 @@ const (
 )
 
 const (
-	AccountNameMaxLength = 100
-	MaxSafeBalanceFloat  = 9223372036854775.0
-	OpeningAccountMemo   = "Opening Balance"
-	TypeEquity           = "C"
+	AccountNameMaxLength  = 100
+	DescriptionMaxLength  = 500
+	MemoMaxLength         = 200
+	MaxSafeBalanceFloat   = 9223372036854775.0
+	OpeningAccountMemo    = "Opening Balance"
+	TypeEquity            = "C"
 )
 
 var ReservedNames = map[string]bool{

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -153,3 +153,11 @@ func TestAccountTypeFromRootName_RoundTrips(t *testing.T) {
 		assert.Equal(t, at, gotType, "round-trip failed for %s", at)
 	}
 }
+
+func TestDescriptionMaxLength(t *testing.T) {
+	assert.Equal(t, 500, DescriptionMaxLength)
+}
+
+func TestMemoMaxLength(t *testing.T) {
+	assert.Equal(t, 200, MemoMaxLength)
+}

--- a/internal/service/account_ops.go
+++ b/internal/service/account_ops.go
@@ -48,6 +48,9 @@ func (as *AccountService) validateParentChain(ctx context.Context, accountID int
 
 func (as *AccountService) CreateAccount(ctx context.Context, input model.CreateAccountInput) (*model.Account, error) {
 	input.Currency = strings.ToUpper(strings.TrimSpace(input.Currency))
+	if len(input.Description) > model.DescriptionMaxLength {
+		return nil, validationErrorf("description", "description too long (max %d characters)", model.DescriptionMaxLength)
+	}
 	if err := as.validateAccountFields(ctx, input.Name, input.Type, input.Currency, input.ParentID); err != nil {
 		return nil, err
 	}
@@ -59,6 +62,9 @@ func (as *AccountService) CreateAccount(ctx context.Context, input model.CreateA
 
 func (as *AccountService) CreateAccountWithBalance(ctx context.Context, input model.CreateAccountInput) (*model.Account, error) {
 	input.Currency = strings.ToUpper(strings.TrimSpace(input.Currency))
+	if len(input.Description) > model.DescriptionMaxLength {
+		return nil, validationErrorf("description", "description too long (max %d characters)", model.DescriptionMaxLength)
+	}
 	if err := as.validateAccountFields(ctx, input.Name, input.Type, input.Currency, input.ParentID); err != nil {
 		return nil, err
 	}

--- a/internal/service/account_ops.go
+++ b/internal/service/account_ops.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/repository"
@@ -48,7 +49,7 @@ func (as *AccountService) validateParentChain(ctx context.Context, accountID int
 
 func (as *AccountService) CreateAccount(ctx context.Context, input model.CreateAccountInput) (*model.Account, error) {
 	input.Currency = strings.ToUpper(strings.TrimSpace(input.Currency))
-	if len(input.Description) > model.DescriptionMaxLength {
+	if utf8.RuneCountInString(input.Description) > model.DescriptionMaxLength {
 		return nil, validationErrorf("description", "description too long (max %d characters)", model.DescriptionMaxLength)
 	}
 	if err := as.validateAccountFields(ctx, input.Name, input.Type, input.Currency, input.ParentID); err != nil {
@@ -62,7 +63,7 @@ func (as *AccountService) CreateAccount(ctx context.Context, input model.CreateA
 
 func (as *AccountService) CreateAccountWithBalance(ctx context.Context, input model.CreateAccountInput) (*model.Account, error) {
 	input.Currency = strings.ToUpper(strings.TrimSpace(input.Currency))
-	if len(input.Description) > model.DescriptionMaxLength {
+	if utf8.RuneCountInString(input.Description) > model.DescriptionMaxLength {
 		return nil, validationErrorf("description", "description too long (max %d characters)", model.DescriptionMaxLength)
 	}
 	if err := as.validateAccountFields(ctx, input.Name, input.Type, input.Currency, input.ParentID); err != nil {

--- a/internal/service/account_ops_test.go
+++ b/internal/service/account_ops_test.go
@@ -1139,6 +1139,87 @@ func TestCreateAccount_ParentNameConsistency(t *testing.T) {
 // Parent with transactions guard (#150)
 // ──────────────────────────────────────────────
 
+// ──────────────────────────────────────────────
+// Description length validation
+// ──────────────────────────────────────────────
+
+func TestCreateAccount_DescriptionValidation(t *testing.T) {
+	t.Run("empty description is allowed", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		input := model.CreateAccountInput{
+			Name:        "Assets:Checking",
+			Type:        model.AccountTypeAsset,
+			Currency:    "USD",
+			Description: "",
+		}
+		acc, err := svc.CreateAccount(context.Background(), input)
+		require.NoError(t, err)
+		assert.NotNil(t, acc)
+	})
+
+	t.Run("over-length description rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		input := model.CreateAccountInput{
+			Name:        "Assets:Checking",
+			Type:        model.AccountTypeAsset,
+			Currency:    "USD",
+			Description: strings.Repeat("d", model.DescriptionMaxLength+1),
+		}
+		acc, err := svc.CreateAccount(context.Background(), input)
+		assert.Nil(t, acc)
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+		assert.Contains(t, ve.Message, "too long")
+	})
+
+	t.Run("exactly max-length description accepted", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		input := model.CreateAccountInput{
+			Name:        "Assets:Checking",
+			Type:        model.AccountTypeAsset,
+			Currency:    "USD",
+			Description: strings.Repeat("d", model.DescriptionMaxLength),
+		}
+		acc, err := svc.CreateAccount(context.Background(), input)
+		require.NoError(t, err)
+		assert.NotNil(t, acc)
+	})
+}
+
+func TestCreateAccountWithBalance_DescriptionValidation(t *testing.T) {
+	t.Run("over-length description rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		addOpeningBalancesForCurrency(accRepo, "USD")
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		input := model.CreateAccountInput{
+			Name:        "Assets:Checking",
+			Type:        model.AccountTypeAsset,
+			Currency:    "USD",
+			Description: strings.Repeat("d", model.DescriptionMaxLength+1),
+			Balance:     10000,
+		}
+		acc, err := svc.CreateAccountWithBalance(context.Background(), input)
+		assert.Nil(t, acc)
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+	})
+}
+
+// ──────────────────────────────────────────────
+// Parent with transactions guard (#150)
+// ──────────────────────────────────────────────
+
 func TestCreateAccount_ParentHasTransactions(t *testing.T) {
 	t.Run("parent with transactions rejected", func(t *testing.T) {
 		accRepo := newMockAccountRepo()

--- a/internal/service/account_service.go
+++ b/internal/service/account_service.go
@@ -166,6 +166,10 @@ func (as *AccountService) SearchAccounts(ctx context.Context, filter model.Accou
 }
 
 func (as *AccountService) UpdateAccountMetadata(ctx context.Context, accountID int64, description string, isHidden bool) (*model.Account, error) {
+	if len(description) > model.DescriptionMaxLength {
+		return nil, validationErrorf("description", "description too long (max %d characters)", model.DescriptionMaxLength)
+	}
+
 	acc, err := as.repo.GetAccountByID(ctx, accountID)
 	if err != nil {
 		return nil, err

--- a/internal/service/account_service.go
+++ b/internal/service/account_service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/hance08/kea/internal/config"
 	"github.com/hance08/kea/internal/model"
@@ -166,7 +167,7 @@ func (as *AccountService) SearchAccounts(ctx context.Context, filter model.Accou
 }
 
 func (as *AccountService) UpdateAccountMetadata(ctx context.Context, accountID int64, description string, isHidden bool) (*model.Account, error) {
-	if len(description) > model.DescriptionMaxLength {
+	if utf8.RuneCountInString(description) > model.DescriptionMaxLength {
 		return nil, validationErrorf("description", "description too long (max %d characters)", model.DescriptionMaxLength)
 	}
 

--- a/internal/service/account_service_test.go
+++ b/internal/service/account_service_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hance08/kea/internal/model"
@@ -146,6 +147,44 @@ func TestGetAccountBalanceFormatted(t *testing.T) {
 		require.Error(t, err)
 		assert.False(t, errors.Is(err, ErrNotFound))
 		assert.Equal(t, dbErr, err)
+	})
+}
+
+func TestUpdateAccountMetadata_DescriptionValidation(t *testing.T) {
+	t.Run("empty description is allowed", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Cash", Type: model.AccountTypeAsset, Currency: "USD"})
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		acc, err := svc.UpdateAccountMetadata(context.Background(), 1, "", false)
+		require.NoError(t, err)
+		assert.NotNil(t, acc)
+	})
+
+	t.Run("over-length description rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Cash", Type: model.AccountTypeAsset, Currency: "USD"})
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		longDesc := strings.Repeat("d", model.DescriptionMaxLength+1)
+		acc, err := svc.UpdateAccountMetadata(context.Background(), 1, longDesc, false)
+		assert.Nil(t, acc)
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+		assert.Contains(t, ve.Message, "too long")
+	})
+
+	t.Run("exactly max-length description accepted", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Cash", Type: model.AccountTypeAsset, Currency: "USD"})
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		exactDesc := strings.Repeat("d", model.DescriptionMaxLength)
+		acc, err := svc.UpdateAccountMetadata(context.Background(), 1, exactDesc, false)
+		require.NoError(t, err)
+		assert.NotNil(t, acc)
 	})
 }
 

--- a/internal/service/account_validation.go
+++ b/internal/service/account_validation.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/hance08/kea/internal/model"
 )
@@ -25,7 +26,7 @@ func (as *AccountService) ValidateAccountName(name string) error {
 	if model.ReservedNames[strings.ToLower(name)] {
 		return validationErrorf("name", "'%s' is a reserved root account name", name)
 	}
-	if len(name) > model.AccountNameMaxLength {
+	if utf8.RuneCountInString(name) > model.AccountNameMaxLength {
 		return validationErrorf("name", "account name too long (max %d characters)", model.AccountNameMaxLength)
 	}
 	return nil
@@ -40,7 +41,7 @@ func (as *AccountService) ValidateFullAccountName(fullName string) error {
 	if fullName == "" {
 		return validationErrorf("name", "account name can't be empty")
 	}
-	if len(fullName) > model.AccountNameMaxLength {
+	if utf8.RuneCountInString(fullName) > model.AccountNameMaxLength {
 		return validationErrorf("name", "account name too long (max %d characters)", model.AccountNameMaxLength)
 	}
 
@@ -65,7 +66,7 @@ func (as *AccountService) ValidateFullAccountName(fullName string) error {
 		if strings.Contains(segment, ":") {
 			return validationErrorf("name", "account segment '%s' cannot contain ':'", segment)
 		}
-		if len(segment) > model.AccountNameMaxLength {
+		if utf8.RuneCountInString(segment) > model.AccountNameMaxLength {
 			return validationErrorf("name", "account segment too long (max %d characters)", model.AccountNameMaxLength)
 		}
 		if i > 0 && model.ReservedNames[strings.ToLower(segment)] {

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -269,6 +269,13 @@ func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, inp
 		return validationErrorf("status", "invalid status: must be Pending or Cleared")
 	}
 
+	if strings.TrimSpace(input.Description) == "" {
+		return validationErrorf("description", "description is required")
+	}
+	if len(input.Description) > model.DescriptionMaxLength {
+		return validationErrorf("description", "description too long (max %d characters)", model.DescriptionMaxLength)
+	}
+
 	oldTx, err := ts.txRepo.GetTransactionByID(ctx, input.ID)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
@@ -292,6 +299,12 @@ func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, inp
 
 	if err := ts.ValidateSplitsMatchType(ctx, input.Type, input.Splits); err != nil {
 		return fmt.Errorf("splits do not match transaction type %q: %w", input.Type, err)
+	}
+
+	for i, s := range input.Splits {
+		if len(s.Memo) > model.MemoMaxLength {
+			return validationErrorf("memo", "split #%d memo too long (max %d characters)", i+1, model.MemoMaxLength)
+		}
 	}
 
 	return ts.tm.ExecTx(ctx, func(repo repository.Repository) error {

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hance08/kea/internal/model"
@@ -38,6 +39,13 @@ func (ts *TransactionService) CreateTransaction(ctx context.Context, input model
 		return 0, validationErrorf("status", "invalid status: new transactions must be Pending or Cleared")
 	}
 
+	if strings.TrimSpace(input.Description) == "" {
+		return 0, validationErrorf("description", "description is required")
+	}
+	if len(input.Description) > model.DescriptionMaxLength {
+		return 0, validationErrorf("description", "description too long (max %d characters)", model.DescriptionMaxLength)
+	}
+
 	// Set default timestamp: Use current system time if not provided.
 	if input.Timestamp == 0 {
 		input.Timestamp = time.Now().Unix()
@@ -63,6 +71,10 @@ func (ts *TransactionService) CreateTransaction(ctx context.Context, input model
 		splitCurrency := currency
 		if account.Currency != "" {
 			splitCurrency = account.Currency
+		}
+
+		if len(splitInput.Memo) > model.MemoMaxLength {
+			return 0, validationErrorf("memo", "split #%d memo too long (max %d characters)", i+1, model.MemoMaxLength)
 		}
 
 		splits = append(splits, model.Split{

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/repository"
@@ -39,10 +40,11 @@ func (ts *TransactionService) CreateTransaction(ctx context.Context, input model
 		return 0, validationErrorf("status", "invalid status: new transactions must be Pending or Cleared")
 	}
 
-	if strings.TrimSpace(input.Description) == "" {
+	input.Description = strings.TrimSpace(input.Description)
+	if input.Description == "" {
 		return 0, validationErrorf("description", "description is required")
 	}
-	if len(input.Description) > model.DescriptionMaxLength {
+	if utf8.RuneCountInString(input.Description) > model.DescriptionMaxLength {
 		return 0, validationErrorf("description", "description too long (max %d characters)", model.DescriptionMaxLength)
 	}
 
@@ -73,7 +75,7 @@ func (ts *TransactionService) CreateTransaction(ctx context.Context, input model
 			splitCurrency = account.Currency
 		}
 
-		if len(splitInput.Memo) > model.MemoMaxLength {
+		if utf8.RuneCountInString(splitInput.Memo) > model.MemoMaxLength {
 			return 0, validationErrorf("memo", "split #%d memo too long (max %d characters)", i+1, model.MemoMaxLength)
 		}
 
@@ -269,10 +271,11 @@ func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, inp
 		return validationErrorf("status", "invalid status: must be Pending or Cleared")
 	}
 
-	if strings.TrimSpace(input.Description) == "" {
+	input.Description = strings.TrimSpace(input.Description)
+	if input.Description == "" {
 		return validationErrorf("description", "description is required")
 	}
-	if len(input.Description) > model.DescriptionMaxLength {
+	if utf8.RuneCountInString(input.Description) > model.DescriptionMaxLength {
 		return validationErrorf("description", "description too long (max %d characters)", model.DescriptionMaxLength)
 	}
 
@@ -302,7 +305,7 @@ func (ts *TransactionService) UpdateTransactionComplete(ctx context.Context, inp
 	}
 
 	for i, s := range input.Splits {
-		if len(s.Memo) > model.MemoMaxLength {
+		if utf8.RuneCountInString(s.Memo) > model.MemoMaxLength {
 			return validationErrorf("memo", "split #%d memo too long (max %d characters)", i+1, model.MemoMaxLength)
 		}
 	}

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -96,7 +97,8 @@ func TestCreateTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
 
 		input := model.TransactionDetail{
-			Type: model.TxTypeExpense,
+			Description: "test",
+			Type:        model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountName: "Expenses:Food", Amount: 500},
 				{AccountName: "Assets:Bank", Amount: -400}, // off by 100
@@ -113,7 +115,8 @@ func TestCreateTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
 
 		input := model.TransactionDetail{
-			Type: model.TxTypeExpense,
+			Description: "test",
+			Type:        model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountName: "Assets:Bank", Amount: -500},
 				{AccountName: "NonExistent:Account", Amount: 500},
@@ -132,8 +135,9 @@ func TestCreateTransaction(t *testing.T) {
 
 		before := time.Now().Unix()
 		input := model.TransactionDetail{
-			Timestamp: 0,
-			Type:      model.TxTypeExpense,
+			Description: "test",
+			Timestamp:   0,
+			Type:        model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountName: "Expenses:Food", Amount: 500},
 				{AccountName: "Assets:Bank", Amount: -500},
@@ -155,7 +159,8 @@ func TestCreateTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		input := model.TransactionDetail{
-			Type: model.TxTypeExpense,
+			Description: "test",
+			Type:        model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountName: "Expenses:TWDFood", Amount: 500},
 				{AccountName: "Assets:TWDBank", Amount: -500},
@@ -179,7 +184,8 @@ func TestCreateTransaction(t *testing.T) {
 
 		// Assets:Cash is TWD, Expenses:Food has no currency (falls back to USD)
 		input := model.TransactionDetail{
-			Type: model.TxTypeExpense,
+			Description: "test",
+			Type:        model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountName: "Expenses:Food", Amount: 500},
 				{AccountName: "Assets:Cash", Amount: -500},
@@ -197,7 +203,8 @@ func TestCreateTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		input := model.TransactionDetail{
-			Type: model.TxTypeExpense,
+			Description: "test",
+			Type:        model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountName: "Expenses:Food", Amount: 500},
 				{AccountName: "Assets:Bank", Amount: -500},
@@ -219,7 +226,8 @@ func TestCreateTransaction(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		input := model.TransactionDetail{
-			Type: model.TxTypeExpense,
+			Description: "test",
+			Type:        model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountName: "Expenses:Food", Amount: 500},
 				{AccountName: "Assets:Bank", Amount: -500},
@@ -985,6 +993,100 @@ func TestCreateTransactionFromSplits(t *testing.T) {
 		}
 		_, err := svc.CreateTransactionFromSplits(context.Background(), model.CreateTransactionFromSplitsInput{Splits: splits, Description: "team lunch", Timestamp: 0, Status: model.StatusCleared, Type: model.TxTypeExpense})
 		require.Error(t, err)
+	})
+}
+
+// ──────────────────────────────────────────────
+// CreateTransaction: Description & Memo validation
+// ──────────────────────────────────────────────
+
+func TestCreateTransaction_DescriptionValidation(t *testing.T) {
+	makeInput := func(desc string, memo string) model.TransactionDetail {
+		return model.TransactionDetail{
+			Description: desc,
+			Type:        model.TxTypeExpense,
+			Splits: []model.SplitDetail{
+				{AccountName: "Expenses:Food", Amount: 500, Memo: memo},
+				{AccountName: "Assets:Bank", Amount: -500},
+			},
+		}
+	}
+
+	t.Run("empty description rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+		_, err := svc.CreateTransaction(context.Background(), makeInput("", ""))
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+		assert.Contains(t, ve.Message, "required")
+	})
+
+	t.Run("whitespace-only description rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+		_, err := svc.CreateTransaction(context.Background(), makeInput("   ", ""))
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+	})
+
+	t.Run("over-length description rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+		longDesc := strings.Repeat("a", model.DescriptionMaxLength+1)
+		_, err := svc.CreateTransaction(context.Background(), makeInput(longDesc, ""))
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+		assert.Contains(t, ve.Message, "too long")
+	})
+
+	t.Run("exactly max-length description accepted", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		exactDesc := strings.Repeat("a", model.DescriptionMaxLength)
+		id, err := svc.CreateTransaction(context.Background(), makeInput(exactDesc, ""))
+		require.NoError(t, err)
+		assert.Greater(t, id, int64(0))
+	})
+
+	t.Run("over-length memo on split rejected", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+		longMemo := strings.Repeat("m", model.MemoMaxLength+1)
+		_, err := svc.CreateTransaction(context.Background(), makeInput("Valid desc", longMemo))
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "memo", ve.Field)
+		assert.Contains(t, ve.Message, "too long")
+	})
+
+	t.Run("exactly max-length memo accepted", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		exactMemo := strings.Repeat("m", model.MemoMaxLength)
+		id, err := svc.CreateTransaction(context.Background(), makeInput("Valid desc", exactMemo))
+		require.NoError(t, err)
+		assert.Greater(t, id, int64(0))
 	})
 }
 

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -602,7 +602,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.TransactionStatus(99), Type: model.TxTypeExpense, Splits: nil})
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "test", Timestamp: 0, Status: model.TransactionStatus(99), Type: model.TxTypeExpense, Splits: nil})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid status")
 	})
@@ -639,9 +639,10 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		svc := newTestTransactionService(accRepo, txRepo)
 
 		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{
-			ID:     999,
-			Status: model.StatusPending,
-			Splits: []model.SplitDetail{{AccountID: 1, Amount: 100}, {AccountID: 2, Amount: -100}},
+			ID:          999,
+			Description: "test",
+			Status:      model.StatusPending,
+			Splits:      []model.SplitDetail{{AccountID: 1, Amount: 100}, {AccountID: 2, Amount: -100}},
 		})
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrNotFound), "expected ErrNotFound, got: %v", err)
@@ -652,7 +653,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusReconciled}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusCleared, Type: model.TxTypeExpense,
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "test", Timestamp: 0, Status: model.StatusCleared, Type: model.TxTypeExpense,
 			Splits: []model.SplitDetail{{AccountID: 1, Amount: 500}, {AccountID: 2, Amount: -500}}})
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrReconciled))
@@ -663,7 +664,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(newMockAccountRepo(), txRepo)
 
-		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense,
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "test", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense,
 			Splits: []model.SplitDetail{{AccountID: 1, Amount: 0}}})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "at least 2")
@@ -676,7 +677,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(accRepo, txRepo)
 
-		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense,
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "test", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountID: 1, Amount: -500},
 				{AccountID: 2, Amount: 400}, // off by 100
@@ -710,7 +711,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 		txRepo.addTransaction(&model.Transaction{ID: 5, Status: model.StatusPending}, nil)
 		svc := newTestTransactionService(accRepo, txRepo)
 
-		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense,
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "test", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense,
 			Splits: []model.SplitDetail{
 				{AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -500},
 				{AccountID: 99, AccountType: model.AccountTypeExpense, Amount: 500}, // does not exist
@@ -738,7 +739,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -1000, Currency: "USD"},
 			{ID: 11, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 1000, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "test", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
 		require.NoError(t, err)
 		assert.Contains(t, txRepo.deleteSplitCalls, int64(12), "split ID 12 should be deleted")
 	})
@@ -757,7 +758,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -1000, Currency: "USD"},
 			{ID: 0, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 1000, Currency: "USD"}, // new split
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "test", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
 		require.NoError(t, err)
 		assert.Len(t, txRepo.createSplitCalls, 1, "CreateSplit should be called once")
 	})
@@ -779,7 +780,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 10, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -800, Currency: "USD"},
 			{ID: 11, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 800, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "test", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
 		require.NoError(t, err)
 		assert.Contains(t, txRepo.updateSplitCalls, int64(10))
 		assert.Contains(t, txRepo.updateSplitCalls, int64(11))
@@ -797,7 +798,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{AccountID: 10, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"},
 			{AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "test", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "hidden")
 	})
@@ -815,7 +816,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{AccountID: 11, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"},
 			{AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "test", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "parent account")
 	})
@@ -854,7 +855,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{ID: 20, AccountID: 10, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"}, // moved to hidden account
 			{ID: 21, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "test", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeExpense, Splits: splits})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "hidden")
 	})
@@ -874,7 +875,7 @@ func TestUpdateTransactionComplete(t *testing.T) {
 			{AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD"},
 			{AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"},
 		}
-		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeTransfer, Splits: splits})
+		err := svc.UpdateTransactionComplete(context.Background(), model.UpdateTransactionInput{ID: 5, Description: "test", Timestamp: 0, Status: model.StatusPending, Type: model.TxTypeTransfer, Splits: splits})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "splits do not match transaction type")
 	})
@@ -1087,6 +1088,88 @@ func TestCreateTransaction_DescriptionValidation(t *testing.T) {
 		id, err := svc.CreateTransaction(context.Background(), makeInput("Valid desc", exactMemo))
 		require.NoError(t, err)
 		assert.Greater(t, id, int64(0))
+	})
+}
+
+// ──────────────────────────────────────────────
+// UpdateTransactionComplete: Description & Memo validation
+// ──────────────────────────────────────────────
+
+func TestUpdateTransactionComplete_DescriptionValidation(t *testing.T) {
+	setupForUpdate := func() (*mockAccountRepo, *mockTransactionRepo, *TransactionService) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		txRepo.addTransaction(
+			&model.Transaction{ID: 1, Description: "Old", Status: model.StatusPending, Type: model.TxTypeExpense},
+			[]*model.Split{
+				{ID: 10, TransactionID: 1, AccountID: 2, Amount: 500, Currency: "USD"},
+				{ID: 11, TransactionID: 1, AccountID: 1, Amount: -500, Currency: "USD"},
+			},
+		)
+		svc := newTestTransactionService(accRepo, txRepo)
+		return accRepo, txRepo, svc
+	}
+
+	makeInput := func(desc string, memo string) model.UpdateTransactionInput {
+		return model.UpdateTransactionInput{
+			ID:          1,
+			Description: desc,
+			Timestamp:   time.Now().Unix(),
+			Status:      model.StatusPending,
+			Type:        model.TxTypeExpense,
+			Splits: []model.SplitDetail{
+				{ID: 10, AccountID: 2, AccountType: model.AccountTypeExpense, Amount: 500, Currency: "USD", Memo: memo},
+				{ID: 11, AccountID: 1, AccountType: model.AccountTypeAsset, Amount: -500, Currency: "USD"},
+			},
+		}
+	}
+
+	t.Run("empty description rejected", func(t *testing.T) {
+		_, _, svc := setupForUpdate()
+		err := svc.UpdateTransactionComplete(context.Background(), makeInput("", ""))
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+		assert.Contains(t, ve.Message, "required")
+	})
+
+	t.Run("whitespace-only description rejected", func(t *testing.T) {
+		_, _, svc := setupForUpdate()
+		err := svc.UpdateTransactionComplete(context.Background(), makeInput("   ", ""))
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+	})
+
+	t.Run("over-length description rejected", func(t *testing.T) {
+		_, _, svc := setupForUpdate()
+		longDesc := strings.Repeat("a", model.DescriptionMaxLength+1)
+		err := svc.UpdateTransactionComplete(context.Background(), makeInput(longDesc, ""))
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "description", ve.Field)
+		assert.Contains(t, ve.Message, "too long")
+	})
+
+	t.Run("over-length memo on split rejected", func(t *testing.T) {
+		_, _, svc := setupForUpdate()
+		longMemo := strings.Repeat("m", model.MemoMaxLength+1)
+		err := svc.UpdateTransactionComplete(context.Background(), makeInput("Valid desc", longMemo))
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve))
+		assert.Equal(t, "memo", ve.Field)
+		assert.Contains(t, ve.Message, "too long")
+	})
+
+	t.Run("valid description and memo accepted", func(t *testing.T) {
+		_, _, svc := setupForUpdate()
+		err := svc.UpdateTransactionComplete(context.Background(), makeInput("Updated lunch", "some memo"))
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
## Summary
- Add `DescriptionMaxLength` (500) and `MemoMaxLength` (200) constants to `model/types.go`
- Validate Description and Memo length in `CreateTransaction`, `UpdateTransactionComplete`, `CreateAccount`, `CreateAccountWithBalance`, and `UpdateAccountMetadata`
- Transaction descriptions are **required** (empty/whitespace rejected); account descriptions are **optional** (length-only)
- Split memos are optional but length-capped at 200 characters

## Test plan
- [ ] New validation tests pass for all 5 service methods (empty, whitespace, over-length, boundary)
- [ ] Existing tests updated with valid descriptions — no regressions
- [ ] `go test ./...` passes across all packages

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)