### PR TITLE
feat(api): ledger endpoints

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -148,7 +148,7 @@ func Execute(migrations fs.FS) {
 		rootCmd.AddCommand(NewInfoCmd(application.Service))
 		rootCmd.AddCommand(NewReportCmd(application.Service))
 		rootCmd.AddCommand(NewReconcileCmd(application.Service))
-		rootCmd.AddCommand(NewServeCmd(application.Service, cfg))
+		rootCmd.AddCommand(NewServeCmd(application, migrations, appDir))
 
 		if err := rootCmd.ExecuteContext(ctx); err != nil {
 			pterm.Error.Println(capitalize(err.Error()))

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -4,23 +4,31 @@
 package cmd
 
 import (
+	"io/fs"
 	"log/slog"
 	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/hance08/kea/internal/api"
-	"github.com/hance08/kea/internal/config"
-	"github.com/hance08/kea/internal/service"
+	"github.com/hance08/kea/internal/app"
 )
 
-func NewServeCmd(svc *service.Service, cfg *config.Config) *cobra.Command {
+func NewServeCmd(application *app.App, migrationFS fs.FS, appDir string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "serve",
 		Short: "Run the local web server",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
-			srv := api.NewServer(cfg, svc, logger)
+			srv := api.NewServer(
+				application.Config(),
+				application.Service,
+				application.Registry,
+				migrationFS,
+				appDir,
+				application.SwitchLedger,
+				logger,
+			)
 			return srv.Run(cmd.Context())
 		},
 	}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -5,12 +5,10 @@ package cmd
 
 import (
 	"testing"
-
-	"github.com/hance08/kea/internal/config"
 )
 
 func TestNewServeCmdShape(t *testing.T) {
-	cmd := NewServeCmd(nil, &config.Config{})
+	cmd := NewServeCmd(nil, nil, "")
 	if cmd.Use != "serve" {
 		t.Errorf("Use: got %q, want %q", cmd.Use, "serve")
 	}

--- a/internal/api/accounts_write_test.go
+++ b/internal/api/accounts_write_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hance08/kea/internal/model"
 )
 
-func postJSON(t *testing.T, url string, body string) *http.Response {
+func postJSONStr(t *testing.T, url string, body string) *http.Response {
 	t.Helper()
 	resp, err := http.Post(url, "application/json", strings.NewReader(body))
 	if err != nil {
@@ -25,7 +25,7 @@ func TestHandleCreateAccount_OK(t *testing.T) {
 	ts, _ := newServerWithStore(t)
 
 	body := `{"name":"Assets:Cash","type":"A","currency":"USD","description":"","balance":0}`
-	resp := postJSON(t, ts.URL+"/api/accounts", body)
+	resp := postJSONStr(t, ts.URL+"/api/accounts", body)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
@@ -47,7 +47,7 @@ func TestHandleCreateAccount_WithBalance(t *testing.T) {
 	ts, _ := newServerWithStore(t)
 
 	body := `{"name":"Assets:Bank","type":"A","currency":"USD","description":"","balance":100000}`
-	resp := postJSON(t, ts.URL+"/api/accounts", body)
+	resp := postJSONStr(t, ts.URL+"/api/accounts", body)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
@@ -85,7 +85,7 @@ func TestHandleCreateAccount_LiabilityBalanceSignReversed(t *testing.T) {
 	ts, _ := newServerWithStore(t)
 
 	body := `{"name":"Liabilities:CreditCard","type":"L","currency":"USD","description":"","balance":50000}`
-	resp := postJSON(t, ts.URL+"/api/accounts", body)
+	resp := postJSONStr(t, ts.URL+"/api/accounts", body)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusCreated {
 		t.Fatalf("status: got %d", resp.StatusCode)
@@ -111,7 +111,7 @@ func TestHandleCreateAccount_DuplicateName(t *testing.T) {
 	seedAccount(t, svc, "Assets:Cash", model.AccountTypeAsset, 0)
 
 	body := `{"name":"Assets:Cash","type":"A","currency":"USD","description":"","balance":0}`
-	resp := postJSON(t, ts.URL+"/api/accounts", body)
+	resp := postJSONStr(t, ts.URL+"/api/accounts", body)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusConflict {
@@ -138,7 +138,7 @@ func TestHandleCreateAccount_CircularParent(t *testing.T) {
 		"parent_id": parent.ID,
 		"balance":   0,
 	})
-	resp := postJSON(t, ts.URL+"/api/accounts", string(body))
+	resp := postJSONStr(t, ts.URL+"/api/accounts", string(body))
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusConflict {
 		t.Fatalf("status: got %d, want 409", resp.StatusCode)
@@ -154,7 +154,7 @@ func TestHandleCreateAccount_InvalidType(t *testing.T) {
 	ts, _ := newServerWithStore(t)
 
 	body := `{"name":"Assets:Cash","type":"Z","currency":"USD","description":"","balance":0}`
-	resp := postJSON(t, ts.URL+"/api/accounts", body)
+	resp := postJSONStr(t, ts.URL+"/api/accounts", body)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusBadRequest {
@@ -171,7 +171,7 @@ func TestHandleCreateAccount_EmptyName(t *testing.T) {
 	ts, _ := newServerWithStore(t)
 
 	body := `{"name":"","type":"A","currency":"USD","description":"","balance":0}`
-	resp := postJSON(t, ts.URL+"/api/accounts", body)
+	resp := postJSONStr(t, ts.URL+"/api/accounts", body)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusBadRequest {
@@ -199,7 +199,7 @@ func TestHandleCreateAccount_DescriptionTooLong(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 
-	resp := postJSON(t, ts.URL+"/api/accounts", string(body))
+	resp := postJSONStr(t, ts.URL+"/api/accounts", string(body))
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusBadRequest {
@@ -216,7 +216,7 @@ func TestHandleCreateAccount_UnknownField(t *testing.T) {
 	ts, _ := newServerWithStore(t)
 
 	body := `{"name":"Assets:Cash","type":"A","currency":"USD","balance":0,"unknown_field":1}`
-	resp := postJSON(t, ts.URL+"/api/accounts", body)
+	resp := postJSONStr(t, ts.URL+"/api/accounts", body)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusBadRequest {

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/hance08/kea/internal/ledger"
 	"github.com/hance08/kea/internal/service"
 )
 
@@ -43,6 +44,14 @@ func mapError(err error) (int, errorBody) {
 		return http.StatusConflict, errorBody{Error: "circular_parent", Message: err.Error()}
 	case errors.Is(err, service.ErrNotEditable):
 		return http.StatusForbidden, errorBody{Error: "not_editable", Message: err.Error()}
+	case errors.Is(err, ledger.ErrLedgerNotFound):
+		return http.StatusNotFound, errorBody{Error: "not_found", Message: err.Error()}
+	case errors.Is(err, ledger.ErrLedgerExists):
+		return http.StatusConflict, errorBody{Error: "already_exists", Message: err.Error()}
+	case errors.Is(err, ledger.ErrRemoveActive):
+		return http.StatusConflict, errorBody{Error: "cannot_remove_active", Message: err.Error()}
+	case errors.Is(err, ledger.ErrNoActiveLedger):
+		return http.StatusNotFound, errorBody{Error: "no_active_ledger", Message: err.Error()}
 	default:
 		return http.StatusInternalServerError, errorBody{Error: "internal", Message: "internal server error"}
 	}

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hance08/kea/internal/ledger"
 	"github.com/hance08/kea/internal/service"
 )
 
@@ -26,6 +27,14 @@ func TestMapError(t *testing.T) {
 		{"reconciled", service.ErrReconciled, 409, "reconciled", ""},
 		{"circular_parent", service.ErrCircularParent, 409, "circular_parent", ""},
 		{"not_editable", service.ErrNotEditable, 403, "not_editable", ""},
+		{"ledger_not_found", ledger.ErrLedgerNotFound, 404, "not_found", ""},
+		{"ledger_not_found_wrapped", fmt.Errorf("ledger %q: %w", "x", ledger.ErrLedgerNotFound), 404, "not_found", ""},
+		{"ledger_exists", ledger.ErrLedgerExists, 409, "already_exists", ""},
+		{"ledger_exists_wrapped", fmt.Errorf("ledger %q: %w", "x", ledger.ErrLedgerExists), 409, "already_exists", ""},
+		{"remove_active", ledger.ErrRemoveActive, 409, "cannot_remove_active", ""},
+		{"remove_active_wrapped", fmt.Errorf("active: %w", ledger.ErrRemoveActive), 409, "cannot_remove_active", ""},
+		{"no_active_ledger", ledger.ErrNoActiveLedger, 404, "no_active_ledger", ""},
+		{"no_active_ledger_wrapped", fmt.Errorf("ledger: %w", ledger.ErrNoActiveLedger), 404, "no_active_ledger", ""},
 		{"unknown", errors.New("boom"), 500, "internal", ""},
 	}
 	for _, tc := range cases {

--- a/internal/api/ledgers.go
+++ b/internal/api/ledgers.go
@@ -4,7 +4,10 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
+
+	"github.com/hance08/kea/internal/ledger"
 )
 
 type ledgerInfo struct {
@@ -24,6 +27,18 @@ type createLedgerRequest struct {
 
 type switchLedgerRequest struct {
 	Name string `json:"name"`
+}
+
+func (s *Server) handleActiveLedger(w http.ResponseWriter, r *http.Request) error {
+	name := s.registry.ActiveName()
+	if name == "" {
+		return ledger.ErrNoActiveLedger
+	}
+	e, ok := s.registry.EntryFor(name)
+	if !ok {
+		return fmt.Errorf("%w: %q", ledger.ErrLedgerNotFound, name)
+	}
+	return writeJSON(w, http.StatusOK, ledgerInfo{Name: name, Path: e.Path, Active: true})
 }
 
 func (s *Server) handleListLedgers(w http.ResponseWriter, r *http.Request) error {

--- a/internal/api/ledgers.go
+++ b/internal/api/ledgers.go
@@ -95,3 +95,18 @@ func (s *Server) handleCreateLedger(w http.ResponseWriter, r *http.Request) erro
 	}
 	return writeJSON(w, http.StatusCreated, ledgerInfo{Name: req.Name, Path: dbPath, Active: false})
 }
+
+func (s *Server) handleSwitchLedger(w http.ResponseWriter, r *http.Request) error {
+	var req switchLedgerRequest
+	if err := decodeJSON(r, &req); err != nil {
+		return err
+	}
+	if err := validateLedgerName(req.Name); err != nil {
+		return err
+	}
+	if err := s.switchLedger(req.Name); err != nil {
+		return err
+	}
+	e, _ := s.registry.EntryFor(req.Name)
+	return writeJSON(w, http.StatusOK, ledgerInfo{Name: req.Name, Path: e.Path, Active: true})
+}

--- a/internal/api/ledgers.go
+++ b/internal/api/ledgers.go
@@ -36,6 +36,11 @@ type switchLedgerRequest struct {
 	Name string `json:"name"`
 }
 
+type deleteLedgerResponse struct {
+	Deleted bool   `json:"deleted"`
+	Name    string `json:"name"`
+}
+
 func (s *Server) handleActiveLedger(w http.ResponseWriter, r *http.Request) error {
 	name := s.registry.ActiveName()
 	if name == "" {
@@ -115,8 +120,11 @@ func (s *Server) handleSwitchLedger(w http.ResponseWriter, r *http.Request) erro
 
 func (s *Server) handleDeleteLedger(w http.ResponseWriter, r *http.Request) error {
 	name := chi.URLParam(r, "name")
+	if err := validateLedgerName(name); err != nil {
+		return err
+	}
 	if err := s.registry.Remove(name, false); err != nil {
 		return err
 	}
-	return writeJSON(w, http.StatusOK, map[string]any{"deleted": true, "name": name})
+	return writeJSON(w, http.StatusOK, deleteLedgerResponse{Deleted: true, Name: name})
 }

--- a/internal/api/ledgers.go
+++ b/internal/api/ledgers.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package api
+
+import (
+	"net/http"
+)
+
+type ledgerInfo struct {
+	Name   string `json:"name"`
+	Path   string `json:"path"`
+	Active bool   `json:"active"`
+}
+
+type ledgerListResponse struct {
+	Active string       `json:"active"`
+	Items  []ledgerInfo `json:"items"`
+}
+
+type createLedgerRequest struct {
+	Name string `json:"name"`
+}
+
+type switchLedgerRequest struct {
+	Name string `json:"name"`
+}
+
+func (s *Server) handleListLedgers(w http.ResponseWriter, r *http.Request) error {
+	active := s.registry.ActiveName()
+	names := s.registry.Names()
+	items := make([]ledgerInfo, 0, len(names))
+	for _, n := range names {
+		e, _ := s.registry.EntryFor(n)
+		items = append(items, ledgerInfo{Name: n, Path: e.Path, Active: n == active})
+	}
+	return writeJSON(w, http.StatusOK, ledgerListResponse{Active: active, Items: items})
+}

--- a/internal/api/ledgers.go
+++ b/internal/api/ledgers.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/hance08/kea/internal/app"
 	"github.com/hance08/kea/internal/ledger"
 	"github.com/hance08/kea/internal/service"
@@ -109,4 +111,12 @@ func (s *Server) handleSwitchLedger(w http.ResponseWriter, r *http.Request) erro
 	}
 	e, _ := s.registry.EntryFor(req.Name)
 	return writeJSON(w, http.StatusOK, ledgerInfo{Name: req.Name, Path: e.Path, Active: true})
+}
+
+func (s *Server) handleDeleteLedger(w http.ResponseWriter, r *http.Request) error {
+	name := chi.URLParam(r, "name")
+	if err := s.registry.Remove(name, false); err != nil {
+		return err
+	}
+	return writeJSON(w, http.StatusOK, map[string]any{"deleted": true, "name": name})
 }

--- a/internal/api/ledgers.go
+++ b/internal/api/ledgers.go
@@ -6,8 +6,13 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 
+	"github.com/hance08/kea/internal/app"
 	"github.com/hance08/kea/internal/ledger"
+	"github.com/hance08/kea/internal/service"
 )
 
 type ledgerInfo struct {
@@ -50,4 +55,43 @@ func (s *Server) handleListLedgers(w http.ResponseWriter, r *http.Request) error
 		items = append(items, ledgerInfo{Name: n, Path: e.Path, Active: n == active})
 	}
 	return writeJSON(w, http.StatusOK, ledgerListResponse{Active: active, Items: items})
+}
+
+func validateLedgerName(name string) error {
+	if name == "" {
+		return &service.ValidationError{Field: "name", Message: "name is required"}
+	}
+	if strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") {
+		return &service.ValidationError{Field: "name", Message: "name must not contain path separators"}
+	}
+	for _, r := range name {
+		if r < 0x20 || r == 0x7f {
+			return &service.ValidationError{Field: "name", Message: "name must not contain control characters"}
+		}
+	}
+	return nil
+}
+
+func (s *Server) handleCreateLedger(w http.ResponseWriter, r *http.Request) error {
+	var req createLedgerRequest
+	if err := decodeJSON(r, &req); err != nil {
+		return err
+	}
+	if err := validateLedgerName(req.Name); err != nil {
+		return err
+	}
+	if _, exists := s.registry.EntryFor(req.Name); exists {
+		return fmt.Errorf("%w: %q", ledger.ErrLedgerExists, req.Name)
+	}
+	dbPath := filepath.Join(s.appDir, "ledgers", req.Name+".db")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0755); err != nil {
+		return fmt.Errorf("create ledger directory: %w", err)
+	}
+	if err := app.InitLedgerDB(dbPath, s.migrations); err != nil {
+		return fmt.Errorf("initialize database: %w", err)
+	}
+	if err := s.registry.Add(req.Name, dbPath); err != nil {
+		return err
+	}
+	return writeJSON(w, http.StatusCreated, ledgerInfo{Name: req.Name, Path: dbPath, Active: false})
 }

--- a/internal/api/ledgers_test.go
+++ b/internal/api/ledgers_test.go
@@ -440,3 +440,21 @@ func TestHandleDeleteLedger_Unknown(t *testing.T) {
 		t.Errorf("error: got %q, want not_found", eb.Error)
 	}
 }
+
+func TestHandleDeleteLedger_InvalidName(t *testing.T) {
+	ts, _, _, _ := newTestServerWithLedger(t)
+
+	// chi only routes to the handler when {name} is non-empty, so we exercise
+	// the post-routing validation via a name containing "..".
+	status, body := deleteURL(t, ts.URL+"/api/ledgers/..foo")
+	if status != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body=%s", status, body)
+	}
+	var eb errorBody
+	if err := json.Unmarshal(body, &eb); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if eb.Error != "validation_failed" || eb.Field != "name" {
+		t.Errorf("error: got %+v, want validation_failed/name", eb)
+	}
+}

--- a/internal/api/ledgers_test.go
+++ b/internal/api/ledgers_test.go
@@ -284,3 +284,74 @@ func TestHandleCreateLedger_UnknownField(t *testing.T) {
 		t.Errorf("error: got %q, want validation_failed", eb.Error)
 	}
 }
+
+func TestHandleSwitchLedger_Success(t *testing.T) {
+	ts, reg, appDir, calls := newTestServerWithLedger(t)
+
+	pathA := filepath.Join(appDir, "ledgers", "alpha.db")
+	pathB := filepath.Join(appDir, "ledgers", "beta.db")
+	if err := reg.Add("alpha", pathA); err != nil {
+		t.Fatalf("add alpha: %v", err)
+	}
+	if err := reg.Add("beta", pathB); err != nil {
+		t.Fatalf("add beta: %v", err)
+	}
+	if err := reg.Switch("alpha"); err != nil {
+		t.Fatalf("seed switch: %v", err)
+	}
+
+	status, body := postJSON(t, ts.URL+"/api/ledgers/switch", map[string]any{"name": "beta"})
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", status, body)
+	}
+
+	var got struct {
+		Name   string `json:"name"`
+		Path   string `json:"path"`
+		Active bool   `json:"active"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.Name != "beta" || got.Path != pathB || !got.Active {
+		t.Errorf("body: got %+v, want {beta, %s, true}", got, pathB)
+	}
+	if reg.ActiveName() != "beta" {
+		t.Errorf("registry active: got %q, want beta", reg.ActiveName())
+	}
+	if len(*calls) != 1 || (*calls)[0] != "beta" {
+		t.Errorf("switchLedger calls: got %v, want [beta]", *calls)
+	}
+}
+
+func TestHandleSwitchLedger_Unknown(t *testing.T) {
+	ts, _, _, _ := newTestServerWithLedger(t)
+
+	status, body := postJSON(t, ts.URL+"/api/ledgers/switch", map[string]any{"name": "ghost"})
+	if status != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", status, body)
+	}
+	var eb errorBody
+	if err := json.Unmarshal(body, &eb); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if eb.Error != "not_found" {
+		t.Errorf("error: got %q, want not_found", eb.Error)
+	}
+}
+
+func TestHandleSwitchLedger_EmptyName(t *testing.T) {
+	ts, _, _, _ := newTestServerWithLedger(t)
+
+	status, body := postJSON(t, ts.URL+"/api/ledgers/switch", map[string]any{"name": ""})
+	if status != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body=%s", status, body)
+	}
+	var eb errorBody
+	if err := json.Unmarshal(body, &eb); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if eb.Error != "validation_failed" || eb.Field != "name" {
+		t.Errorf("error: got %+v, want validation_failed/name", eb)
+	}
+}

--- a/internal/api/ledgers_test.go
+++ b/internal/api/ledgers_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"testing"
+)
+
+func getJSON(t *testing.T, url string) (int, []byte) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp.StatusCode, body
+}
+
+func postJSON(t *testing.T, url string, payload any) (int, []byte) {
+	t.Helper()
+	var buf bytes.Buffer
+	if payload != nil {
+		if err := json.NewEncoder(&buf).Encode(payload); err != nil {
+			t.Fatalf("encode payload: %v", err)
+		}
+	}
+	resp, err := http.Post(url, "application/json", &buf)
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp.StatusCode, body
+}
+
+func deleteURL(t *testing.T, url string) (int, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp.StatusCode, body
+}
+
+func TestHandleListLedgers_Empty(t *testing.T) {
+	ts, _, _, _ := newTestServerWithLedger(t)
+
+	status, body := getJSON(t, ts.URL+"/api/ledgers")
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", status, body)
+	}
+
+	var got struct {
+		Active string `json:"active"`
+		Items  []struct {
+			Name   string `json:"name"`
+			Path   string `json:"path"`
+			Active bool   `json:"active"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.Active != "" {
+		t.Errorf("active: got %q, want \"\"", got.Active)
+	}
+	if len(got.Items) != 0 {
+		t.Errorf("items: got %v, want []", got.Items)
+	}
+}
+
+func TestHandleListLedgers_TwoRegisteredOneActive(t *testing.T) {
+	ts, reg, appDir, _ := newTestServerWithLedger(t)
+
+	pathA := filepath.Join(appDir, "ledgers", "alpha.db")
+	pathB := filepath.Join(appDir, "ledgers", "beta.db")
+	if err := reg.Add("alpha", pathA); err != nil {
+		t.Fatalf("add alpha: %v", err)
+	}
+	if err := reg.Add("beta", pathB); err != nil {
+		t.Fatalf("add beta: %v", err)
+	}
+	if err := reg.Switch("alpha"); err != nil {
+		t.Fatalf("switch alpha: %v", err)
+	}
+
+	status, body := getJSON(t, ts.URL+"/api/ledgers")
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", status, body)
+	}
+
+	var got struct {
+		Active string `json:"active"`
+		Items  []struct {
+			Name   string `json:"name"`
+			Path   string `json:"path"`
+			Active bool   `json:"active"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.Active != "alpha" {
+		t.Errorf("active: got %q, want %q", got.Active, "alpha")
+	}
+	if len(got.Items) != 2 {
+		t.Fatalf("items: got %d, want 2", len(got.Items))
+	}
+	// Items must be sorted by name: alpha, beta.
+	if got.Items[0].Name != "alpha" || got.Items[1].Name != "beta" {
+		t.Errorf("sort order: got [%q, %q], want [alpha, beta]",
+			got.Items[0].Name, got.Items[1].Name)
+	}
+	if !got.Items[0].Active || got.Items[1].Active {
+		t.Errorf("active flags: got [%v, %v], want [true, false]",
+			got.Items[0].Active, got.Items[1].Active)
+	}
+	if got.Items[0].Path != pathA || got.Items[1].Path != pathB {
+		t.Errorf("paths: got [%q, %q], want [%q, %q]",
+			got.Items[0].Path, got.Items[1].Path, pathA, pathB)
+	}
+}

--- a/internal/api/ledgers_test.go
+++ b/internal/api/ledgers_test.go
@@ -91,6 +91,50 @@ func TestHandleListLedgers_Empty(t *testing.T) {
 	}
 }
 
+func TestHandleActiveLedger_None(t *testing.T) {
+	ts, _, _, _ := newTestServerWithLedger(t)
+
+	status, body := getJSON(t, ts.URL+"/api/ledgers/active")
+	if status != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", status, body)
+	}
+	var got errorBody
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.Error != "no_active_ledger" {
+		t.Errorf("error: got %q, want %q", got.Error, "no_active_ledger")
+	}
+}
+
+func TestHandleActiveLedger_Set(t *testing.T) {
+	ts, reg, appDir, _ := newTestServerWithLedger(t)
+
+	path := filepath.Join(appDir, "ledgers", "alpha.db")
+	if err := reg.Add("alpha", path); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := reg.Switch("alpha"); err != nil {
+		t.Fatalf("switch: %v", err)
+	}
+
+	status, body := getJSON(t, ts.URL+"/api/ledgers/active")
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", status, body)
+	}
+	var got struct {
+		Name   string `json:"name"`
+		Path   string `json:"path"`
+		Active bool   `json:"active"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.Name != "alpha" || got.Path != path || !got.Active {
+		t.Errorf("body: got %+v, want {alpha, %s, true}", got, path)
+	}
+}
+
 func TestHandleListLedgers_TwoRegisteredOneActive(t *testing.T) {
 	ts, reg, appDir, _ := newTestServerWithLedger(t)
 

--- a/internal/api/ledgers_test.go
+++ b/internal/api/ledgers_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -184,5 +185,102 @@ func TestHandleListLedgers_TwoRegisteredOneActive(t *testing.T) {
 	if got.Items[0].Path != pathA || got.Items[1].Path != pathB {
 		t.Errorf("paths: got [%q, %q], want [%q, %q]",
 			got.Items[0].Path, got.Items[1].Path, pathA, pathB)
+	}
+}
+
+func TestHandleCreateLedger_Success(t *testing.T) {
+	ts, reg, appDir, _ := newTestServerWithLedger(t)
+
+	status, body := postJSON(t, ts.URL+"/api/ledgers", map[string]any{"name": "alpha"})
+	if status != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201; body=%s", status, body)
+	}
+
+	var got struct {
+		Name   string `json:"name"`
+		Path   string `json:"path"`
+		Active bool   `json:"active"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	wantPath := filepath.Join(appDir, "ledgers", "alpha.db")
+	if got.Name != "alpha" || got.Path != wantPath || got.Active {
+		t.Errorf("body: got %+v, want {alpha, %s, false}", got, wantPath)
+	}
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Errorf("db file not created at %q: %v", wantPath, err)
+	}
+	if _, ok := reg.EntryFor("alpha"); !ok {
+		t.Errorf("registry missing alpha after create")
+	}
+}
+
+func TestHandleCreateLedger_DuplicateName(t *testing.T) {
+	ts, reg, appDir, _ := newTestServerWithLedger(t)
+
+	if err := reg.Add("alpha", filepath.Join(appDir, "ledgers", "alpha.db")); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	status, body := postJSON(t, ts.URL+"/api/ledgers", map[string]any{"name": "alpha"})
+	if status != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409; body=%s", status, body)
+	}
+	var eb errorBody
+	if err := json.Unmarshal(body, &eb); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if eb.Error != "already_exists" {
+		t.Errorf("error: got %q, want %q", eb.Error, "already_exists")
+	}
+}
+
+func TestHandleCreateLedger_InvalidName(t *testing.T) {
+	ts, _, _, _ := newTestServerWithLedger(t)
+
+	cases := []struct {
+		name    string
+		payload map[string]any
+	}{
+		{"empty", map[string]any{"name": ""}},
+		{"slash", map[string]any{"name": "a/b"}},
+		{"backslash", map[string]any{"name": `a\b`}},
+		{"dotdot", map[string]any{"name": "..foo"}},
+		{"control_char", map[string]any{"name": "a\x00b"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, body := postJSON(t, ts.URL+"/api/ledgers", tc.payload)
+			if status != http.StatusBadRequest {
+				t.Fatalf("status: got %d, want 400; body=%s", status, body)
+			}
+			var eb errorBody
+			if err := json.Unmarshal(body, &eb); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if eb.Error != "validation_failed" || eb.Field != "name" {
+				t.Errorf("error: got %+v, want validation_failed/name", eb)
+			}
+		})
+	}
+}
+
+func TestHandleCreateLedger_UnknownField(t *testing.T) {
+	ts, _, _, _ := newTestServerWithLedger(t)
+
+	status, body := postJSON(t, ts.URL+"/api/ledgers", map[string]any{
+		"name": "alpha",
+		"path": "/tmp/evil.db",
+	})
+	if status != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body=%s", status, body)
+	}
+	var eb errorBody
+	if err := json.Unmarshal(body, &eb); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if eb.Error != "validation_failed" {
+		t.Errorf("error: got %q, want validation_failed", eb.Error)
 	}
 }

--- a/internal/api/ledgers_test.go
+++ b/internal/api/ledgers_test.go
@@ -355,3 +355,88 @@ func TestHandleSwitchLedger_EmptyName(t *testing.T) {
 		t.Errorf("error: got %+v, want validation_failed/name", eb)
 	}
 }
+
+func TestHandleDeleteLedger_Inactive(t *testing.T) {
+	ts, reg, appDir, _ := newTestServerWithLedger(t)
+
+	pathA := filepath.Join(appDir, "ledgers", "alpha.db")
+	pathB := filepath.Join(appDir, "ledgers", "beta.db")
+	if err := reg.Add("alpha", pathA); err != nil {
+		t.Fatalf("add alpha: %v", err)
+	}
+	if err := reg.Add("beta", pathB); err != nil {
+		t.Fatalf("add beta: %v", err)
+	}
+	if err := reg.Switch("alpha"); err != nil {
+		t.Fatalf("switch: %v", err)
+	}
+
+	// Create the beta file on disk so we can assert the file is untouched
+	// after DELETE.
+	if err := os.MkdirAll(filepath.Dir(pathB), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(pathB, []byte("sqlite-magic"), 0644); err != nil {
+		t.Fatalf("write beta: %v", err)
+	}
+
+	status, body := deleteURL(t, ts.URL+"/api/ledgers/beta")
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", status, body)
+	}
+	var got struct {
+		Deleted bool   `json:"deleted"`
+		Name    string `json:"name"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !got.Deleted || got.Name != "beta" {
+		t.Errorf("body: got %+v, want {deleted:true, name:beta}", got)
+	}
+	if _, ok := reg.EntryFor("beta"); ok {
+		t.Errorf("registry still has beta after delete")
+	}
+	if _, err := os.Stat(pathB); err != nil {
+		t.Errorf("beta db file removed despite unregister-only policy: %v", err)
+	}
+}
+
+func TestHandleDeleteLedger_Active(t *testing.T) {
+	ts, reg, appDir, _ := newTestServerWithLedger(t)
+
+	if err := reg.Add("alpha", filepath.Join(appDir, "ledgers", "alpha.db")); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := reg.Switch("alpha"); err != nil {
+		t.Fatalf("switch: %v", err)
+	}
+
+	status, body := deleteURL(t, ts.URL+"/api/ledgers/alpha")
+	if status != http.StatusConflict {
+		t.Fatalf("status: got %d, want 409; body=%s", status, body)
+	}
+	var eb errorBody
+	if err := json.Unmarshal(body, &eb); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if eb.Error != "cannot_remove_active" {
+		t.Errorf("error: got %q, want cannot_remove_active", eb.Error)
+	}
+}
+
+func TestHandleDeleteLedger_Unknown(t *testing.T) {
+	ts, _, _, _ := newTestServerWithLedger(t)
+
+	status, body := deleteURL(t, ts.URL+"/api/ledgers/ghost")
+	if status != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", status, body)
+	}
+	var eb errorBody
+	if err := json.Unmarshal(body, &eb); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if eb.Error != "not_found" {
+		t.Errorf("error: got %q, want not_found", eb.Error)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -43,6 +43,7 @@ func (s *Server) routes() http.Handler {
 		r.Method(http.MethodGet, "/reports/net-worth", apiHandler(s.handleNetWorth))
 		r.Method(http.MethodGet, "/ledgers/active", apiHandler(s.handleActiveLedger))
 		r.Method(http.MethodGet, "/ledgers", apiHandler(s.handleListLedgers))
+		r.Method(http.MethodPost, "/ledgers", apiHandler(s.handleCreateLedger))
 	})
 
 	return r

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -45,6 +45,7 @@ func (s *Server) routes() http.Handler {
 		r.Method(http.MethodGet, "/ledgers", apiHandler(s.handleListLedgers))
 		r.Method(http.MethodPost, "/ledgers", apiHandler(s.handleCreateLedger))
 		r.Method(http.MethodPost, "/ledgers/switch", apiHandler(s.handleSwitchLedger))
+		r.Method(http.MethodDelete, "/ledgers/{name}", apiHandler(s.handleDeleteLedger))
 	})
 
 	return r

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -44,6 +44,7 @@ func (s *Server) routes() http.Handler {
 		r.Method(http.MethodGet, "/ledgers/active", apiHandler(s.handleActiveLedger))
 		r.Method(http.MethodGet, "/ledgers", apiHandler(s.handleListLedgers))
 		r.Method(http.MethodPost, "/ledgers", apiHandler(s.handleCreateLedger))
+		r.Method(http.MethodPost, "/ledgers/switch", apiHandler(s.handleSwitchLedger))
 	})
 
 	return r

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -41,6 +41,7 @@ func (s *Server) routes() http.Handler {
 		r.Method(http.MethodGet, "/reports/expense-breakdown", apiHandler(s.handleExpenseBreakdown))
 		r.Method(http.MethodGet, "/reports/balance-sheet", apiHandler(s.handleBalanceSheet))
 		r.Method(http.MethodGet, "/reports/net-worth", apiHandler(s.handleNetWorth))
+		r.Method(http.MethodGet, "/ledgers/active", apiHandler(s.handleActiveLedger))
 		r.Method(http.MethodGet, "/ledgers", apiHandler(s.handleListLedgers))
 	})
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -41,6 +41,7 @@ func (s *Server) routes() http.Handler {
 		r.Method(http.MethodGet, "/reports/expense-breakdown", apiHandler(s.handleExpenseBreakdown))
 		r.Method(http.MethodGet, "/reports/balance-sheet", apiHandler(s.handleBalanceSheet))
 		r.Method(http.MethodGet, "/reports/net-worth", apiHandler(s.handleNetWorth))
+		r.Method(http.MethodGet, "/ledgers", apiHandler(s.handleListLedgers))
 	})
 
 	return r

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -21,7 +21,7 @@ func newTestServer(t *testing.T) *httptest.Server {
 			CORSOrigins: []string{"http://localhost:5173"},
 		},
 	}
-	srv := NewServer(cfg, nil, discardLogger())
+	srv := NewServer(cfg, nil, nil, nil, "", nil, discardLogger())
 	ts := httptest.NewServer(srv.routes())
 	t.Cleanup(ts.Close)
 	return ts

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -6,6 +6,7 @@ package api
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"log/slog"
 	"net"
 	"net/http"
@@ -13,20 +14,41 @@ import (
 	"time"
 
 	"github.com/hance08/kea/internal/config"
+	"github.com/hance08/kea/internal/ledger"
 	"github.com/hance08/kea/internal/service"
 )
 
 const shutdownTimeout = 5 * time.Second
 
 type Server struct {
-	cfg    *config.Config
-	svc    *service.Service
-	logger *slog.Logger
-	http   *http.Server
+	cfg        *config.Config
+	svc        *service.Service
+	registry   *ledger.Registry
+	migrations fs.FS
+	appDir     string
+	switchLedger func(name string) error
+	logger     *slog.Logger
+	http       *http.Server
 }
 
-func NewServer(cfg *config.Config, svc *service.Service, logger *slog.Logger) *Server {
-	s := &Server{cfg: cfg, svc: svc, logger: logger}
+func NewServer(
+	cfg *config.Config,
+	svc *service.Service,
+	registry *ledger.Registry,
+	migrations fs.FS,
+	appDir string,
+	switchLedger func(name string) error,
+	logger *slog.Logger,
+) *Server {
+	s := &Server{
+		cfg:        cfg,
+		svc:        svc,
+		registry:   registry,
+		migrations: migrations,
+		appDir:     appDir,
+		switchLedger: switchLedger,
+		logger:     logger,
+	}
 	addr := net.JoinHostPort(cfg.Server.Host, strconv.Itoa(cfg.Server.Port))
 	s.http = &http.Server{
 		Addr:              addr,

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -18,7 +18,7 @@ func TestRunReturnsWhenContextCancelled(t *testing.T) {
 			Port: 0, // Let the kernel pick a free port.
 		},
 	}
-	srv := NewServer(cfg, nil, discardLogger())
+	srv := NewServer(cfg, nil, nil, nil, "", nil, discardLogger())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)

--- a/internal/api/testhelper_test.go
+++ b/internal/api/testhelper_test.go
@@ -4,11 +4,13 @@
 package api
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
 
 	"github.com/hance08/kea/internal/config"
+	"github.com/hance08/kea/internal/ledger"
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/service"
 	"github.com/hance08/kea/internal/store"
@@ -110,6 +112,73 @@ func injectParentSelfCycle(t *testing.T, st *store.Store, accountID int64) {
 	if _, err := st.DB().ExecContext(t.Context(),
 		"UPDATE accounts SET parent_id = ? WHERE id = ?", accountID, accountID); err != nil {
 		t.Fatalf("inject cycle: %v", err)
+	}
+}
+
+// newTestServerWithLedger wires a fresh Server backed by a real on-disk
+// *ledger.Registry plus a fake switchLedger fn that records calls and
+// updates the registry's active name without invoking dbStore.Swap.
+//
+// The real store-swap behavior is exercised in internal/app/app_test.go;
+// duplicating it at the HTTP boundary does not pin additional behavior.
+func newTestServerWithLedger(t *testing.T) (
+	ts *httptest.Server,
+	reg *ledger.Registry,
+	appDir string,
+	switchCalls *[]string,
+) {
+	t.Helper()
+
+	appDir = t.TempDir()
+
+	var err error
+	reg, err = ledger.Load(appDir)
+	if err != nil {
+		t.Fatalf("ledger.Load: %v", err)
+	}
+
+	// ledger.Load auto-creates a "default" entry pointing at <appDir>/kea.db
+	// and sets it active. Remove it so tests start from a clean slate; tests
+	// that need a default-active ledger seed one explicitly.
+	delete(reg.Ledgers, "default")
+	reg.ActiveLedger = ""
+	if err := reg.Save(); err != nil {
+		t.Fatalf("clear default: %v", err)
+	}
+
+	calls := []string{}
+	switchLedger := func(name string) error {
+		calls = append(calls, name)
+		if _, ok := reg.EntryFor(name); !ok {
+			return fmt.Errorf("%w: %q", ledger.ErrLedgerNotFound, name)
+		}
+		return reg.Switch(name)
+	}
+
+	cfg := config.NewDefault()
+	srv := NewServer(cfg, nil, reg, migrations.FS, appDir, switchLedger, discardLogger())
+	ts = httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+
+	return ts, reg, appDir, &calls
+}
+
+func TestNewTestServerWithLedger_StartsClean(t *testing.T) {
+	_, reg, appDir, calls := newTestServerWithLedger(t)
+	if reg == nil {
+		t.Fatal("registry is nil")
+	}
+	if got := reg.ActiveName(); got != "" {
+		t.Errorf("ActiveName: got %q, want \"\"", got)
+	}
+	if len(reg.Names()) != 0 {
+		t.Errorf("Names: got %v, want empty", reg.Names())
+	}
+	if appDir == "" {
+		t.Error("appDir is empty")
+	}
+	if calls == nil {
+		t.Error("switchCalls slice is nil")
 	}
 }
 

--- a/internal/api/testhelper_test.go
+++ b/internal/api/testhelper_test.go
@@ -81,7 +81,7 @@ func newServerForWrite(t *testing.T) (*httptest.Server, *service.Service, *store
 	cfg.Defaults.Currency = "USD"
 
 	svc := service.NewService(st, st, st, cfg)
-	srv := NewServer(cfg, svc, discardLogger())
+	srv := NewServer(cfg, svc, nil, nil, "", nil, discardLogger())
 	ts := httptest.NewServer(srv.routes())
 	t.Cleanup(ts.Close)
 

--- a/internal/api/transactions_write_test.go
+++ b/internal/api/transactions_write_test.go
@@ -27,7 +27,7 @@ func TestHandleCreateTransaction_OK(t *testing.T) {
 		"status":"Cleared",
 		"type":"Expense"
 	}`
-	resp := postJSON(t, ts.URL+"/api/transactions", body)
+	resp := postJSONStr(t, ts.URL+"/api/transactions", body)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusCreated {
 		t.Fatalf("status: got %d, want 201", resp.StatusCode)
@@ -61,7 +61,7 @@ func TestHandleCreateTransaction_Unbalanced(t *testing.T) {
 		],
 		"description":"x","timestamp":1700000000,"status":"Cleared","type":"Expense"
 	}`
-	resp := postJSON(t, ts.URL+"/api/transactions", body)
+	resp := postJSONStr(t, ts.URL+"/api/transactions", body)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("status: got %d, want 400", resp.StatusCode)
@@ -76,7 +76,7 @@ func TestHandleCreateTransaction_OneSplit(t *testing.T) {
 		"splits":[{"account_name":"Assets:Bank","amount":-500}],
 		"description":"x","timestamp":1700000000,"status":"Cleared","type":"Expense"
 	}`
-	resp := postJSON(t, ts.URL+"/api/transactions", body)
+	resp := postJSONStr(t, ts.URL+"/api/transactions", body)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("status: got %d, want 400", resp.StatusCode)
@@ -101,7 +101,7 @@ func TestHandleCreateTransaction_TypeMismatch(t *testing.T) {
 		],
 		"description":"x","timestamp":1700000000,"status":"Cleared","type":"Income"
 	}`
-	resp := postJSON(t, ts.URL+"/api/transactions", body)
+	resp := postJSONStr(t, ts.URL+"/api/transactions", body)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("status: got %d, want 400", resp.StatusCode)
@@ -120,7 +120,7 @@ func TestHandleCreateTransaction_ReconciledOnCreate(t *testing.T) {
 		],
 		"description":"x","timestamp":1700000000,"status":"Reconciled","type":"Expense"
 	}`
-	resp := postJSON(t, ts.URL+"/api/transactions", body)
+	resp := postJSONStr(t, ts.URL+"/api/transactions", body)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("status: got %d, want 400", resp.StatusCode)
@@ -144,7 +144,7 @@ func TestHandleCreateTransaction_EmptyDescription(t *testing.T) {
 		],
 		"description":"","timestamp":1700000000,"status":"Cleared","type":"Expense"
 	}`
-	resp := postJSON(t, ts.URL+"/api/transactions", body)
+	resp := postJSONStr(t, ts.URL+"/api/transactions", body)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("status: got %d, want 400", resp.StatusCode)
@@ -170,7 +170,7 @@ func TestHandleCreateTransaction_MemoTooLong(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	resp := postJSON(t, ts.URL+"/api/transactions", string(body))
+	resp := postJSONStr(t, ts.URL+"/api/transactions", string(body))
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("status: got %d, want 400", resp.StatusCode)
@@ -197,7 +197,7 @@ func TestHandleCreateTransaction_HiddenAccount(t *testing.T) {
 		],
 		"description":"x","timestamp":1700000000,"status":"Cleared","type":"Expense"
 	}`
-	resp := postJSON(t, ts.URL+"/api/transactions", body)
+	resp := postJSONStr(t, ts.URL+"/api/transactions", body)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("status: got %d, want 400", resp.StatusCode)
@@ -219,7 +219,7 @@ func TestHandleCreateTransaction_NonexistentAccount_Currently500(t *testing.T) {
 		],
 		"description":"x","timestamp":1700000000,"status":"Cleared","type":"Expense"
 	}`
-	resp := postJSON(t, ts.URL+"/api/transactions", body)
+	resp := postJSONStr(t, ts.URL+"/api/transactions", body)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusInternalServerError {
 		t.Errorf("status: got %d, want 500 (known rough edge — fix is out of scope)", resp.StatusCode)
@@ -250,7 +250,7 @@ func TestHandleCreateTransaction_ParentAccountInSplit(t *testing.T) {
 		],
 		"description":"x","timestamp":1700000000,"status":"Cleared","type":"Expense"
 	}`
-	resp := postJSON(t, ts.URL+"/api/transactions", body)
+	resp := postJSONStr(t, ts.URL+"/api/transactions", body)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status: got %d, want 400", resp.StatusCode)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -102,6 +102,10 @@ func (a *App) SwitchLedger(name string) error {
 	return a.Registry.Switch(name)
 }
 
+// Config returns the config in use. Used by callers that build subcommands
+// from *App and need the same cfg pointer NewApp captured.
+func (a *App) Config() *config.Config { return a.cfg }
+
 func InitLedgerDB(path string, migrations fs.FS) error {
 	s, err := store.NewStore(path, migrations)
 	if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -17,8 +17,11 @@ import (
 )
 
 type App struct {
-	Service  *service.Service
-	Registry *ledger.Registry
+	Service    *service.Service
+	Registry   *ledger.Registry
+	store      *store.Store
+	migrations fs.FS
+	cfg        *config.Config
 }
 
 // NewApp initialize config, database and core logic, then return App entity
@@ -61,8 +64,11 @@ func NewApp(cfg *config.Config, registry *ledger.Registry, migrationFS fs.FS) (*
 	}
 
 	return &App{
-		Service:  svc,
-		Registry: registry,
+		Service:    svc,
+		Registry:   registry,
+		store:      dbStore,
+		migrations: migrationFS,
+		cfg:        cfg,
 	}, cleanup, nil
 }
 
@@ -77,6 +83,23 @@ func GetAppDataDir() (string, error) {
 	}
 
 	return filepath.Join(configDir, "kea"), nil
+}
+
+// SwitchLedger atomically swaps the active store to the named ledger,
+// updates the in-memory config, and persists the active-name change to
+// ledgers.yaml. The registry's fsnotify watcher subsequently fires reload(),
+// which short-circuits because ActiveLedger already matches.
+func (a *App) SwitchLedger(name string) error {
+	entry, ok := a.Registry.EntryFor(name)
+	if !ok {
+		return fmt.Errorf("%w: %q", ledger.ErrLedgerNotFound, name)
+	}
+	if err := a.store.Swap(entry.Path, a.migrations); err != nil {
+		return fmt.Errorf("swap store: %w", err)
+	}
+	a.cfg.ActiveLedger = name
+	a.cfg.Database.Path = entry.Path
+	return a.Registry.Switch(name)
 }
 
 func InitLedgerDB(path string, migrations fs.FS) error {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package app
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hance08/kea/internal/config"
+	"github.com/hance08/kea/internal/ledger"
+	"github.com/hance08/kea/internal/store"
+	"github.com/hance08/kea/migrations"
+)
+
+// newTestApp returns an *App wired to two on-disk ledgers ("a", "b"), both
+// registered, with "a" active. tempDir holds ledgers.yaml plus the two DB
+// files.
+func newTestApp(t *testing.T) (a *App, tempDir string, pathA, pathB string) {
+	t.Helper()
+	tempDir = t.TempDir()
+	pathA = filepath.Join(tempDir, "a.db")
+	pathB = filepath.Join(tempDir, "b.db")
+
+	if err := InitLedgerDB(pathA, migrations.FS); err != nil {
+		t.Fatalf("init a: %v", err)
+	}
+	if err := InitLedgerDB(pathB, migrations.FS); err != nil {
+		t.Fatalf("init b: %v", err)
+	}
+
+	reg, err := ledger.Load(tempDir)
+	if err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+	// ledger.Load auto-seeds a "default" entry; drop it so the test starts
+	// with exactly "a" and "b".
+	delete(reg.Ledgers, "default")
+	reg.ActiveLedger = ""
+	if err := reg.Add("a", pathA); err != nil {
+		t.Fatalf("add a: %v", err)
+	}
+	if err := reg.Add("b", pathB); err != nil {
+		t.Fatalf("add b: %v", err)
+	}
+	if err := reg.Switch("a"); err != nil {
+		t.Fatalf("switch a: %v", err)
+	}
+
+	cfg := config.NewDefault()
+	cfg.Database.Path = pathA
+	cfg.ActiveLedger = "a"
+
+	st, err := store.NewStore(pathA, migrations.FS)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	return &App{
+		Registry:   reg,
+		store:      st,
+		migrations: migrations.FS,
+		cfg:        cfg,
+	}, tempDir, pathA, pathB
+}
+
+func TestSwitchLedger_SwapsStoreAndUpdatesConfig(t *testing.T) {
+	a, _, _, pathB := newTestApp(t)
+
+	if err := a.SwitchLedger("b"); err != nil {
+		t.Fatalf("SwitchLedger: %v", err)
+	}
+
+	if a.cfg.ActiveLedger != "b" {
+		t.Errorf("cfg.ActiveLedger: got %q, want %q", a.cfg.ActiveLedger, "b")
+	}
+	if a.cfg.Database.Path != pathB {
+		t.Errorf("cfg.Database.Path: got %q, want %q", a.cfg.Database.Path, pathB)
+	}
+	if a.Registry.ActiveLedger != "b" {
+		t.Errorf("registry.ActiveLedger: got %q, want %q", a.Registry.ActiveLedger, "b")
+	}
+
+	// Verify the store now talks to pathB by writing through the swapped
+	// connection.
+	_, err := a.store.DB().ExecContext(t.Context(),
+		"INSERT INTO accounts (name, type, currency) VALUES (?, ?, ?)",
+		"Assets:Probe", "A", "USD",
+	)
+	if err != nil {
+		t.Fatalf("insert into swapped store: %v", err)
+	}
+}
+
+func TestSwitchLedger_UnknownNameReturnsErrLedgerNotFound(t *testing.T) {
+	a, _, pathA, _ := newTestApp(t)
+
+	err := a.SwitchLedger("nope")
+	if !errors.Is(err, ledger.ErrLedgerNotFound) {
+		t.Fatalf("err: got %v, want ErrLedgerNotFound", err)
+	}
+	if a.cfg.ActiveLedger != "a" {
+		t.Errorf("cfg.ActiveLedger leaked: got %q, want %q", a.cfg.ActiveLedger, "a")
+	}
+	if a.cfg.Database.Path != pathA {
+		t.Errorf("cfg.Database.Path leaked: got %q, want %q", a.cfg.Database.Path, pathA)
+	}
+	if a.Registry.ActiveLedger != "a" {
+		t.Errorf("registry.ActiveLedger leaked: got %q, want %q", a.Registry.ActiveLedger, "a")
+	}
+}
+
+func TestSwitchLedger_FailedSwapLeavesStateUnchanged(t *testing.T) {
+	a, tempDir, pathA, _ := newTestApp(t)
+
+	// Register a ledger whose path points at a file used as the parent
+	// directory; os.MkdirAll will fail, so NewStore returns an error and Swap
+	// never mutates state. The corresponding store-layer behavior is pinned by
+	// store.TestSwap_FailedSwapKeepsOldConnection.
+	blockingFile := filepath.Join(tempDir, "not-a-dir")
+	if f, err := os.Create(blockingFile); err != nil {
+		t.Fatalf("create blocking file: %v", err)
+	} else {
+		_ = f.Close()
+	}
+	badPath := filepath.Join(blockingFile, "bad.db")
+	if err := a.Registry.Add("bad", badPath); err != nil {
+		t.Fatalf("add bad: %v", err)
+	}
+
+	err := a.SwitchLedger("bad")
+	if err == nil {
+		t.Fatal("expected error from SwitchLedger to nonexistent path")
+	}
+	if a.cfg.ActiveLedger != "a" {
+		t.Errorf("cfg.ActiveLedger leaked: got %q, want %q", a.cfg.ActiveLedger, "a")
+	}
+	if a.cfg.Database.Path != pathA {
+		t.Errorf("cfg.Database.Path leaked: got %q, want %q", a.cfg.Database.Path, pathA)
+	}
+	if a.Registry.ActiveLedger != "a" {
+		t.Errorf("registry.ActiveLedger leaked: got %q, want %q", a.Registry.ActiveLedger, "a")
+	}
+}


### PR DESCRIPTION
## Summary

Adds the ledger management surface to the Kea web API. Five endpoints let the SPA list, inspect, create, switch, and delete ledgers without dropping to the CLI.

| Method | Path | Returns |
|--------|------|---------|
| GET | `/api/ledgers` | `{active, items[]}` sorted by name |
| GET | `/api/ledgers/active` | `LedgerInfo` (404 `no_active_ledger` when none) |
| POST | `/api/ledgers` | `201` `LedgerInfo`; DB created at `<appDir>/ledgers/<name>.db` |
| POST | `/api/ledgers/switch` | `200` `LedgerInfo` (synchronous swap) |
| DELETE | `/api/ledgers/{name}` | `200 {deleted, name}`; DB file stays on disk |

### Approach

- New `App.SwitchLedger(name) error` does the synchronous store swap: resolve entry → `store.Swap` → update cfg → `Registry.Switch`. The fsnotify reload becomes a no-op because `ActiveLedger` already matches by the time it fires.
- `internal/api/Server` gains four fields (`registry`, `migrations`, `appDir`, `switchLedger`); `NewServer` signature extended; `NewServeCmd` now takes `*app.App` so it can reach `Service`, `Registry`, `Config()`, and `SwitchLedger` without an ever-growing arg list.
- `mapError` wires four `ledger.*` sentinels to HTTP status codes: `ErrLedgerNotFound` → 404 `not_found`, `ErrLedgerExists` → 409 `already_exists`, `ErrRemoveActive` → 409 `cannot_remove_active`, `ErrNoActiveLedger` → 404 `no_active_ledger`.
- `validateLedgerName` rejects empty, `/`, `\`, `..`, and ASCII control chars; applied on create, switch, and delete.
- Create always uses the default `<appDir>/ledgers/<name>.db` location — no custom path via HTTP. Delete unregisters only; CLI keeps `--delete-file` for the destructive option.

### Design and plan

- Spec: `docs/superpowers/specs/2026-06-04-web-api-ledgers-design.md`
- Plan: `docs/superpowers/plans/2026-06-04-web-api-ledgers.md`

## Test plan

- [x] `go test ./...` clean
- [x] `go build ./...` clean
- [x] `app.SwitchLedger` exercised end-to-end over a real `store.Store` in `internal/app/app_test.go` (happy path, unknown name, failed swap)
- [x] Each handler covered by table-driven tests over a real on-disk `*ledger.Registry` plus a fake `switchLedger` that records calls
- [x] Every error sentinel (`ErrLedgerNotFound`, `ErrLedgerExists`, `ErrRemoveActive`, `ErrNoActiveLedger`) exercised both directly and through `fmt.Errorf("...: %w", ...)` in `errors_test.go`
- [ ] Manual curl smoke test against `kea serve` (optional; tests cover the full handler stack via httptest)

## Known follow-up

A pre-existing data race in `internal/ledger/registry.go` — `Switch`/`Add`/`EntryFor` mutate `r.ActiveLedger`/`r.Ledgers` without holding `r.mu`, while the fsnotify `reload()` does hold the lock. The CLI never had concurrent callers, so the race was theoretical. The web API now has HTTP handlers calling these methods alongside the watcher goroutine. Flagged for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)