### PR TITLE
feat(api): reconciliation endpoints (list, preview, commit)

### DIFF
--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/hance08/kea/internal/ledger"
@@ -12,9 +13,22 @@ import (
 )
 
 type errorBody struct {
-	Error   string `json:"error"`
-	Message string `json:"message"`
-	Field   string `json:"field,omitempty"`
+	Error      string `json:"error"`
+	Message    string `json:"message"`
+	Field      string `json:"field,omitempty"`
+	Difference *int64 `json:"difference,omitempty"`
+}
+
+// balanceMismatchError is returned by the reconcile commit handler when the
+// caller did not set allow_mismatch=true and the computed diff is non-zero.
+// Mirrors --force semantics from the CLI; lives in the API layer because the
+// service contract always persists regardless of diff.
+type balanceMismatchError struct {
+	Difference int64
+}
+
+func (e *balanceMismatchError) Error() string {
+	return fmt.Sprintf("statement balance off by %d", e.Difference)
 }
 
 func writeError(w http.ResponseWriter, r *http.Request, err error) {
@@ -29,11 +43,21 @@ func writeError(w http.ResponseWriter, r *http.Request, err error) {
 
 func mapError(err error) (int, errorBody) {
 	var verr *service.ValidationError
-	switch {
-	case errors.As(err, &verr):
+	if errors.As(err, &verr) {
 		return http.StatusBadRequest, errorBody{
 			Error: "validation_failed", Message: verr.Message, Field: verr.Field,
 		}
+	}
+	var bme *balanceMismatchError
+	if errors.As(err, &bme) {
+		diff := bme.Difference
+		return http.StatusConflict, errorBody{
+			Error:      "balance_mismatch",
+			Message:    bme.Error(),
+			Difference: &diff,
+		}
+	}
+	switch {
 	case errors.Is(err, service.ErrNotFound):
 		return http.StatusNotFound, errorBody{Error: "not_found", Message: err.Error()}
 	case errors.Is(err, service.ErrAlreadyExists):

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -59,3 +59,33 @@ func TestMapErrorInternalHidesDetail(t *testing.T) {
 		t.Errorf("internal error must not expose detail in body; got %q", body.Message)
 	}
 }
+
+func TestMapError_BalanceMismatch(t *testing.T) {
+	cases := []struct {
+		name           string
+		err            error
+		wantStatus     int
+		wantCode       string
+		wantDifference int64
+	}{
+		{"direct", &balanceMismatchError{Difference: 50450}, 409, "balance_mismatch", 50450},
+		{"wrapped", fmt.Errorf("commit: %w", &balanceMismatchError{Difference: -100}), 409, "balance_mismatch", -100},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, body := mapError(tc.err)
+			if status != tc.wantStatus {
+				t.Errorf("status: got %d, want %d", status, tc.wantStatus)
+			}
+			if body.Error != tc.wantCode {
+				t.Errorf("error code: got %q, want %q", body.Error, tc.wantCode)
+			}
+			if body.Difference == nil {
+				t.Fatalf("Difference: got nil, want pointer to %d", tc.wantDifference)
+			}
+			if *body.Difference != tc.wantDifference {
+				t.Errorf("Difference: got %d, want %d", *body.Difference, tc.wantDifference)
+			}
+		})
+	}
+}

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -49,6 +49,9 @@ func TestMapError(t *testing.T) {
 			if body.Field != tc.wantField {
 				t.Errorf("field: got %q, want %q", body.Field, tc.wantField)
 			}
+			if body.Difference != nil {
+				t.Errorf("Difference: want nil for %q, got %d", tc.name, *body.Difference)
+			}
 		})
 	}
 }
@@ -66,10 +69,11 @@ func TestMapError_BalanceMismatch(t *testing.T) {
 		err            error
 		wantStatus     int
 		wantCode       string
+		wantMessage    string
 		wantDifference int64
 	}{
-		{"direct", &balanceMismatchError{Difference: 50450}, 409, "balance_mismatch", 50450},
-		{"wrapped", fmt.Errorf("commit: %w", &balanceMismatchError{Difference: -100}), 409, "balance_mismatch", -100},
+		{"direct", &balanceMismatchError{Difference: 50450}, 409, "balance_mismatch", "statement balance off by 50450", 50450},
+		{"wrapped", fmt.Errorf("commit: %w", &balanceMismatchError{Difference: -100}), 409, "balance_mismatch", "statement balance off by -100", -100},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -79,6 +83,9 @@ func TestMapError_BalanceMismatch(t *testing.T) {
 			}
 			if body.Error != tc.wantCode {
 				t.Errorf("error code: got %q, want %q", body.Error, tc.wantCode)
+			}
+			if body.Message != tc.wantMessage {
+				t.Errorf("message: got %q, want %q", body.Message, tc.wantMessage)
 			}
 			if body.Difference == nil {
 				t.Fatalf("Difference: got nil, want pointer to %d", tc.wantDifference)

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -84,6 +84,12 @@ func (s *Server) handleReconcileCommit(w http.ResponseWriter, r *http.Request) e
 	}
 	ctx := r.Context()
 
+	// Gate: preview-first when allow_mismatch is off. PreviewReconcile is
+	// read-only; if it returns a non-zero diff we reject without writing.
+	// There is a brief TOCTOU window between preview and commit (unreconciled
+	// set could change between calls), but ReconcileTransactions re-validates
+	// IDs atomically inside ExecTx, so any intervening change surfaces as a
+	// 400 rather than silent data corruption.
 	if !req.AllowMismatch {
 		diff, err := s.svc.Transaction().PreviewReconcile(ctx, id, req.StatementBalance, req.TransactionIDs)
 		if err != nil {
@@ -102,6 +108,6 @@ func (s *Server) handleReconcileCommit(w http.ResponseWriter, r *http.Request) e
 	return writeJSON(w, http.StatusOK, reconcileCommitResponse{
 		ReconciledCount:       len(req.TransactionIDs),
 		Difference:            diff,
-		LastReconciledBalance: req.StatementBalance - diff,
+		LastReconciledBalance: req.StatementBalance - diff, // statement_balance - diff == lastBalance + clearedBalance
 	})
 }

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -60,3 +60,48 @@ func (s *Server) handleReconcilePreview(w http.ResponseWriter, r *http.Request) 
 	}
 	return writeJSON(w, http.StatusOK, reconcilePreviewResponse{Difference: diff})
 }
