### PR TITLE
feat: add composite index on splits(account_id, reconciled)

### DIFF
--- a/migrations/0008_add_splits_account_reconciled_index.down.sql
+++ b/migrations/0008_add_splits_account_reconciled_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_splits_account_reconciled;

--- a/migrations/0008_add_splits_account_reconciled_index.up.sql
+++ b/migrations/0008_add_splits_account_reconciled_index.up.sql
@@ -1,0 +1,5 @@
+-- Composite index for GetUnreconciledTransactionsByAccount, which filters on
+-- (account_id, reconciled). With separate single-column indexes SQLite can
+-- only use one per scan; the composite lets it satisfy the full predicate.
+CREATE INDEX IF NOT EXISTS idx_splits_account_reconciled
+    ON splits (account_id, reconciled);


### PR DESCRIPTION
## Summary

Closes #132. Adds composite index `idx_splits_account_reconciled` on `splits(account_id, reconciled)` so `GetUnreconciledTransactionsByAccount` can satisfy its full `WHERE s.account_id = ? AND s.reconciled = 0` predicate from a single index instead of one index plus a row filter.

## EXPLAIN QUERY PLAN

Both runs use an in-memory SQLite DB with migrations `0001`–`0007` applied (and `0008` added for the "after" run):

Before:

```
QUERY PLAN
|--SEARCH s USING INDEX idx_splits_reconciled (reconciled=?)
|--SEARCH t USING INTEGER PRIMARY KEY (rowid=?)
`--USE TEMP B-TREE FOR GROUP BY
```

After:

```
QUERY PLAN
|--SEARCH s USING INDEX idx_splits_account_reconciled (account_id=? AND reconciled=?)
|--SEARCH t USING INTEGER PRIMARY KEY (rowid=?)
`--USE TEMP B-TREE FOR GROUP BY
```

The planner now matches both columns against the composite index.

## Out of scope

- Pruning the now-partially-redundant `idx_splits_account_id` and the low-cardinality `idx_splits_reconciled`. Left for a follow-up once every `WHERE`-clause call site has been audited.

## Test plan

- [x] `make build` — migrations embed cleanly
- [x] `go test ./...` — no regressions
- [x] `EXPLAIN QUERY PLAN` confirms the planner now uses the composite index

🤖 Generated with [Claude Code](https://claude.com/claude-code)
