### PR TITLE
feat: add GetAccountTree service method (#131)

### DIFF
--- a/internal/model/account.go
+++ b/internal/model/account.go
@@ -12,3 +12,8 @@ type Account struct {
 	Description string      `json:"description"`
 	IsHidden    bool        `json:"is_hidden"`
 }
+
+type AccountNode struct {
+	Account  *Account       `json:"account"`
+	Children []*AccountNode `json:"children"`
+}

--- a/internal/service/account_service.go
+++ b/internal/service/account_service.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"unicode/utf8"
 
@@ -59,6 +60,60 @@ func (as *AccountService) ListAccounts(ctx context.Context, opts ListAccountsOpt
 
 func (as *AccountService) GetAllAccounts(ctx context.Context) ([]*model.Account, error) {
 	return as.repo.GetAllAccounts(ctx)
+}
+
+type AccountTreeOptions struct {
+	ShowHidden bool
+}
+
+// GetAccountTree returns root accounts as a hierarchical tree built from the flat
+// account list, alphabetically sorted; when ShowHidden is false hidden accounts
+// are dropped and any visible orphan is promoted to a root.
+func (as *AccountService) GetAccountTree(ctx context.Context, opts AccountTreeOptions) ([]*model.AccountNode, error) {
+	accounts, err := as.repo.GetAllAccounts(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if !opts.ShowHidden {
+		filtered := make([]*model.Account, 0, len(accounts))
+		for _, acc := range accounts {
+			if !acc.IsHidden {
+				filtered = append(filtered, acc)
+			}
+		}
+		accounts = filtered
+	}
+
+	nodes := make(map[int64]*model.AccountNode, len(accounts))
+	for _, acc := range accounts {
+		nodes[acc.ID] = &model.AccountNode{Account: acc}
+	}
+
+	roots := []*model.AccountNode{}
+	for _, acc := range accounts {
+		node := nodes[acc.ID]
+		if acc.ParentID != nil {
+			if parent, ok := nodes[*acc.ParentID]; ok {
+				parent.Children = append(parent.Children, node)
+				continue
+			}
+		}
+		roots = append(roots, node)
+	}
+
+	sortNodes(roots)
+	for _, node := range nodes {
+		sortNodes(node.Children)
+	}
+
+	return roots, nil
+}
+
+func sortNodes(nodes []*model.AccountNode) {
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].Account.Name < nodes[j].Account.Name
+	})
 }
 
 func (as *AccountService) GetAccountByName(ctx context.Context, name string) (*model.Account, error) {

--- a/internal/service/account_service_test.go
+++ b/internal/service/account_service_test.go
@@ -277,25 +277,25 @@ func TestGetAccountTree(t *testing.T) {
 		assert.Nil(t, tree)
 	})
 
-	t.Run("sibling ordering is deterministic across runs", func(t *testing.T) {
-		for i := 0; i < 5; i++ {
-			accRepo := newMockAccountRepo()
-			accRepo.addAccount(&model.Account{ID: 1, Name: "Assets", Type: model.AccountTypeAsset, Currency: "USD"})
-			accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Zeta", Type: model.AccountTypeAsset, Currency: "USD", ParentID: ptrID(1)})
-			accRepo.addAccount(&model.Account{ID: 3, Name: "Assets:Alpha", Type: model.AccountTypeAsset, Currency: "USD", ParentID: ptrID(1)})
-			accRepo.addAccount(&model.Account{ID: 4, Name: "Assets:Mike", Type: model.AccountTypeAsset, Currency: "USD", ParentID: ptrID(1)})
-			svc := newTestAccountService(accRepo, newMockTransactionRepo())
+	t.Run("sorts siblings alphabetically regardless of insertion order", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		// Insert siblings in reverse-alphabetical order so the only thing that
+		// can produce alphabetical output is sortNodes inside GetAccountTree.
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets", Type: model.AccountTypeAsset, Currency: "USD"})
+		accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Zucchini", Type: model.AccountTypeAsset, Currency: "USD", ParentID: ptrID(1)})
+		accRepo.addAccount(&model.Account{ID: 3, Name: "Assets:Mango", Type: model.AccountTypeAsset, Currency: "USD", ParentID: ptrID(1)})
+		accRepo.addAccount(&model.Account{ID: 4, Name: "Assets:Apple", Type: model.AccountTypeAsset, Currency: "USD", ParentID: ptrID(1)})
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
 
-			tree, err := svc.GetAccountTree(context.Background(), AccountTreeOptions{})
+		tree, err := svc.GetAccountTree(context.Background(), AccountTreeOptions{})
 
-			require.NoError(t, err)
-			require.Len(t, tree, 1)
-			children := tree[0].Children
-			require.Len(t, children, 3)
-			assert.Equal(t, "Assets:Alpha", children[0].Account.Name)
-			assert.Equal(t, "Assets:Mike", children[1].Account.Name)
-			assert.Equal(t, "Assets:Zeta", children[2].Account.Name)
-		}
+		require.NoError(t, err)
+		require.Len(t, tree, 1)
+		children := tree[0].Children
+		require.Len(t, children, 3)
+		assert.Equal(t, "Assets:Apple", children[0].Account.Name)
+		assert.Equal(t, "Assets:Mango", children[1].Account.Name)
+		assert.Equal(t, "Assets:Zucchini", children[2].Account.Name)
 	})
 }
 