+
+type reconcileCommitRequest struct {
+	StatementBalance int64   `json:"statement_balance"`
+	TransactionIDs   []int64 `json:"transaction_ids"`
+	AllowMismatch    bool    `json:"allow_mismatch"`
+}
+
+type reconcileCommitResponse struct {
+	ReconciledCount       int   `json:"reconciled_count"`
+	Difference            int64 `json:"difference"`
+	LastReconciledBalance int64 `json:"last_reconciled_balance"`
+}
+
+func (s *Server) handleReconcileCommit(w http.ResponseWriter, r *http.Request) error {
+	id, err := parseInt64Path(r, "id")
+	if err != nil {
+		return err
+	}
+	var req reconcileCommitRequest
+	if err := decodeJSON(r, &req); err != nil {
+		return err
+	}
+	ctx := r.Context()
+
+	if !req.AllowMismatch {
+		diff, err := s.svc.Transaction().PreviewReconcile(ctx, id, req.StatementBalance, req.TransactionIDs)
+		if err != nil {
+			return err
+		}
+		if diff != 0 {
+			return &balanceMismatchError{Difference: diff}
+		}
+	}
+
+	diff, err := s.svc.Transaction().ReconcileTransactions(ctx, id, req.StatementBalance, req.TransactionIDs)
+	if err != nil {
+		return err
+	}
+
+	return writeJSON(w, http.StatusOK, reconcileCommitResponse{
+		ReconciledCount:       len(req.TransactionIDs),
+		Difference:            diff,
+		LastReconciledBalance: req.StatementBalance - diff,
+	})
+}

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -35,3 +35,28 @@ func (s *Server) handleListUnreconciled(w http.ResponseWriter, r *http.Request) 
 		LastReconciledBalance: lastBalance,
 	})
 }
+
+type reconcilePreviewRequest struct {
+	StatementBalance int64   `json:"statement_balance"`
+	TransactionIDs   []int64 `json:"transaction_ids"`
+}
+
+type reconcilePreviewResponse struct {
+	Difference int64 `json:"difference"`
+}
+
+func (s *Server) handleReconcilePreview(w http.ResponseWriter, r *http.Request) error {
+	id, err := parseInt64Path(r, "id")
+	if err != nil {
+		return err
+	}
+	var req reconcilePreviewRequest
+	if err := decodeJSON(r, &req); err != nil {
+		return err
+	}
+	diff, err := s.svc.Transaction().PreviewReconcile(r.Context(), id, req.StatementBalance, req.TransactionIDs)
+	if err != nil {
+		return err
+	}
+	return writeJSON(w, http.StatusOK, reconcilePreviewResponse{Difference: diff})
+}

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/hance08/kea/internal/model"
+)
+
+type unreconciledResponse struct {
+	Entries               []*model.ReconcileEntry `json:"entries"`
+	LastReconciledBalance int64                   `json:"last_reconciled_balance"`
+}
+
+func (s *Server) handleListUnreconciled(w http.ResponseWriter, r *http.Request) error {
+	id, err := parseInt64Path(r, "id")
+	if err != nil {
+		return err
+	}
+	ctx := r.Context()
+	if _, err := s.svc.Account().GetAccountByID(ctx, id); err != nil {
+		return err
+	}
+	entries, lastBalance, err := s.svc.Transaction().GetUnreconciledByAccount(ctx, id)
+	if err != nil {
+		return err
+	}
+	if entries == nil {
+		entries = []*model.ReconcileEntry{}
+	}
+	return writeJSON(w, http.StatusOK, unreconciledResponse{
+		Entries:               entries,
+		LastReconciledBalance: lastBalance,
+	})
+}

--- a/internal/api/reconcile_test.go
+++ b/internal/api/reconcile_test.go
@@ -224,3 +224,194 @@ func TestHandleListUnreconciled_BadPathParam(t *testing.T) {
 		t.Fatalf("status: got %d, want 400; body=%s", status, body)
 	}
 }
