### PR TITLE
fix(service): translate repository.ErrNotFound in CreateSimpleTransaction type inference

### DIFF
--- a/internal/service/transaction_ops.go
+++ b/internal/service/transaction_ops.go
@@ -171,10 +171,18 @@ func (ts *TransactionService) CreateSimpleTransaction(ctx context.Context, input
 	if txType == "" {
 		fromAcc, err := ts.accRepo.GetAccountByName(ctx, input.FromAccount)
 		if err != nil {
+			if errors.Is(err, repository.ErrNotFound) {
+				return model.TransactionDetail{}, validationErrorf("from_account",
+					"from account %q not found", input.FromAccount)
+			}
 			return model.TransactionDetail{}, fmt.Errorf("failed to resolve from account: %w", err)
 		}
 		toAcc, err := ts.accRepo.GetAccountByName(ctx, input.ToAccount)
 		if err != nil {
+			if errors.Is(err, repository.ErrNotFound) {
+				return model.TransactionDetail{}, validationErrorf("to_account",
+					"to account %q not found", input.ToAccount)
+			}
 			return model.TransactionDetail{}, fmt.Errorf("failed to resolve to account: %w", err)
 		}
 		inferred, err := ts.DetermineType(ctx, []model.SplitDetail{

--- a/internal/service/transaction_ops_test.go
+++ b/internal/service/transaction_ops_test.go
@@ -458,6 +458,56 @@ func TestCreateSimpleTransaction(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, model.TxTypeExpense, detail.Type)
 	})
+
+	t.Run("unknown from account returns validation error on from_account", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		_, err := svc.CreateSimpleTransaction(
+			context.Background(),
+			model.CreateSimpleTransactionInput{
+				FromAccount: "Assets:NotReal",
+				ToAccount:   "Expenses:Food",
+				Amount:      100,
+				Description: "x",
+				Timestamp:   0,
+				Status:      model.StatusPending,
+				Type:        "", // empty -> enters the type-inference branch
+			},
+		)
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve), "expected *ValidationError, got %T: %v", err, err)
+		assert.Equal(t, "from_account", ve.Field)
+		assert.Contains(t, ve.Message, "Assets:NotReal")
+	})
+
+	t.Run("unknown to account returns validation error on to_account", func(t *testing.T) {
+		accRepo := newMockAccountRepo()
+		txRepo := newMockTransactionRepo()
+		setupStandardAccounts(accRepo)
+		svc := newTestTransactionService(accRepo, txRepo)
+
+		_, err := svc.CreateSimpleTransaction(
+			context.Background(),
+			model.CreateSimpleTransactionInput{
+				FromAccount: "Assets:Bank",
+				ToAccount:   "Expenses:NotReal",
+				Amount:      100,
+				Description: "x",
+				Timestamp:   0,
+				Status:      model.StatusPending,
+				Type:        "", // empty -> enters the type-inference branch
+			},
+		)
+		require.Error(t, err)
+		var ve *ValidationError
+		require.True(t, errors.As(err, &ve), "expected *ValidationError, got %T: %v", err, err)
+		assert.Equal(t, "to_account", ve.Field)
+		assert.Contains(t, ve.Message, "Expenses:NotReal")
+	})
 }
 
 // ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `CreateSimpleTransaction`'s type-inference branch (entered when `Type: ""`) called `GetAccountByName` for both `FromAccount` and `ToAccount` and wrapped errors unconditionally, leaking `repository.ErrNotFound` past the service boundary.
- The web API doesn't currently reach this path (every write endpoint requires `Type`), but the CLI's `add` command does — and any future API that mirrors the CLI ergonomics would inherit the leak.
- Mirrors the pattern from PR #180 (commit `a8a08e2`): translate `repository.ErrNotFound` to `validationErrorf` with `from_account` / `to_account` field tags. The non-`ErrNotFound` branch keeps its existing wrap so genuine repo failures continue to surface.
- Caught during PR #180 code-quality review; spawned as a separate follow-up to keep that PR scoped.
- Spec/plan (local-only, gitignored): `docs/superpowers/specs/2026-06-05-fix-create-simple-transaction-errnotfound-design.md`, `docs/superpowers/plans/2026-06-05-fix-create-simple-transaction-errnotfound.md`.

## Implementation

Two parallel translations in the type-inference branch:

```go
if errors.Is(err, repository.ErrNotFound) {
    return model.TransactionDetail{}, validationErrorf("from_account",
        "from account %q not found", input.FromAccount)
}
return model.TransactionDetail{}, fmt.Errorf("failed to resolve from account: %w", err)
```

Same shape for the `ToAccount` lookup with field `to_account`.

## Test plan

- [x] Two new subtests inside `TestCreateSimpleTransaction`, both setting `Type: ""` to enter the type-inference branch:
  - `unknown_from_account_returns_validation_error_on_from_account` — asserts `Field == "from_account"`, message contains the unknown name.
  - `unknown_to_account_returns_validation_error_on_to_account` — same shape for `to_account`.
- [x] All 8 `TestCreateSimpleTransaction` subtests pass (6 existing + 2 new).
- [x] `go test ./...` and `go build ./...` — green.

## User-visible side effect

The CLI prints whatever error `CreateSimpleTransaction` returns. Before: `failed to resolve from account: account "X" not found: record not found`. After: `from account "X" not found`. Cleaner, more actionable; intentional improvement.