### PR TITLE
fix(api): CreateTransaction split-account ErrNotFound returns 400 instead of 500

### DIFF
--- a/internal/api/transactions_write_test.go
+++ b/internal/api/transactions_write_test.go
@@ -204,11 +204,7 @@ func TestHandleCreateTransaction_HiddenAccount(t *testing.T) {
 	}
 }
 
-// A split referencing a nonexistent account currently returns 500 because
-// CreateTransaction surfaces repository.ErrNotFound (not service.ErrNotFound),
-// and mapError only matches the service-level sentinel. The spec records this
-// as a known rough edge to be fixed outside this plan.
-func TestHandleCreateTransaction_NonexistentAccount_Currently500(t *testing.T) {
+func TestHandleCreateTransaction_NonexistentAccount(t *testing.T) {
 	ts, svc := newServerWithStore(t)
 	seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 100000)
 
@@ -221,8 +217,25 @@ func TestHandleCreateTransaction_NonexistentAccount_Currently500(t *testing.T) {
 	}`
 	resp := postJSONStr(t, ts.URL+"/api/transactions", body)
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusInternalServerError {
-		t.Errorf("status: got %d, want 500 (known rough edge — fix is out of scope)", resp.StatusCode)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", resp.StatusCode)
+	}
+	var got struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+		Field   string `json:"field"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Error != "validation_failed" {
+		t.Errorf("error code: got %q, want %q", got.Error, "validation_failed")
+	}
+	if got.Field != "splits" {
+		t.Errorf("field: got %q, want %q", got.Field, "splits")
+	}
+	if !strings.Contains(got.Message, "Expenses:DoesNotExist") {
+		t.Errorf("message should mention the unknown account; got %q", got.Message)
 	}
 }
 

--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -61,6 +61,10 @@ func (ts *TransactionService) CreateTransaction(ctx context.Context, input model
 		// Step 1: Validate account existence and retrieve account details.
 		account, err := ts.accRepo.GetAccountByName(ctx, splitInput.AccountName)
 		if err != nil {
+			if errors.Is(err, repository.ErrNotFound) {
+				return 0, validationErrorf("splits",
+					"split #%d: account %q not found", i+1, splitInput.AccountName)
+			}
 			return 0, fmt.Errorf("split #%d: %w", i+1, err)
 		}
 

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -344,6 +344,36 @@ func TestCreateTransaction(t *testing.T) {
 	})
 }
 
+// TestCreateTransaction_UnknownSplitAccount_ReturnsValidationError pins the
+// service contract: when a request references a nonexistent split account
+// name, CreateTransaction must return a *ValidationError tagged with the
+// "splits" field, not a wrapped repository.ErrNotFound. The latter would
+// fall through mapError to HTTP 500; the former maps to 400.
+func TestCreateTransaction_UnknownSplitAccount_ReturnsValidationError(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	setupStandardAccounts(accRepo)
+	svc := newTestTransactionService(accRepo, newMockTransactionRepo())
+
+	input := model.TransactionDetail{
+		Type:        model.TxTypeExpense,
+		Description: "lunch",
+		Status:      model.StatusCleared,
+		Timestamp:   1700000000,
+		Splits: []model.SplitDetail{
+			{AccountName: "Assets:Bank", Amount: -500},
+			{AccountName: "Expenses:DoesNotExist", Amount: 500},
+		},
+	}
+
+	_, err := svc.CreateTransaction(context.Background(), input)
+	require.Error(t, err)
+
+	var ve *ValidationError
+	require.True(t, errors.As(err, &ve), "expected *ValidationError, got %T: %v", err, err)
+	assert.Equal(t, "splits", ve.Field)
+	assert.Contains(t, ve.Message, "Expenses:DoesNotExist")
+}
+
 // ──────────────────────────────────────────────
 // CreateSimpleTransaction
 // ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `CreateTransaction` now translates `repository.ErrNotFound` from the per-split `GetAccountByName` lookup into a service-layer `validationErrorf("splits", "split #%d: account %q not found", ...)`. The API consequently returns **400 with `error="validation_failed"` and `field="splits"`** instead of the previous 500.
- Mirrors `UpdateTransaction`'s existing pattern at `internal/service/transaction_ops.go:350` — Create and Update now agree on the same logical error.
- Spec/plan (gitignored, local): `docs/superpowers/specs/2026-06-05-fix-create-transaction-split-account-errnotfound-design.md`, `docs/superpowers/plans/2026-06-05-fix-create-transaction-split-account-errnotfound.md`.

## Test plan

- [x] `go test ./...` — all packages pass.
- [x] `go build ./...` — clean.
- [x] New service-layer test `TestCreateTransaction_UnknownSplitAccount_ReturnsValidationError` pins the contract (`*ValidationError`, `Field == "splits"`, message contains the unknown name). Verified failing before the fix, passing after.
- [x] Existing API test renamed `TestHandleCreateTransaction_NonexistentAccount_Currently500` → `TestHandleCreateTransaction_NonexistentAccount`; stale "Known rough edge" comment dropped; assertions updated to 400 / `validation_failed` / `field="splits"` / message-contains.
- [ ] Manual smoke (optional): `kea serve`, `curl -X POST /api/transactions -d '{...splits referencing a missing account...}'` → 400 with field tag.

## Follow-up

`CreateSimpleTransaction`'s type-inference branch (`internal/service/transaction_ops.go` lines ~172/176) has the same `repository.ErrNotFound` leak pattern. The web API never reaches it (it requires `Type` to be set), but the CLI's `add` path does. Tracked as a separate task.