+
+func TestHandleReconcilePreview_ZeroDiff(t *testing.T) {
+	ts, svc, _ := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+	seedAccount(t, svc, "Expenses:Coffee", model.AccountTypeExpense, 0)
+	seedAccount(t, svc, "Revenue:Salary", model.AccountTypeRevenue, 0)
+
+	t1 := seedTransaction(t, svc, "Assets:Bank", "Expenses:Coffee", 450, 1735689600, "Coffee", model.TxTypeExpense, model.StatusCleared)
+	t2 := seedTransaction(t, svc, "Revenue:Salary", "Assets:Bank", 500000, 1735776000, "Salary", model.TxTypeIncome, model.StatusCleared)
+
+	// Net for Assets:Bank: -450 + 500000 = 499550. With lastBalance=0, statement 499550 → diff 0.
+	payload := map[string]any{"statement_balance": 499550, "transaction_ids": []int64{t1.ID, t2.ID}}
+	status, body := postJSON(t, fmt.Sprintf("%s/api/accounts/%d/reconcile/preview", ts.URL, src.ID), payload)
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", status, body)
+	}
+	var got struct {
+		Difference int64 `json:"difference"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.Difference != 0 {
+		t.Errorf("difference: got %d, want 0", got.Difference)
+	}
+}
+
+func TestHandleReconcilePreview_UnderShoot(t *testing.T) {
+	ts, svc, _ := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+	seedAccount(t, svc, "Revenue:Salary", model.AccountTypeRevenue, 0)
+	tx := seedTransaction(t, svc, "Revenue:Salary", "Assets:Bank", 100000, 1735776000, "Salary", model.TxTypeIncome, model.StatusCleared)
+
+	payload := map[string]any{"statement_balance": 105000, "transaction_ids": []int64{tx.ID}}
+	status, body := postJSON(t, fmt.Sprintf("%s/api/accounts/%d/reconcile/preview", ts.URL, src.ID), payload)
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", status, body)
+	}
+	var got struct {
+		Difference int64 `json:"difference"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.Difference != 5000 {
+		t.Errorf("difference: got %d, want 5000", got.Difference)
+	}
+}
+
+func TestHandleReconcilePreview_OverShoot(t *testing.T) {
+	ts, svc, _ := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+	seedAccount(t, svc, "Revenue:Salary", model.AccountTypeRevenue, 0)
+	tx := seedTransaction(t, svc, "Revenue:Salary", "Assets:Bank", 100000, 1735776000, "Salary", model.TxTypeIncome, model.StatusCleared)
+
+	payload := map[string]any{"statement_balance": 90000, "transaction_ids": []int64{tx.ID}}
+	status, body := postJSON(t, fmt.Sprintf("%s/api/accounts/%d/reconcile/preview", ts.URL, src.ID), payload)
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", status, body)
+	}
+	var got struct {
+		Difference int64 `json:"difference"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.Difference != -10000 {
+		t.Errorf("difference: got %d, want -10000", got.Difference)
+	}
+}
+
+func TestHandleReconcilePreview_EmptyIDs(t *testing.T) {
+	ts, svc, _ := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+
+	payload := map[string]any{"statement_balance": 0, "transaction_ids": []int64{}}
+	status, body := postJSON(t, fmt.Sprintf("%s/api/accounts/%d/reconcile/preview", ts.URL, src.ID), payload)
+	if status != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body=%s", status, body)
+	}
+	var got errorBody
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.Error != "validation_failed" {
+		t.Errorf("error code: got %q, want validation_failed", got.Error)
+	}
+	if got.Field != "transactions" {
+		t.Errorf("field: got %q, want transactions", got.Field)
+	}
+}
+
+func TestHandleReconcilePreview_DuplicateIDs(t *testing.T) {
+	ts, svc, _ := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+	seedAccount(t, svc, "Expenses:Coffee", model.AccountTypeExpense, 0)
+	tx := seedTransaction(t, svc, "Assets:Bank", "Expenses:Coffee", 450, 1735689600, "Coffee", model.TxTypeExpense, model.StatusCleared)
+
+	payload := map[string]any{"statement_balance": -450, "transaction_ids": []int64{tx.ID, tx.ID}}
+	status, body := postJSON(t, fmt.Sprintf("%s/api/accounts/%d/reconcile/preview", ts.URL, src.ID), payload)
+	if status != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body=%s", status, body)
+	}
+	var got errorBody
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.Field != "transactions" {
+		t.Errorf("field: got %q, want transactions", got.Field)
+	}
+}
+
+func TestHandleReconcilePreview_IDNotInUnreconciledSet(t *testing.T) {
+	ts, svc, st := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+	seedAccount(t, svc, "Expenses:Coffee", model.AccountTypeExpense, 0)
+	tx := seedTransaction(t, svc, "Assets:Bank", "Expenses:Coffee", 450, 1735689600, "Coffee", model.TxTypeExpense, model.StatusCleared)
+	seedReconciledTransaction(t, st, src.ID, tx.ID)
+
+	payload := map[string]any{"statement_balance": -450, "transaction_ids": []int64{tx.ID}}
+	status, body := postJSON(t, fmt.Sprintf("%s/api/accounts/%d/reconcile/preview", ts.URL, src.ID), payload)
+	if status != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body=%s", status, body)
+	}
+	var got errorBody
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.Field != "transactions" {
+		t.Errorf("field: got %q, want transactions", got.Field)
+	}
+}
+
+func TestHandleReconcilePreview_UnknownAccount(t *testing.T) {
+	ts, _, _ := newServerForWrite(t)
+
+	payload := map[string]any{"statement_balance": 0, "transaction_ids": []int64{1}}
+	status, body := postJSON(t, fmt.Sprintf("%s/api/accounts/99999/reconcile/preview", ts.URL), payload)
+	if status != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", status, body)
+	}
+	var got errorBody
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.Error != "not_found" {
+		t.Errorf("error code: got %q, want not_found", got.Error)
+	}
+}
+
+func TestHandleReconcilePreview_UnknownJSONField(t *testing.T) {
+	ts, svc, _ := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+
+	payload := map[string]any{
+		"statement_balance": 0,
+		"transaction_ids":   []int64{1},
+		"extra_field":       "nope",
+	}
+	status, _ := postJSON(t, fmt.Sprintf("%s/api/accounts/%d/reconcile/preview", ts.URL, src.ID), payload)
+	if status != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", status)
+	}
+}
+
+func TestHandleReconcilePreview_DoesNotWrite(t *testing.T) {
+	ts, svc, _ := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+	seedAccount(t, svc, "Expenses:Coffee", model.AccountTypeExpense, 0)
+	tx := seedTransaction(t, svc, "Assets:Bank", "Expenses:Coffee", 450, 1735689600, "Coffee", model.TxTypeExpense, model.StatusCleared)
+
+	payload := map[string]any{"statement_balance": -450, "transaction_ids": []int64{tx.ID}}
+	if status, body := postJSON(t, fmt.Sprintf("%s/api/accounts/%d/reconcile/preview", ts.URL, src.ID), payload); status != http.StatusOK {
+		t.Fatalf("preview: got %d; body=%s", status, body)
+	}
+
+	// Re-fetch unreconciled list — entry must still be present.
+	status, body := getJSON(t, fmt.Sprintf("%s/api/accounts/%d/unreconciled", ts.URL, src.ID))
+	if status != http.StatusOK {
+		t.Fatalf("list: got %d; body=%s", status, body)
+	}
+	var got struct {
+		Entries []model.ReconcileEntry `json:"entries"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if len(got.Entries) != 1 {
+		t.Errorf("entries: got %d, want 1 (preview must not write)", len(got.Entries))
+	}
+}

--- a/internal/api/reconcile_test.go
+++ b/internal/api/reconcile_test.go
@@ -41,8 +41,8 @@ func TestHandleListUnreconciled_WithTransactions(t *testing.T) {
 	seedAccount(t, svc, "Expenses:Coffee", model.AccountTypeExpense, 0)
 	seedAccount(t, svc, "Revenue:Salary", model.AccountTypeRevenue, 0)
 
-	seedTransaction(t, svc, "Assets:Bank", "Expenses:Coffee", 450, 1735689600, "Coffee", model.TxTypeExpense, model.StatusCleared)
-	seedTransaction(t, svc, "Revenue:Salary", "Assets:Bank", 500000, 1735776000, "Salary", model.TxTypeIncome, model.StatusCleared)
+	coffee := seedTransaction(t, svc, "Assets:Bank", "Expenses:Coffee", 450, 1735689600, "Coffee", model.TxTypeExpense, model.StatusCleared)
+	salary := seedTransaction(t, svc, "Revenue:Salary", "Assets:Bank", 500000, 1735776000, "Salary", model.TxTypeIncome, model.StatusCleared)
 
 	status, body := getJSON(t, fmt.Sprintf("%s/api/accounts/%d/unreconciled", ts.URL, src.ID))
 	if status != http.StatusOK {
@@ -60,6 +60,79 @@ func TestHandleListUnreconciled_WithTransactions(t *testing.T) {
 	}
 	if got.LastReconciledBalance != 0 {
 		t.Errorf("last_reconciled_balance: got %d, want 0", got.LastReconciledBalance)
+	}
+
+	byID := make(map[int64]model.ReconcileEntry, len(got.Entries))
+	for _, e := range got.Entries {
+		byID[e.ID] = e
+	}
+
+	coffeeEntry, ok := byID[coffee.ID]
+	if !ok {
+		t.Fatalf("coffee transaction id %d missing from response", coffee.ID)
+	}
+	if coffeeEntry.Amount != -450 {
+		t.Errorf("coffee amount: got %d, want -450", coffeeEntry.Amount)
+	}
+	if coffeeEntry.OffsetAccount != "Expenses:Coffee" {
+		t.Errorf("coffee offset_account: got %q, want %q", coffeeEntry.OffsetAccount, "Expenses:Coffee")
+	}
+
+	salaryEntry, ok := byID[salary.ID]
+	if !ok {
+		t.Fatalf("salary transaction id %d missing from response", salary.ID)
+	}
+	if salaryEntry.Amount != 500000 {
+		t.Errorf("salary amount: got %d, want 500000", salaryEntry.Amount)
+	}
+	if salaryEntry.OffsetAccount != "Revenue:Salary" {
+		t.Errorf("salary offset_account: got %q, want %q", salaryEntry.OffsetAccount, "Revenue:Salary")
+	}
+}
+
+func TestHandleListUnreconciled_AccountIsolation(t *testing.T) {
+	ts, svc, _ := newServerForWrite(t)
+	bank := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+	savings := seedAccount(t, svc, "Assets:Savings", model.AccountTypeAsset, 0)
+	seedAccount(t, svc, "Expenses:Coffee", model.AccountTypeExpense, 0)
+
+	bankTx := seedTransaction(t, svc, "Assets:Bank", "Expenses:Coffee", 100, 1735689600, "Bank coffee", model.TxTypeExpense, model.StatusCleared)
+	savingsTx := seedTransaction(t, svc, "Assets:Savings", "Expenses:Coffee", 200, 1735776000, "Savings coffee", model.TxTypeExpense, model.StatusCleared)
+
+	// Bank account should only see its own transaction.
+	status, body := getJSON(t, fmt.Sprintf("%s/api/accounts/%d/unreconciled", ts.URL, bank.ID))
+	if status != http.StatusOK {
+		t.Fatalf("bank status: got %d, want 200; body=%s", status, body)
+	}
+	var bankResp struct {
+		Entries []model.ReconcileEntry `json:"entries"`
+	}
+	if err := json.Unmarshal(body, &bankResp); err != nil {
+		t.Fatalf("bank unmarshal: %v", err)
+	}
+	if len(bankResp.Entries) != 1 {
+		t.Fatalf("bank entries: got %d, want 1", len(bankResp.Entries))
+	}
+	if bankResp.Entries[0].ID != bankTx.ID {
+		t.Errorf("bank entry id: got %d, want %d", bankResp.Entries[0].ID, bankTx.ID)
+	}
+
+	// Savings account should only see its own transaction.
+	status, body = getJSON(t, fmt.Sprintf("%s/api/accounts/%d/unreconciled", ts.URL, savings.ID))
+	if status != http.StatusOK {
+		t.Fatalf("savings status: got %d, want 200; body=%s", status, body)
+	}
+	var savingsResp struct {
+		Entries []model.ReconcileEntry `json:"entries"`
+	}
+	if err := json.Unmarshal(body, &savingsResp); err != nil {
+		t.Fatalf("savings unmarshal: %v", err)
+	}
+	if len(savingsResp.Entries) != 1 {
+		t.Fatalf("savings entries: got %d, want 1", len(savingsResp.Entries))
+	}
+	if savingsResp.Entries[0].ID != savingsTx.ID {
+		t.Errorf("savings entry id: got %d, want %d", savingsResp.Entries[0].ID, savingsTx.ID)
 	}
 }
 
@@ -110,7 +183,8 @@ func TestHandleListUnreconciled_IncludesPending(t *testing.T) {
 		t.Fatalf("status: got %d, want 200; body=%s", status, body)
 	}
 	var got struct {
-		Entries []model.ReconcileEntry `json:"entries"`
+		Entries               []model.ReconcileEntry `json:"entries"`
+		LastReconciledBalance int64                  `json:"last_reconciled_balance"`
 	}
 	if err := json.Unmarshal(body, &got); err != nil {
 		t.Fatalf("unmarshal: %v; body=%s", err, body)
@@ -120,6 +194,9 @@ func TestHandleListUnreconciled_IncludesPending(t *testing.T) {
 	}
 	if got.Entries[0].Status != model.StatusPending {
 		t.Errorf("entry status: got %v, want Pending", got.Entries[0].Status)
+	}
+	if got.LastReconciledBalance != 0 {
+		t.Errorf("last_reconciled_balance: got %d, want 0", got.LastReconciledBalance)
 	}
 }
 

--- a/internal/api/reconcile_test.go
+++ b/internal/api/reconcile_test.go
@@ -415,3 +415,12 @@ func TestHandleReconcilePreview_DoesNotWrite(t *testing.T) {
 		t.Errorf("entries: got %d, want 1 (preview must not write)", len(got.Entries))
 	}
 }
+
+func TestHandleReconcilePreview_BadPathParam(t *testing.T) {
+	ts, _, _ := newServerForWrite(t)
+	payload := map[string]any{"statement_balance": 0, "transaction_ids": []int64{1}}
+	status, body := postJSON(t, ts.URL+"/api/accounts/not-a-number/reconcile/preview", payload)
+	if status != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body=%s", status, body)
+	}
+}

--- a/internal/api/reconcile_test.go
+++ b/internal/api/reconcile_test.go
@@ -499,6 +499,9 @@ func TestHandleReconcileCommit_AllowMismatchTrue(t *testing.T) {
 	if err := json.Unmarshal(body, &got); err != nil {
 		t.Fatalf("unmarshal: %v; body=%s", err, body)
 	}
+	if got.ReconciledCount != 1 {
+		t.Errorf("reconciled_count: got %d, want 1", got.ReconciledCount)
+	}
 	if got.Difference != 5000 {
 		t.Errorf("difference: got %d, want 5000", got.Difference)
 	}

--- a/internal/api/reconcile_test.go
+++ b/internal/api/reconcile_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hance08/kea/internal/model"
+)
+
+func TestHandleListUnreconciled_Empty(t *testing.T) {
+	ts, svc, _ := newServerForWrite(t)
+	acc := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+
+	status, body := getJSON(t, fmt.Sprintf("%s/api/accounts/%d/unreconciled", ts.URL, acc.ID))
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", status, body)
+	}
+	var got struct {
+		Entries               []model.ReconcileEntry `json:"entries"`
+		LastReconciledBalance int64                  `json:"last_reconciled_balance"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if len(got.Entries) != 0 {
+		t.Errorf("entries: got %v, want []", got.Entries)
+	}
+	if got.LastReconciledBalance != 0 {
+		t.Errorf("last_reconciled_balance: got %d, want 0", got.LastReconciledBalance)
+	}
+}
+
+func TestHandleListUnreconciled_WithTransactions(t *testing.T) {
+	ts, svc, _ := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+	seedAccount(t, svc, "Expenses:Coffee", model.AccountTypeExpense, 0)
+	seedAccount(t, svc, "Revenue:Salary", model.AccountTypeRevenue, 0)
+
+	seedTransaction(t, svc, "Assets:Bank", "Expenses:Coffee", 450, 1735689600, "Coffee", model.TxTypeExpense, model.StatusCleared)
+	seedTransaction(t, svc, "Revenue:Salary", "Assets:Bank", 500000, 1735776000, "Salary", model.TxTypeIncome, model.StatusCleared)
+
+	status, body := getJSON(t, fmt.Sprintf("%s/api/accounts/%d/unreconciled", ts.URL, src.ID))
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", status, body)
+	}
+	var got struct {
+		Entries               []model.ReconcileEntry `json:"entries"`
+		LastReconciledBalance int64                  `json:"last_reconciled_balance"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if len(got.Entries) != 2 {
+		t.Fatalf("entries length: got %d, want 2", len(got.Entries))
+	}
+	if got.LastReconciledBalance != 0 {
+		t.Errorf("last_reconciled_balance: got %d, want 0", got.LastReconciledBalance)
+	}
+}
+
+func TestHandleListUnreconciled_ExcludesReconciled(t *testing.T) {
+	ts, svc, st := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+	seedAccount(t, svc, "Expenses:Coffee", model.AccountTypeExpense, 0)
+
+	pinned := seedTransaction(t, svc, "Assets:Bank", "Expenses:Coffee", 450, 1735689600, "Pinned", model.TxTypeExpense, model.StatusCleared)
+	open := seedTransaction(t, svc, "Assets:Bank", "Expenses:Coffee", 200, 1735776000, "Open", model.TxTypeExpense, model.StatusCleared)
+
+	seedReconciledTransaction(t, st, src.ID, pinned.ID)
+	if err := st.SetLastReconciledBalance(t.Context(), src.ID, 250000); err != nil {
+		t.Fatalf("SetLastReconciledBalance: %v", err)
+	}
+
+	status, body := getJSON(t, fmt.Sprintf("%s/api/accounts/%d/unreconciled", ts.URL, src.ID))
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", status, body)
+	}
+	var got struct {
+		Entries               []model.ReconcileEntry `json:"entries"`
+		LastReconciledBalance int64                  `json:"last_reconciled_balance"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if len(got.Entries) != 1 {
+		t.Fatalf("entries length: got %d, want 1 (pinned excluded)", len(got.Entries))
+	}
+	if got.Entries[0].ID != open.ID {
+		t.Errorf("entry id: got %d, want %d (open)", got.Entries[0].ID, open.ID)
+	}
+	if got.LastReconciledBalance != 250000 {
+		t.Errorf("last_reconciled_balance: got %d, want 250000", got.LastReconciledBalance)
+	}
+}
+
+func TestHandleListUnreconciled_IncludesPending(t *testing.T) {
+	ts, svc, _ := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+	seedAccount(t, svc, "Expenses:Coffee", model.AccountTypeExpense, 0)
+
+	seedTransaction(t, svc, "Assets:Bank", "Expenses:Coffee", 450, 1735689600, "Pending", model.TxTypeExpense, model.StatusPending)
+
+	status, body := getJSON(t, fmt.Sprintf("%s/api/accounts/%d/unreconciled", ts.URL, src.ID))
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", status, body)
+	}
+	var got struct {
+		Entries []model.ReconcileEntry `json:"entries"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if len(got.Entries) != 1 {
+		t.Fatalf("entries length: got %d, want 1", len(got.Entries))
+	}
+	if got.Entries[0].Status != model.StatusPending {
+		t.Errorf("entry status: got %v, want Pending", got.Entries[0].Status)
+	}
+}
+
+func TestHandleListUnreconciled_UnknownAccount(t *testing.T) {
+	ts, _, _ := newServerForWrite(t)
+
+	status, body := getJSON(t, fmt.Sprintf("%s/api/accounts/99999/unreconciled", ts.URL))
+	if status != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", status, body)
+	}
+	var got errorBody
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.Error != "not_found" {
+		t.Errorf("error code: got %q, want %q", got.Error, "not_found")
+	}
+}
+
+func TestHandleListUnreconciled_BadPathParam(t *testing.T) {
+	ts, _, _ := newServerForWrite(t)
+
+	status, body := getJSON(t, ts.URL+"/api/accounts/not-a-number/unreconciled")
+	if status != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body=%s", status, body)
+	}
+}

--- a/internal/api/reconcile_test.go
+++ b/internal/api/reconcile_test.go
@@ -424,3 +424,300 @@ func TestHandleReconcilePreview_BadPathParam(t *testing.T) {
 		t.Fatalf("status: got %d, want 400; body=%s", status, body)
 	}
 }
+
+func TestHandleReconcileCommit_Clean(t *testing.T) {
+	ts, svc, st := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+	seedAccount(t, svc, "Revenue:Salary", model.AccountTypeRevenue, 0)
+	tx := seedTransaction(t, svc, "Revenue:Salary", "Assets:Bank", 100000, 1735776000, "Salary", model.TxTypeIncome, model.StatusCleared)
+
+	payload := map[string]any{"statement_balance": 100000, "transaction_ids": []int64{tx.ID}}
+	status, body := postJSON(t, fmt.Sprintf("%s/api/accounts/%d/reconcile", ts.URL, src.ID), payload)
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", status, body)
+	}
+	var got struct {
+		ReconciledCount       int   `json:"reconciled_count"`
+		Difference            int64 `json:"difference"`
+		LastReconciledBalance int64 `json:"last_reconciled_balance"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.ReconciledCount != 1 {
+		t.Errorf("reconciled_count: got %d, want 1", got.ReconciledCount)
+	}
+	if got.Difference != 0 {
+		t.Errorf("difference: got %d, want 0", got.Difference)
+	}
+	if got.LastReconciledBalance != 100000 {
+		t.Errorf("last_reconciled_balance: got %d, want 100000", got.LastReconciledBalance)
+	}
+
+	// Persistence: unreconciled list must exclude the committed ID.
+	_, listBody := getJSON(t, fmt.Sprintf("%s/api/accounts/%d/unreconciled", ts.URL, src.ID))
+	var list struct {
+		Entries []model.ReconcileEntry `json:"entries"`
+	}
+	if err := json.Unmarshal(listBody, &list); err != nil {
+		t.Fatalf("unmarshal list: %v", err)
+	}
+	if len(list.Entries) != 0 {
+		t.Errorf("entries: got %d, want 0 after commit", len(list.Entries))
+	}
+
+	persisted, err := st.GetLastReconciledBalance(t.Context(), src.ID)
+	if err != nil {
+		t.Fatalf("GetLastReconciledBalance: %v", err)
+	}
+	if persisted != 100000 {
+		t.Errorf("persisted balance: got %d, want 100000", persisted)
+	}
+}
+
+func TestHandleReconcileCommit_AllowMismatchTrue(t *testing.T) {
+	ts, svc, st := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+	seedAccount(t, svc, "Revenue:Salary", model.AccountTypeRevenue, 0)
+	tx := seedTransaction(t, svc, "Revenue:Salary", "Assets:Bank", 100000, 1735776000, "Salary", model.TxTypeIncome, model.StatusCleared)
+
+	// statement 105000, cleared 100000 → diff 5000.
+	payload := map[string]any{
+		"statement_balance": 105000,
+		"transaction_ids":   []int64{tx.ID},
+		"allow_mismatch":    true,
+	}
+	status, body := postJSON(t, fmt.Sprintf("%s/api/accounts/%d/reconcile", ts.URL, src.ID), payload)
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", status, body)
+	}
+	var got struct {
+		ReconciledCount       int   `json:"reconciled_count"`
+		Difference            int64 `json:"difference"`
+		LastReconciledBalance int64 `json:"last_reconciled_balance"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.Difference != 5000 {
+		t.Errorf("difference: got %d, want 5000", got.Difference)
+	}
+	// Re-derivation: last_reconciled_balance == statement_balance - diff == 105000 - 5000 == 100000.
+	if got.LastReconciledBalance != 100000 {
+		t.Errorf("last_reconciled_balance: got %d, want 100000", got.LastReconciledBalance)
+	}
+
+	persisted, err := st.GetLastReconciledBalance(t.Context(), src.ID)
+	if err != nil {
+		t.Fatalf("GetLastReconciledBalance: %v", err)
+	}
+	if persisted != 100000 {
+		t.Errorf("persisted balance: got %d, want 100000", persisted)
+	}
+}
+
+func TestHandleReconcileCommit_GateRejectsMismatch(t *testing.T) {
+	ts, svc, st := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+	seedAccount(t, svc, "Revenue:Salary", model.AccountTypeRevenue, 0)
+	tx := seedTransaction(t, svc, "Revenue:Salary", "Assets:Bank", 100000, 1735776000, "Salary", model.TxTypeIncome, model.StatusCleared)
+
+	cases := []struct {
+		name    string
+		payload map[string]any
+	}{
+		{"absent_flag", map[string]any{
+			"statement_balance": 105000,
+			"transaction_ids":   []int64{tx.ID},
+		}},
+		{"explicit_false", map[string]any{
+			"statement_balance": 105000,
+			"transaction_ids":   []int64{tx.ID},
+			"allow_mismatch":    false,
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, body := postJSON(t, fmt.Sprintf("%s/api/accounts/%d/reconcile", ts.URL, src.ID), tc.payload)
+			if status != http.StatusConflict {
+				t.Fatalf("status: got %d, want 409; body=%s", status, body)
+			}
+			var got errorBody
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Fatalf("unmarshal: %v; body=%s", err, body)
+			}
+			if got.Error != "balance_mismatch" {
+				t.Errorf("error code: got %q, want balance_mismatch", got.Error)
+			}
+			if got.Difference == nil {
+				t.Fatalf("difference: got nil, want pointer to 5000")
+			}
+			if *got.Difference != 5000 {
+				t.Errorf("difference: got %d, want 5000", *got.Difference)
+			}
+
+			// Critical: no write happened.
+			persisted, err := st.GetLastReconciledBalance(t.Context(), src.ID)
+			if err != nil {
+				t.Fatalf("GetLastReconciledBalance: %v", err)
+			}
+			if persisted != 0 {
+				t.Errorf("persisted balance after rejected gate: got %d, want 0", persisted)
+			}
+			_, listBody := getJSON(t, fmt.Sprintf("%s/api/accounts/%d/unreconciled", ts.URL, src.ID))
+			var list struct {
+				Entries []model.ReconcileEntry `json:"entries"`
+			}
+			if err := json.Unmarshal(listBody, &list); err != nil {
+				t.Fatalf("unmarshal list: %v", err)
+			}
+			if len(list.Entries) != 1 {
+				t.Errorf("entries: got %d, want 1 (no write expected)", len(list.Entries))
+			}
+		})
+	}
+}
+
+func TestHandleReconcileCommit_ValidationPassthrough(t *testing.T) {
+	ts, svc, st := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+	seedAccount(t, svc, "Expenses:Coffee", model.AccountTypeExpense, 0)
+	tx := seedTransaction(t, svc, "Assets:Bank", "Expenses:Coffee", 450, 1735689600, "Coffee", model.TxTypeExpense, model.StatusCleared)
+	reconciledTx := seedTransaction(t, svc, "Assets:Bank", "Expenses:Coffee", 200, 1735776000, "Pinned", model.TxTypeExpense, model.StatusCleared)
+	seedReconciledTransaction(t, st, src.ID, reconciledTx.ID)
+
+	cases := []struct {
+		name       string
+		payload    map[string]any
+		wantStatus int
+		wantField  string
+	}{
+		{"empty_ids_gate_on", map[string]any{
+			"statement_balance": -450,
+			"transaction_ids":   []int64{},
+		}, 400, "transactions"},
+		{"empty_ids_gate_off", map[string]any{
+			"statement_balance": -450,
+			"transaction_ids":   []int64{},
+			"allow_mismatch":    true,
+		}, 400, "transactions"},
+		{"duplicate_gate_on", map[string]any{
+			"statement_balance": -450,
+			"transaction_ids":   []int64{tx.ID, tx.ID},
+		}, 400, "transactions"},
+		{"duplicate_gate_off", map[string]any{
+			"statement_balance": -450,
+			"transaction_ids":   []int64{tx.ID, tx.ID},
+			"allow_mismatch":    true,
+		}, 400, "transactions"},
+		{"already_reconciled_id_gate_on", map[string]any{
+			"statement_balance": -200,
+			"transaction_ids":   []int64{reconciledTx.ID},
+		}, 400, "transactions"},
+		{"already_reconciled_id_gate_off", map[string]any{
+			"statement_balance": -200,
+			"transaction_ids":   []int64{reconciledTx.ID},
+			"allow_mismatch":    true,
+		}, 400, "transactions"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, body := postJSON(t, fmt.Sprintf("%s/api/accounts/%d/reconcile", ts.URL, src.ID), tc.payload)
+			if status != tc.wantStatus {
+				t.Fatalf("status: got %d, want %d; body=%s", status, tc.wantStatus, body)
+			}
+			var got errorBody
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Fatalf("unmarshal: %v; body=%s", err, body)
+			}
+			if got.Field != tc.wantField {
+				t.Errorf("field: got %q, want %q", got.Field, tc.wantField)
+			}
+		})
+	}
+}
+
+func TestHandleReconcileCommit_UnknownAccount(t *testing.T) {
+	ts, _, _ := newServerForWrite(t)
+
+	cases := []struct {
+		name    string
+		payload map[string]any
+	}{
+		{"gate_on", map[string]any{"statement_balance": 0, "transaction_ids": []int64{1}}},
+		{"gate_off", map[string]any{"statement_balance": 0, "transaction_ids": []int64{1}, "allow_mismatch": true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, body := postJSON(t, fmt.Sprintf("%s/api/accounts/99999/reconcile", ts.URL), tc.payload)
+			if status != http.StatusNotFound {
+				t.Fatalf("status: got %d, want 404; body=%s", status, body)
+			}
+			var got errorBody
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Fatalf("unmarshal: %v; body=%s", err, body)
+			}
+			if got.Error != "not_found" {
+				t.Errorf("error code: got %q, want not_found", got.Error)
+			}
+		})
+	}
+}
+
+func TestHandleReconcileCommit_UnknownJSONField(t *testing.T) {
+	ts, svc, _ := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+
+	payload := map[string]any{
+		"statement_balance": 0,
+		"transaction_ids":   []int64{1},
+		"extra_field":       "nope",
+	}
+	status, body := postJSON(t, fmt.Sprintf("%s/api/accounts/%d/reconcile", ts.URL, src.ID), payload)
+	if status != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body=%s", status, body)
+	}
+	var got errorBody
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.Error != "validation_failed" {
+		t.Errorf("error code: got %q, want validation_failed", got.Error)
+	}
+}
+
+func TestHandleReconcileCommit_BadPathParam(t *testing.T) {
+	ts, _, _ := newServerForWrite(t)
+	payload := map[string]any{"statement_balance": 0, "transaction_ids": []int64{1}}
+	status, body := postJSON(t, ts.URL+"/api/accounts/not-a-number/reconcile", payload)
+	if status != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400; body=%s", status, body)
+	}
+}
+
+func TestHandleReconcileCommit_Replay(t *testing.T) {
+	ts, svc, _ := newServerForWrite(t)
+	src := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+	seedAccount(t, svc, "Revenue:Salary", model.AccountTypeRevenue, 0)
+	tx := seedTransaction(t, svc, "Revenue:Salary", "Assets:Bank", 100000, 1735776000, "Salary", model.TxTypeIncome, model.StatusCleared)
+
+	payload := map[string]any{"statement_balance": 100000, "transaction_ids": []int64{tx.ID}}
+
+	// First commit succeeds.
+	if status, body := postJSON(t, fmt.Sprintf("%s/api/accounts/%d/reconcile", ts.URL, src.ID), payload); status != http.StatusOK {
+		t.Fatalf("first commit: got %d; body=%s", status, body)
+	}
+
+	// Replay returns 400 — the ID is no longer in the unreconciled set.
+	status, body := postJSON(t, fmt.Sprintf("%s/api/accounts/%d/reconcile", ts.URL, src.ID), payload)
+	if status != http.StatusBadRequest {
+		t.Fatalf("replay: got %d, want 400; body=%s", status, body)
+	}
+	var got errorBody
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if got.Field != "transactions" {
+		t.Errorf("field: got %q, want transactions", got.Field)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -32,6 +32,7 @@ func (s *Server) routes() http.Handler {
 		r.Method(http.MethodGet, "/accounts/{id}/balance", apiHandler(s.handleAccountBalance))
 		r.Method(http.MethodGet, "/accounts/{id}/unreconciled", apiHandler(s.handleListUnreconciled))
 		r.Method(http.MethodPost, "/accounts/{id}/reconcile/preview", apiHandler(s.handleReconcilePreview))
+		r.Method(http.MethodPost, "/accounts/{id}/reconcile", apiHandler(s.handleReconcileCommit))
 		r.Method(http.MethodGet, "/transactions", apiHandler(s.handleListTransactions))
 		r.Method(http.MethodPost, "/transactions", apiHandler(s.handleCreateTransaction))
 		r.Method(http.MethodGet, "/transactions/{id}", apiHandler(s.handleTransactionByID))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -30,6 +30,7 @@ func (s *Server) routes() http.Handler {
 		r.Method(http.MethodPatch, "/accounts/{id}", apiHandler(s.handleUpdateAccount))
 		r.Method(http.MethodDelete, "/accounts/{id}", apiHandler(s.handleDeleteAccount))
 		r.Method(http.MethodGet, "/accounts/{id}/balance", apiHandler(s.handleAccountBalance))
+		r.Method(http.MethodGet, "/accounts/{id}/unreconciled", apiHandler(s.handleListUnreconciled))
 		r.Method(http.MethodGet, "/transactions", apiHandler(s.handleListTransactions))
 		r.Method(http.MethodPost, "/transactions", apiHandler(s.handleCreateTransaction))
 		r.Method(http.MethodGet, "/transactions/{id}", apiHandler(s.handleTransactionByID))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -31,6 +31,7 @@ func (s *Server) routes() http.Handler {
 		r.Method(http.MethodDelete, "/accounts/{id}", apiHandler(s.handleDeleteAccount))
 		r.Method(http.MethodGet, "/accounts/{id}/balance", apiHandler(s.handleAccountBalance))
 		r.Method(http.MethodGet, "/accounts/{id}/unreconciled", apiHandler(s.handleListUnreconciled))
+		r.Method(http.MethodPost, "/accounts/{id}/reconcile/preview", apiHandler(s.handleReconcilePreview))
 		r.Method(http.MethodGet, "/transactions", apiHandler(s.handleListTransactions))
 		r.Method(http.MethodPost, "/transactions", apiHandler(s.handleCreateTransaction))
 		r.Method(http.MethodGet, "/transactions/{id}", apiHandler(s.handleTransactionByID))

--- a/internal/service/reconcile_ops.go
+++ b/internal/service/reconcile_ops.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hance08/kea/internal/model"
@@ -42,7 +43,10 @@ func (ts *TransactionService) PreviewReconcile(ctx context.Context, accountID in
 	}
 
 	if _, err := ts.accRepo.GetAccountByID(ctx, accountID); err != nil {
-		return 0, fmt.Errorf("account not found: %w", err)
+		if errors.Is(err, repository.ErrNotFound) {
+			return 0, fmt.Errorf("account #%d: %w", accountID, ErrNotFound)
+		}
+		return 0, fmt.Errorf("account lookup: %w", err)
 	}
 
 	lastBalance, err := ts.txRepo.GetLastReconciledBalance(ctx, accountID)
@@ -99,7 +103,10 @@ func (ts *TransactionService) ReconcileTransactions(ctx context.Context, account
 
 	// Fast-fail: verify account exists before opening a transaction.
 	if _, err := ts.accRepo.GetAccountByID(ctx, accountID); err != nil {
-		return 0, fmt.Errorf("account not found: %w", err)
+		if errors.Is(err, repository.ErrNotFound) {
+			return 0, fmt.Errorf("account #%d: %w", accountID, ErrNotFound)
+		}
+		return 0, fmt.Errorf("account lookup: %w", err)
 	}
 
 	// Duplicate-ID check is pure input validation — no DB needed.

--- a/internal/service/reconcile_ops_test.go
+++ b/internal/service/reconcile_ops_test.go
@@ -238,6 +238,9 @@ func TestReconcileTransactions_AccountNotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unknown account, got nil")
 	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected service.ErrNotFound, got %T: %v", err, err)
+	}
 	if len(txRepo.setLastReconciledBalCalls) != 0 {
 		t.Error("SetLastReconciledBalance must not be called when account lookup fails")
 	}
@@ -429,6 +432,9 @@ func TestPreviewReconcile_AccountNotFound(t *testing.T) {
 
 	if err == nil {
 		t.Fatal("expected error for missing account, got nil")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected service.ErrNotFound, got %T: %v", err, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds three HTTP endpoints on top of the existing `*TransactionService` reconciliation methods, completing step 6 of the [pre-development review](docs/web-layer/2026-06-02-pre-development-review.md):

- `GET /api/accounts/{id}/unreconciled` — list unreconciled entries + last reconciled balance
- `POST /api/accounts/{id}/reconcile/preview` — read-only diff calculation
- `POST /api/accounts/{id}/reconcile` — atomic commit with server-side `allow_mismatch` gate (mirrors CLI `--force`)

Mismatch policy is API-layer-only via a new `*balanceMismatchError` type and an optional `errorBody.Difference *int64` field. When `allow_mismatch` is false/absent and the computed diff is non-zero, the commit endpoint returns 409 `balance_mismatch` with the diff in the response body — no write happens. When `allow_mismatch: true`, the gate is skipped (service still validates IDs atomically inside `ExecTx`).

Also fixes a real cross-cutting bug: `PreviewReconcile` and `ReconcileTransactions` in `internal/service/reconcile_ops.go` were leaking `repository.ErrNotFound` to API callers; the API's `mapError` checks `service.ErrNotFound`, so unknown account IDs returned 500 instead of 404. The fix translates the repo sentinel at the service boundary, mirroring the pattern in `account_service.go`.

Spec: [docs/superpowers/specs/2026-06-04-web-api-reconcile-design.md](docs/superpowers/specs/2026-06-04-web-api-reconcile-design.md)

## Test plan

- [x] `go test ./...` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] 25 new API integration tests (real in-memory SQLite, not mocks):
  - `TestHandleListUnreconciled_*` — 7 cases incl. multi-account isolation
  - `TestHandleReconcilePreview_*` — 10 cases incl. no-write verification
  - `TestHandleReconcileCommit_*` — 8 functions / 15 cases incl. gate rejection, replay safety, no-write verification, re-derivation pinning
- [x] 2 strengthened service-layer tests pinning the new `ErrNotFound` translation
- [x] Route ordering verified: `/reconcile/preview` registered before `/reconcile`