--- a/internal/service/account_service_test.go
+++ b/internal/service/account_service_test.go
@@ -150,6 +150,155 @@ func TestGetAccountBalanceFormatted(t *testing.T) {
 	})
 }
 
+func TestGetAccountTree(t *testing.T) {
+	ptrID := func(id int64) *int64 { return &id }
+
+	t.Run("empty repo returns non-nil empty slice", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		tree, err := svc.GetAccountTree(context.Background(), AccountTreeOptions{})
+
+		require.NoError(t, err)
+		require.NotNil(t, tree)
+		assert.Len(t, tree, 0)
+	})
+
+	t.Run("flat list with no parents becomes sorted roots", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Charlie", Type: model.AccountTypeAsset, Currency: "USD"})
+		accRepo.addAccount(&model.Account{ID: 2, Name: "Alpha", Type: model.AccountTypeAsset, Currency: "USD"})
+		accRepo.addAccount(&model.Account{ID: 3, Name: "Bravo", Type: model.AccountTypeAsset, Currency: "USD"})
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		tree, err := svc.GetAccountTree(context.Background(), AccountTreeOptions{})
+
+		require.NoError(t, err)
+		require.Len(t, tree, 3)
+		assert.Equal(t, "Alpha", tree[0].Account.Name)
+		assert.Equal(t, "Bravo", tree[1].Account.Name)
+		assert.Equal(t, "Charlie", tree[2].Account.Name)
+		for _, n := range tree {
+			assert.Empty(t, n.Children)
+		}
+	})
+
+	t.Run("two-level nesting groups children under parent and sorts them", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets", Type: model.AccountTypeAsset, Currency: "USD"})
+		accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Cash", Type: model.AccountTypeAsset, Currency: "USD", ParentID: ptrID(1)})
+		accRepo.addAccount(&model.Account{ID: 3, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD", ParentID: ptrID(1)})
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		tree, err := svc.GetAccountTree(context.Background(), AccountTreeOptions{})
+
+		require.NoError(t, err)
+		require.Len(t, tree, 1)
+		root := tree[0]
+		assert.Equal(t, "Assets", root.Account.Name)
+		require.Len(t, root.Children, 2)
+		assert.Equal(t, "Assets:Bank", root.Children[0].Account.Name)
+		assert.Equal(t, "Assets:Cash", root.Children[1].Account.Name)
+		for _, c := range root.Children {
+			assert.Empty(t, c.Children)
+		}
+	})
+
+	t.Run("three-level nesting builds correctly at each level", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets", Type: model.AccountTypeAsset, Currency: "USD"})
+		accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD", ParentID: ptrID(1)})
+		accRepo.addAccount(&model.Account{ID: 3, Name: "Assets:Bank:Checking", Type: model.AccountTypeAsset, Currency: "USD", ParentID: ptrID(2)})
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		tree, err := svc.GetAccountTree(context.Background(), AccountTreeOptions{})
+
+		require.NoError(t, err)
+		require.Len(t, tree, 1)
+		root := tree[0]
+		assert.Equal(t, "Assets", root.Account.Name)
+		require.Len(t, root.Children, 1)
+		mid := root.Children[0]
+		assert.Equal(t, "Assets:Bank", mid.Account.Name)
+		require.Len(t, mid.Children, 1)
+		leaf := mid.Children[0]
+		assert.Equal(t, "Assets:Bank:Checking", leaf.Account.Name)
+		assert.Empty(t, leaf.Children)
+	})
+
+	t.Run("ShowHidden false drops hidden accounts and promotes orphaned visible children to roots", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets", Type: model.AccountTypeAsset, Currency: "USD", IsHidden: true})
+		accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Cash", Type: model.AccountTypeAsset, Currency: "USD", ParentID: ptrID(1)})
+		accRepo.addAccount(&model.Account{ID: 3, Name: "Expenses", Type: model.AccountTypeExpense, Currency: "USD"})
+		accRepo.addAccount(&model.Account{ID: 4, Name: "Expenses:Hidden", Type: model.AccountTypeExpense, Currency: "USD", ParentID: ptrID(3), IsHidden: true})
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		tree, err := svc.GetAccountTree(context.Background(), AccountTreeOptions{})
+
+		require.NoError(t, err)
+		require.Len(t, tree, 2)
+		assert.Equal(t, "Assets:Cash", tree[0].Account.Name)
+		assert.Empty(t, tree[0].Children)
+		assert.Equal(t, "Expenses", tree[1].Account.Name)
+		assert.Empty(t, tree[1].Children)
+	})
+
+	t.Run("ShowHidden true includes hidden accounts in the tree", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets", Type: model.AccountTypeAsset, Currency: "USD", IsHidden: true})
+		accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Cash", Type: model.AccountTypeAsset, Currency: "USD", ParentID: ptrID(1)})
+		accRepo.addAccount(&model.Account{ID: 3, Name: "Expenses", Type: model.AccountTypeExpense, Currency: "USD"})
+		accRepo.addAccount(&model.Account{ID: 4, Name: "Expenses:Hidden", Type: model.AccountTypeExpense, Currency: "USD", ParentID: ptrID(3), IsHidden: true})
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		tree, err := svc.GetAccountTree(context.Background(), AccountTreeOptions{ShowHidden: true})
+
+		require.NoError(t, err)
+		require.Len(t, tree, 2)
+		assert.Equal(t, "Assets", tree[0].Account.Name)
+		require.Len(t, tree[0].Children, 1)
+		assert.Equal(t, "Assets:Cash", tree[0].Children[0].Account.Name)
+		assert.Equal(t, "Expenses", tree[1].Account.Name)
+		require.Len(t, tree[1].Children, 1)
+		assert.Equal(t, "Expenses:Hidden", tree[1].Children[0].Account.Name)
+	})
+
+	t.Run("propagates repo error from GetAllAccounts", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		boom := errors.New("boom")
+		accRepo.getAllAccountsErr = boom
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		tree, err := svc.GetAccountTree(context.Background(), AccountTreeOptions{})
+
+		require.Error(t, err)
+		assert.Same(t, boom, err)
+		assert.Nil(t, tree)
+	})
+
+	t.Run("sibling ordering is deterministic across runs", func(t *testing.T) {
+		for i := 0; i < 5; i++ {
+			accRepo := newMockAccountRepo()
+			accRepo.addAccount(&model.Account{ID: 1, Name: "Assets", Type: model.AccountTypeAsset, Currency: "USD"})
+			accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Zeta", Type: model.AccountTypeAsset, Currency: "USD", ParentID: ptrID(1)})
+			accRepo.addAccount(&model.Account{ID: 3, Name: "Assets:Alpha", Type: model.AccountTypeAsset, Currency: "USD", ParentID: ptrID(1)})
+			accRepo.addAccount(&model.Account{ID: 4, Name: "Assets:Mike", Type: model.AccountTypeAsset, Currency: "USD", ParentID: ptrID(1)})
+			svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+			tree, err := svc.GetAccountTree(context.Background(), AccountTreeOptions{})
+
+			require.NoError(t, err)
+			require.Len(t, tree, 1)
+			children := tree[0].Children
+			require.Len(t, children, 3)
+			assert.Equal(t, "Assets:Alpha", children[0].Account.Name)
+			assert.Equal(t, "Assets:Mike", children[1].Account.Name)
+			assert.Equal(t, "Assets:Zeta", children[2].Account.Name)
+		}
+	})
+}
+
 func TestUpdateAccountMetadata_DescriptionValidation(t *testing.T) {
 	t.Run("empty description is allowed", func(t *testing.T) {
 		accRepo := newMockAccountRepo()
@@ -187,4 +336,3 @@ func TestUpdateAccountMetadata_DescriptionValidation(t *testing.T) {
 		assert.NotNil(t, acc)
 	})
 }
-

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -37,6 +37,7 @@ type mockAccountRepo struct {
 	getByIDErr        map[int64]error
 	getBalanceErr     map[int64]error
 	getAllBalancesErr error
+	getAllAccountsErr error
 
 	// call recorders
 	renameCalls         []struct{ old, new string }
@@ -92,6 +93,9 @@ func (m *mockAccountRepo) CreateAccount(_ context.Context, name string, accType 
 }
 
 func (m *mockAccountRepo) GetAllAccounts(_ context.Context) ([]*model.Account, error) {
+	if m.getAllAccountsErr != nil {
+		return nil, m.getAllAccountsErr
+	}
 	result := make([]*model.Account, 0, len(m.accountsByID))
 	for _, acc := range m.accountsByID {
 		result = append(result, acc)


### PR DESCRIPTION
## Summary

Closes #131.

- Adds `model.AccountNode` (Account + Children) so the future React SPA / web layer can render the account hierarchy without rebuilding the tree from a flat list client-side.
- Adds `AccountService.GetAccountTree(ctx, AccountTreeOptions{ShowHidden})` — builds the tree from `GetAllAccounts` using `ParentID`. When `ShowHidden` is false, hidden accounts are dropped and any visible child whose parent was filtered out is promoted to a root (rather than silently dropped). Siblings are sorted alphabetically by `Name` for deterministic output.

## Test plan

- [x] `go test ./internal/service/...` — all pass, including new `TestGetAccountTree` (8 subtests covering empty, flat roots, two-level, three-level, hidden filtering with orphan promotion, `ShowHidden: true`, repo error propagation, and sort-on-unsorted-input)
- [x] `go test ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean