### PR TITLE
fix(api): normalize empty currency in /api/accounts/{id}/balance

### DIFF
--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -66,10 +66,14 @@ func (s *Server) handleAccountBalance(w http.ResponseWriter, r *http.Request) er
 	if err != nil {
 		return err
 	}
+	currency := acc.Currency
+	if currency == "" {
+		currency = s.svc.Config().Defaults.Currency
+	}
 	return writeJSON(w, http.StatusOK, balanceResponse{
 		AccountID: id,
 		Amount:    amount,
-		Currency:  acc.Currency,
+		Currency:  currency,
 	})
 }
 

--- a/internal/api/accounts_test.go
+++ b/internal/api/accounts_test.go
@@ -594,3 +594,44 @@ func TestHandleListAccounts_SearchFiltersHidden(t *testing.T) {
 		t.Errorf("include_hidden=true: hidden account missing from search")
 	}
 }
+
+// TestHandleAccountBalance_EmptyCurrencyNormalized verifies the handler
+// resolves an empty account Currency to the config default, mirroring the
+// behavior of GET /api/balances and GenerateBalanceSheet. ValidateCurrency
+// explicitly allows empty input, so this case is reachable through normal
+// account creation.
+func TestHandleAccountBalance_EmptyCurrencyNormalized(t *testing.T) {
+	ts, svc := newServerWithStore(t)
+	acc, err := svc.Account().CreateAccount(t.Context(), model.CreateAccountInput{
+		Name:     "Assets:NoCurrency",
+		Type:     model.AccountTypeAsset,
+		Currency: "",
+	})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+
+	resp, err := http.Get(ts.URL + "/api/accounts/" + itoa(acc.ID) + "/balance")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+	var got struct {
+		AccountID int64  `json:"account_id"`
+		Amount    int64  `json:"amount"`
+		Currency  string `json:"currency"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := svc.Config().Defaults.Currency
+	if got.Currency != want {
+		t.Errorf("currency: got %q, want %q (config default)", got.Currency, want)
+	}
+	if got.AccountID != acc.ID {
+		t.Errorf("account_id: got %d, want %d", got.AccountID, acc.ID)
+	}
+}


### PR DESCRIPTION
## Summary

- `handleAccountBalance` returned `acc.Currency` directly, so an account created without a Currency (legal per `ValidateCurrency` — "empty is allowed, will use default") surfaced as `\"currency\": \"\"`.
- The bulk `/api/balances` endpoint (PR #182) and `GenerateBalanceSheet` already normalize empty to `config.Defaults.Currency`; this PR applies the same pattern at the handler layer, mirroring how `handleListBalances` composes the `as_of` default inline.
- Caught during PR #182 code-quality review; spawned as a separate follow-up to keep that PR scoped.
- Spec/plan (local-only, gitignored): `docs/superpowers/specs/2026-06-05-fix-account-balance-currency-normalization-design.md`, `docs/superpowers/plans/2026-06-05-fix-account-balance-currency-normalization.md`.

## Implementation

Four added lines in `handleAccountBalance`:

```go
currency := acc.Currency
if currency == "" {
    currency = s.svc.Config().Defaults.Currency
}
```

Audit (`grep "acc\.Currency\|account\.Currency"` non-test code) confirmed this was the only remaining drift site — every other balance-emitting path already normalizes.

## Test plan

- [x] New `TestHandleAccountBalance_EmptyCurrencyNormalized` creates an account with `Currency: \"\"` via `svc.Account().CreateAccount` directly (can't use `seedAccount`, which hardcodes \"USD\"), then GETs the balance endpoint and asserts the response currency equals `svc.Config().Defaults.Currency` (dynamic, not hardcoded).
- [x] Existing `TestHandleAccountBalance_*` cases still pass (normalization is a no-op when currency is already set).
- [x] \`go test ./...\` and \`go build ./...\` — green.