### PR TITLE
feat(api): GET /api/balances for bulk account-balance snapshots

### DIFF
--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/service"
@@ -69,6 +70,31 @@ func (s *Server) handleAccountBalance(w http.ResponseWriter, r *http.Request) er
 		AccountID: id,
 		Amount:    amount,
 		Currency:  acc.Currency,
+	})
+}
+
+func (s *Server) handleListBalances(w http.ResponseWriter, r *http.Request) error {
+	asOfPtr, err := parseInt64Query(r, "as_of")
+	if err != nil {
+		return err
+	}
+	asOf := time.Now().Unix()
+	if asOfPtr != nil {
+		asOf = *asOfPtr
+	}
+	includeHidden, err := parseBoolQuery(r, "include_hidden")
+	if err != nil {
+		return err
+	}
+	rows, err := s.svc.Account().GetAccountBalancesBulk(r.Context(), asOf, includeHidden)
+	if err != nil {
+		return err
+	}
+	return writeJSON(w, http.StatusOK, &model.ListResult[model.AccountBalance]{
+		Items:      rows,
+		TotalCount: len(rows),
+		Limit:      0,
+		Offset:     0,
 	})
 }
 

--- a/internal/api/accounts_test.go
+++ b/internal/api/accounts_test.go
@@ -316,8 +316,10 @@ func TestHandleListAccounts_InvalidType(t *testing.T) {
 
 func TestHandleListBalances_OK(t *testing.T) {
 	ts, svc := newServerWithStore(t)
+	// Seed accounts of different types. seedAccount always uses the config
+	// default currency ("USD"), so multi-currency coverage is not exercised here.
 	seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 125000)
-	seedAccount(t, svc, "Assets:Cash", model.AccountTypeAsset, 3500)
+	seedAccount(t, svc, "Expenses:Coffee", model.AccountTypeExpense, 0)
 
 	resp, err := http.Get(ts.URL + "/api/balances")
 	if err != nil {
@@ -337,7 +339,7 @@ func TestHandleListBalances_OK(t *testing.T) {
 	if got.Limit != 0 || got.Offset != 0 {
 		t.Errorf("limit/offset: got %d/%d, want 0/0", got.Limit, got.Offset)
 	}
-	var foundBank, foundCash bool
+	var foundBank, foundCoffee bool
 	for _, row := range got.Items {
 		switch row.Name {
 		case "Assets:Bank":
@@ -345,21 +347,57 @@ func TestHandleListBalances_OK(t *testing.T) {
 			if row.Amount != 125000 {
 				t.Errorf("Bank amount: got %d, want 125000", row.Amount)
 			}
-		case "Assets:Cash":
-			foundCash = true
-			if row.Amount != 3500 {
-				t.Errorf("Cash amount: got %d, want 3500", row.Amount)
+			if row.Type != model.AccountTypeAsset {
+				t.Errorf("Bank type: got %q, want %q", row.Type, model.AccountTypeAsset)
+			}
+			if row.Currency == "" {
+				t.Errorf("Bank currency: got empty, want a resolved currency string")
+			}
+		case "Expenses:Coffee":
+			foundCoffee = true
+			if row.Type != model.AccountTypeExpense {
+				t.Errorf("Coffee type: got %q, want %q", row.Type, model.AccountTypeExpense)
 			}
 		}
 	}
-	if !foundBank || !foundCash {
-		t.Errorf("missing seeded rows: bank=%v cash=%v", foundBank, foundCash)
+	if !foundBank || !foundCoffee {
+		t.Errorf("missing seeded rows: bank=%v coffee=%v", foundBank, foundCoffee)
 	}
 	// Sorted by AccountID ascending.
 	for i := 1; i < len(got.Items); i++ {
 		if got.Items[i-1].AccountID > got.Items[i].AccountID {
 			t.Errorf("rows not sorted by AccountID at index %d", i)
 		}
+	}
+}
+
+func TestHandleListBalances_Empty(t *testing.T) {
+	ts, _ := newServerWithStore(t)
+	// No accounts seeded. The store may still contain system accounts
+	// (e.g. Equity:OpeningBalances_<CCY>) created during startup; the spec
+	// anticipates this and we assert envelope wellformedness rather than a
+	// strict empty list.
+
+	resp, err := http.Get(ts.URL + "/api/balances")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+	var got model.ListResult[model.AccountBalance]
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Items == nil {
+		t.Error("items: got nil, want [] (non-nil empty slice contract)")
+	}
+	if got.TotalCount != len(got.Items) {
+		t.Errorf("total_count (%d) must equal len(items) (%d)", got.TotalCount, len(got.Items))
+	}
+	if got.Limit != 0 || got.Offset != 0 {
+		t.Errorf("limit/offset: got %d/%d, want 0/0", got.Limit, got.Offset)
 	}
 }
 

--- a/internal/api/accounts_test.go
+++ b/internal/api/accounts_test.go
@@ -314,6 +314,188 @@ func TestHandleListAccounts_InvalidType(t *testing.T) {
 	}
 }
 
+func TestHandleListBalances_OK(t *testing.T) {
+	ts, svc := newServerWithStore(t)
+	seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 125000)
+	seedAccount(t, svc, "Assets:Cash", model.AccountTypeAsset, 3500)
+
+	resp, err := http.Get(ts.URL + "/api/balances")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+	var got model.ListResult[model.AccountBalance]
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.TotalCount < 2 {
+		t.Fatalf("total_count: got %d, want >= 2 (system account may bump it)", got.TotalCount)
+	}
+	if got.Limit != 0 || got.Offset != 0 {
+		t.Errorf("limit/offset: got %d/%d, want 0/0", got.Limit, got.Offset)
+	}
+	var foundBank, foundCash bool
+	for _, row := range got.Items {
+		switch row.Name {
+		case "Assets:Bank":
+			foundBank = true
+			if row.Amount != 125000 {
+				t.Errorf("Bank amount: got %d, want 125000", row.Amount)
+			}
+		case "Assets:Cash":
+			foundCash = true
+			if row.Amount != 3500 {
+				t.Errorf("Cash amount: got %d, want 3500", row.Amount)
+			}
+		}
+	}
+	if !foundBank || !foundCash {
+		t.Errorf("missing seeded rows: bank=%v cash=%v", foundBank, foundCash)
+	}
+	// Sorted by AccountID ascending.
+	for i := 1; i < len(got.Items); i++ {
+		if got.Items[i-1].AccountID > got.Items[i].AccountID {
+			t.Errorf("rows not sorted by AccountID at index %d", i)
+		}
+	}
+}
+
+func TestHandleListBalances_AsOfDefault(t *testing.T) {
+	ts, _ := newServerWithStore(t)
+
+	resp, err := http.Get(ts.URL + "/api/balances")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+	// We do not assert the as_of value the service was called with — the spec
+	// accepts this gap deliberately (no nowFunc test seam).
+}
+
+func TestHandleListBalances_HistoricalAsOf(t *testing.T) {
+	ts, _ := newServerWithStore(t)
+
+	resp, err := http.Get(ts.URL + "/api/balances?as_of=1700000000")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestHandleListBalances_InvalidAsOf(t *testing.T) {
+	ts, _ := newServerWithStore(t)
+
+	resp, err := http.Get(ts.URL + "/api/balances?as_of=banana")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", resp.StatusCode)
+	}
+	var body struct {
+		Error string `json:"error"`
+		Field string `json:"field"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Error != "validation_failed" {
+		t.Errorf("error code: got %q, want %q", body.Error, "validation_failed")
+	}
+	if body.Field != "as_of" {
+		t.Errorf("field: got %q, want %q", body.Field, "as_of")
+	}
+}
+
+func TestHandleListBalances_InvalidIncludeHidden(t *testing.T) {
+	ts, _ := newServerWithStore(t)
+
+	resp, err := http.Get(ts.URL + "/api/balances?include_hidden=maybe")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", resp.StatusCode)
+	}
+	var body struct {
+		Error string `json:"error"`
+		Field string `json:"field"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Error != "validation_failed" {
+		t.Errorf("error code: got %q, want %q", body.Error, "validation_failed")
+	}
+	if body.Field != "include_hidden" {
+		t.Errorf("field: got %q, want %q", body.Field, "include_hidden")
+	}
+}
+
+func TestHandleListBalances_IncludeHidden(t *testing.T) {
+	ts, svc := newServerWithStore(t)
+	visible := seedAccount(t, svc, "Assets:Bank", model.AccountTypeAsset, 0)
+	hidden := seedAccount(t, svc, "Assets:Old", model.AccountTypeAsset, 0)
+
+	// Mark "Assets:Old" hidden via the service.
+	if _, err := svc.Account().UpdateAccountMetadata(
+		t.Context(), hidden.ID, hidden.Description, true,
+	); err != nil {
+		t.Fatalf("hide account: %v", err)
+	}
+	_ = visible // referenced via the response
+
+	// Default: hidden excluded.
+	respDefault, err := http.Get(ts.URL + "/api/balances")
+	if err != nil {
+		t.Fatalf("GET default: %v", err)
+	}
+	defer respDefault.Body.Close()
+	var gotDefault model.ListResult[model.AccountBalance]
+	if err := json.NewDecoder(respDefault.Body).Decode(&gotDefault); err != nil {
+		t.Fatalf("decode default: %v", err)
+	}
+	for _, row := range gotDefault.Items {
+		if row.Name == "Assets:Old" {
+			t.Errorf("hidden account should be excluded by default, got row %+v", row)
+		}
+	}
+
+	// Toggled: hidden included.
+	respAll, err := http.Get(ts.URL + "/api/balances?include_hidden=true")
+	if err != nil {
+		t.Fatalf("GET include_hidden: %v", err)
+	}
+	defer respAll.Body.Close()
+	var gotAll model.ListResult[model.AccountBalance]
+	if err := json.NewDecoder(respAll.Body).Decode(&gotAll); err != nil {
+		t.Fatalf("decode include_hidden: %v", err)
+	}
+	var sawHidden bool
+	for _, row := range gotAll.Items {
+		if row.Name == "Assets:Old" {
+			sawHidden = true
+			if !row.IsHidden {
+				t.Errorf("Assets:Old should have IsHidden=true; got %+v", row)
+			}
+		}
+	}
+	if !sawHidden {
+		t.Error("Assets:Old should appear when include_hidden=true")
+	}
+}
+
 func TestHandleListAccounts_SearchFiltersHidden(t *testing.T) {
 	ts, svc := newServerWithStore(t)
 	visible := seedAccount(t, svc, "Assets:BankA", model.AccountTypeAsset, 0)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -30,6 +30,7 @@ func (s *Server) routes() http.Handler {
 		r.Method(http.MethodPatch, "/accounts/{id}", apiHandler(s.handleUpdateAccount))
 		r.Method(http.MethodDelete, "/accounts/{id}", apiHandler(s.handleDeleteAccount))
 		r.Method(http.MethodGet, "/accounts/{id}/balance", apiHandler(s.handleAccountBalance))
+		r.Method(http.MethodGet, "/balances", apiHandler(s.handleListBalances))
 		r.Method(http.MethodGet, "/accounts/{id}/unreconciled", apiHandler(s.handleListUnreconciled))
 		r.Method(http.MethodPost, "/accounts/{id}/reconcile/preview", apiHandler(s.handleReconcilePreview))
 		r.Method(http.MethodPost, "/accounts/{id}/reconcile", apiHandler(s.handleReconcileCommit))

--- a/internal/model/account.go
+++ b/internal/model/account.go
@@ -17,3 +17,15 @@ type AccountNode struct {
 	Account  *Account       `json:"account"`
 	Children []*AccountNode `json:"children"`
 }
+
+// AccountBalance is one row in a bulk-balance snapshot response.
+// Joins per-account metadata (from Account) with a point-in-time balance.
+type AccountBalance struct {
+	AccountID int64       `json:"account_id"`
+	Name      string      `json:"name"`
+	Type      AccountType `json:"type"`
+	ParentID  *int64      `json:"parent_id,omitempty"`
+	Currency  string      `json:"currency"`
+	Amount    int64       `json:"amount"`
+	IsHidden  bool        `json:"is_hidden"`
+}

--- a/internal/service/account_service.go
+++ b/internal/service/account_service.go
@@ -166,6 +166,49 @@ func (as *AccountService) GetAccountBalanceFormatted(ctx context.Context, accoun
 	return utils.FormatAmount(balance), nil
 }
 
+// GetAccountBalancesBulk returns one AccountBalance row per account known to
+// the registry, with the balance computed as of asOf (Unix seconds). When
+// includeHidden is false, accounts with IsHidden=true are omitted. Rows are
+// sorted by Account.ID for deterministic output. An account that has no
+// entry in the underlying balances map is reported with Amount=0 — this
+// covers newly-created accounts that have no transactions yet.
+func (as *AccountService) GetAccountBalancesBulk(
+	ctx context.Context, asOf int64, includeHidden bool,
+) ([]model.AccountBalance, error) {
+	accounts, err := as.repo.GetAllAccounts(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load accounts: %w", err)
+	}
+	balances, err := as.repo.GetAllAccountBalances(ctx, asOf)
+	if err != nil {
+		return nil, fmt.Errorf("load balances: %w", err)
+	}
+
+	rows := make([]model.AccountBalance, 0, len(accounts))
+	for _, acc := range accounts {
+		if !includeHidden && acc.IsHidden {
+			continue
+		}
+		currency := acc.Currency
+		if currency == "" {
+			currency = as.config.Defaults.Currency
+		}
+		rows = append(rows, model.AccountBalance{
+			AccountID: acc.ID,
+			Name:      acc.Name,
+			Type:      acc.Type,
+			ParentID:  acc.ParentID,
+			Currency:  currency,
+			Amount:    balances[acc.ID],
+			IsHidden:  acc.IsHidden,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].AccountID < rows[j].AccountID
+	})
+	return rows, nil
+}
+
 func (as *AccountService) GetRootNameByType(accType string) (string, error) {
 	at := model.AccountType(strings.ToUpper(accType))
 	name, ok := at.RootName()

--- a/internal/service/account_service_test.go
+++ b/internal/service/account_service_test.go
@@ -299,6 +299,102 @@ func TestGetAccountTree(t *testing.T) {
 	})
 }
 
+func TestGetAccountBalancesBulk(t *testing.T) {
+	t.Run("hidden excluded by default", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD", IsHidden: false})
+		accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:Cash", Type: model.AccountTypeAsset, Currency: "USD", IsHidden: false})
+		accRepo.addAccount(&model.Account{ID: 3, Name: "Assets:Old", Type: model.AccountTypeAsset, Currency: "USD", IsHidden: true})
+		accRepo.addAccount(&model.Account{ID: 4, Name: "Expenses:Food", Type: model.AccountTypeExpense, Currency: "USD", IsHidden: false})
+		accRepo.balances[1] = 125000
+		accRepo.balances[2] = 3500
+		accRepo.balances[3] = 9999
+		accRepo.balances[4] = -2000
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		rows, err := svc.GetAccountBalancesBulk(context.Background(), 1700000000, false)
+		require.NoError(t, err)
+		require.Len(t, rows, 3, "hidden account should be excluded")
+		assert.Equal(t, int64(1), rows[0].AccountID, "rows should be sorted by AccountID")
+		assert.Equal(t, int64(2), rows[1].AccountID)
+		assert.Equal(t, int64(4), rows[2].AccountID)
+		assert.Equal(t, int64(125000), rows[0].Amount)
+		assert.Equal(t, "USD", rows[0].Currency)
+		assert.False(t, rows[0].IsHidden)
+	})
+
+	t.Run("hidden included when toggled", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD", IsHidden: false})
+		accRepo.addAccount(&model.Account{ID: 3, Name: "Assets:Old", Type: model.AccountTypeAsset, Currency: "USD", IsHidden: true})
+		accRepo.balances[1] = 100
+		accRepo.balances[3] = 200
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		rows, err := svc.GetAccountBalancesBulk(context.Background(), 0, true)
+		require.NoError(t, err)
+		require.Len(t, rows, 2)
+		assert.True(t, rows[1].IsHidden)
+	})
+
+	t.Run("empty currency normalized to config default", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "", IsHidden: false})
+		accRepo.balances[1] = 100
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		rows, err := svc.GetAccountBalancesBulk(context.Background(), 0, false)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, defaultConfig().Defaults.Currency, rows[0].Currency,
+			"empty Currency should be normalized to config default")
+	})
+
+	t.Run("account not in balances map gets zero", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD"})
+		accRepo.addAccount(&model.Account{ID: 2, Name: "Assets:NewlyCreated", Type: model.AccountTypeAsset, Currency: "USD"})
+		accRepo.balances[1] = 500 // 2 omitted
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		rows, err := svc.GetAccountBalancesBulk(context.Background(), 0, false)
+		require.NoError(t, err)
+		require.Len(t, rows, 2)
+		assert.Equal(t, int64(0), rows[1].Amount, "account missing from balances map should get zero")
+	})
+
+	t.Run("empty registry returns non-nil empty slice", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		rows, err := svc.GetAccountBalancesBulk(context.Background(), 0, false)
+		require.NoError(t, err)
+		require.NotNil(t, rows, "must be non-nil so JSON marshals to []")
+		assert.Len(t, rows, 0)
+	})
+
+	t.Run("GetAllAccounts error propagates", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.getAllAccountsErr = errors.New("db boom")
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		_, err := svc.GetAccountBalancesBulk(context.Background(), 0, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "load accounts")
+	})
+
+	t.Run("GetAllAccountBalances error propagates", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		accRepo.addAccount(&model.Account{ID: 1, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD"})
+		accRepo.getAllBalancesErr = errors.New("db boom")
+		svc := newTestAccountService(accRepo, newMockTransactionRepo())
+
+		_, err := svc.GetAccountBalancesBulk(context.Background(), 0, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "load balances")
+	})
+}
+
 func TestUpdateAccountMetadata_DescriptionValidation(t *testing.T) {
 	t.Run("empty description is allowed", func(t *testing.T) {
 		accRepo := newMockAccountRepo()


### PR DESCRIPTION
## Summary

- New `GET /api/balances` endpoint returns every account with its point-in-time balance in a single `ListResult[AccountBalance]` payload. Designed for the SPA dashboard's primary fetch path — replaces N round-trips to `/api/accounts/{id}/balance`.
- Defaults align with the existing read API: `include_hidden=false` (matches `/api/accounts`), `as_of=time.Now().Unix()` (matches reports). Both query params validate to 400 with field-tagged envelopes; everything else flows through `mapError`.
- No pagination (account counts are bounded), no embedded per-currency totals (SPA computes from rows trivially), no tree-shape (SPA joins with `/api/accounts/tree` if it needs hierarchy). All three explicitly out of scope per the spec.
- Spec/plan (local-only, gitignored): `docs/superpowers/specs/2026-06-05-web-api-bulk-balances-design.md`, `docs/superpowers/plans/2026-06-05-web-api-bulk-balances.md`.

## Implementation

- `model.AccountBalance` — new struct joining per-account metadata with a point-in-time balance.
- `AccountService.GetAccountBalancesBulk(ctx, asOf, includeHidden)` — composes existing `GetAllAccounts` + `GetAllAccountBalances`, normalizes empty currency to `config.Defaults.Currency` (mirrors `GenerateBalanceSheet`), sorts by `AccountID`, returns non-nil empty slice for the empty case so JSON marshals to `\"items\": []` not `null`.
- `handleListBalances` — thin handler using existing `parseInt64Query` / `parseBoolQuery` helpers; `time.Now().Unix()` default lives in the handler (service stays deterministic for tests).
- One-line route registration in `router.go`.

## Test plan

- [x] `go test ./...` — green across all packages.
- [x] Service-layer: `TestGetAccountBalancesBulk` (7 subtests covering hidden filter both directions, empty-currency normalization, missing-balance-as-zero, empty registry non-nil slice, error propagation from both repo calls).
- [x] API-layer: 7 `TestHandleListBalances_*` tests covering OK (Asset + Expense seeded), `as_of` default, historical `as_of`, invalid `as_of` → 400, invalid `include_hidden` → 400, hidden flip, empty registry envelope shape.
- [x] `go build ./...` — clean.
- [ ] Manual smoke (optional): `kea serve`, `curl localhost:<port>/api/balances`, `curl localhost:<port>/api/balances?include_hidden=true`, `curl localhost:<port>/api/balances?as_of=1700000000`, `curl localhost:<port>/api/balances?as_of=banana` (expect 400).

## Follow-up (already tracked)

Pre-existing inconsistency spotted during review: `handleAccountBalance` (single-account endpoint, untouched here) returns `acc.Currency` directly without normalizing empty to config default — the bulk endpoint correctly normalizes. Spawned as a separate task to keep this PR scoped.