### PR TITLE
fix: validate TransactionType on JSON deserialization (#130)

### DIFF
--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -151,6 +151,35 @@ const (
 	TxTypeOther      TransactionType = "Other"
 )
 
+func (t TransactionType) IsValid() bool {
+	switch t {
+	case TxTypeExpense, TxTypeIncome, TxTypeTransfer,
+		TxTypeOpening, TxTypeDeposit, TxTypeWithdrawal, TxTypeOther:
+		return true
+	}
+	return false
+}
+
+func (t TransactionType) MarshalJSON() ([]byte, error) {
+	if !t.IsValid() {
+		return nil, fmt.Errorf("cannot marshal invalid transaction type %q", string(t))
+	}
+	return json.Marshal(string(t))
+}
+
+func (t *TransactionType) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+	tt := TransactionType(str)
+	if !tt.IsValid() {
+		return fmt.Errorf("unknown transaction type %q", str)
+	}
+	*t = tt
+	return nil
+}
+
 const (
 	DateFormat  = "2006-01-02"
 	MinSplitsCount = 2
@@ -174,8 +203,16 @@ func ParseTransactionType(s string) (TransactionType, error) {
 		return TxTypeIncome, nil
 	case "transfer":
 		return TxTypeTransfer, nil
+	case "opening":
+		return TxTypeOpening, nil
+	case "deposit":
+		return TxTypeDeposit, nil
+	case "withdrawal":
+		return TxTypeWithdrawal, nil
+	case "other":
+		return TxTypeOther, nil
 	default:
-		return "", fmt.Errorf("invalid transaction type %q: must be expense, income, or transfer", s)
+		return "", fmt.Errorf("invalid transaction type %q: must be expense, income, transfer, opening, deposit, withdrawal, or other", s)
 	}
 }
 

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -4,6 +4,7 @@
 package model
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,9 +39,14 @@ func TestParseTransactionType(t *testing.T) {
 		{"Income", TxTypeIncome, false},
 		{"transfer", TxTypeTransfer, false},
 		{"Transfer", TxTypeTransfer, false},
+		{"opening", TxTypeOpening, false},
+		{"Opening", TxTypeOpening, false},
+		{"deposit", TxTypeDeposit, false},
+		{"withdrawal", TxTypeWithdrawal, false},
+		{"  Other  ", TxTypeOther, false},
 		{"unknown", "", true},
 		{"", "", true},
-		{"opening", "", true},
+		{"garbage", "", true},
 	}
 
 	for _, tt := range tests {
@@ -152,6 +158,68 @@ func TestAccountTypeFromRootName_RoundTrips(t *testing.T) {
 		assert.True(t, gotOK)
 		assert.Equal(t, at, gotType, "round-trip failed for %s", at)
 	}
+}
+
+func TestTransactionType_IsValid(t *testing.T) {
+	valid := []TransactionType{
+		TxTypeExpense, TxTypeIncome, TxTypeTransfer,
+		TxTypeOpening, TxTypeDeposit, TxTypeWithdrawal, TxTypeOther,
+	}
+	for _, v := range valid {
+		assert.True(t, v.IsValid(), "expected %q to be valid", v)
+	}
+
+	invalid := []TransactionType{"", "garbage", "expense", "EXPENSE", "Unknown"}
+	for _, v := range invalid {
+		assert.False(t, v.IsValid(), "expected %q to be invalid", v)
+	}
+}
+
+func TestTransactionType_MarshalJSON(t *testing.T) {
+	t.Run("valid round trip", func(t *testing.T) {
+		all := []TransactionType{
+			TxTypeExpense, TxTypeIncome, TxTypeTransfer,
+			TxTypeOpening, TxTypeDeposit, TxTypeWithdrawal, TxTypeOther,
+		}
+		for _, want := range all {
+			data, err := json.Marshal(want)
+			require.NoError(t, err)
+			var got TransactionType
+			require.NoError(t, json.Unmarshal(data, &got))
+			assert.Equal(t, want, got)
+		}
+	})
+
+	t.Run("invalid value fails to marshal", func(t *testing.T) {
+		_, err := json.Marshal(TransactionType("garbage"))
+		assert.Error(t, err)
+	})
+}
+
+func TestTransactionType_UnmarshalJSON(t *testing.T) {
+	t.Run("rejects unknown string", func(t *testing.T) {
+		var got TransactionType
+		err := json.Unmarshal([]byte(`"garbage"`), &got)
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects empty string", func(t *testing.T) {
+		var got TransactionType
+		err := json.Unmarshal([]byte(`""`), &got)
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects non-string", func(t *testing.T) {
+		var got TransactionType
+		err := json.Unmarshal([]byte(`123`), &got)
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects wrong case", func(t *testing.T) {
+		var got TransactionType
+		err := json.Unmarshal([]byte(`"expense"`), &got)
+		assert.Error(t, err)
+	})
 }
 
 func TestDescriptionMaxLength(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `IsValid()`, `MarshalJSON`, and `UnmarshalJSON` to `model.TransactionType`, mirroring the existing `TransactionStatus` pattern. Invalid values from API clients are now rejected instead of silently stored as `TransactionType("garbage")`.
- Extend `ParseTransactionType` to accept `opening`, `deposit`, `withdrawal`, and `other` (previously only `expense`/`income`/`transfer`).

Closes #130.

## Test plan
- [x] `go test ./internal/model/...` passes
- [x] `go test ./...` passes (full suite)
- [x] New tests cover: `IsValid` valid/invalid cases, JSON round-trip for all 7 types, rejection of `"garbage"`, empty string, non-string JSON, and wrong-case values

🤖 Generated with [Claude Code](https://claude.com/claude-code)