### PR TITLE
fix(cmd): start registry watcher in kea serve

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -4,6 +4,8 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -20,6 +22,18 @@ func NewServeCmd(application *app.App, migrationFS fs.FS, appDir string) *cobra.
 		Short: "Run the local web server",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+
+			// Start the registry watcher so external `kea ledger switch` calls
+			// made while the server is running cause this server to swap stores.
+			// The watcher exits when ctx is cancelled; the app's cleanup also
+			// calls StopWatch defensively.
+			go func() {
+				if err := application.Registry.Watch(cmd.Context()); err != nil &&
+					!errors.Is(err, context.Canceled) {
+					logger.Error("registry watcher exited", "err", err)
+				}
+			}()
+
 			srv := api.NewServer(
 				application.Config(),
 				application.Service,

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4,10 +4,12 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/hance08/kea/internal/config"
 	"github.com/hance08/kea/internal/ledger"
@@ -143,5 +145,103 @@ func TestSwitchLedger_FailedSwapLeavesStateUnchanged(t *testing.T) {
 	}
 	if a.Registry.ActiveLedger != "a" {
 		t.Errorf("registry.ActiveLedger leaked: got %q, want %q", a.Registry.ActiveLedger, "a")
+	}
+}
+
+// TestApp_WatchSwapsStoreOnExternalSwitch pins the production scenario for
+// kea serve: a second process (the CLI) writes ledgers.yaml; the server
+// process has a watcher running; fsnotify detects the write; reload() fires
+// the OnSwitch callback wired by NewApp; the callback swaps the store and
+// updates cfg. This is the chain cmd/serve.go's Watch goroutine relies on.
+func TestApp_WatchSwapsStoreOnExternalSwitch(t *testing.T) {
+	tempDir := t.TempDir()
+	pathA := filepath.Join(tempDir, "a.db")
+	pathB := filepath.Join(tempDir, "b.db")
+
+	if err := InitLedgerDB(pathA, migrations.FS); err != nil {
+		t.Fatalf("init a: %v", err)
+	}
+	if err := InitLedgerDB(pathB, migrations.FS); err != nil {
+		t.Fatalf("init b: %v", err)
+	}
+
+	reg, err := ledger.Load(tempDir)
+	if err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+	delete(reg.Ledgers, "default")
+	reg.ActiveLedger = ""
+	if err := reg.Add("a", pathA); err != nil {
+		t.Fatalf("add a: %v", err)
+	}
+	if err := reg.Add("b", pathB); err != nil {
+		t.Fatalf("add b: %v", err)
+	}
+	if err := reg.Switch("a"); err != nil {
+		t.Fatalf("switch a: %v", err)
+	}
+
+	cfg := config.NewDefault()
+	cfg.Database.Path = pathA
+	cfg.ActiveLedger = "a"
+
+	// Use NewApp so the OnSwitch callback (app.go:50) is wired. The existing
+	// newTestApp helper bypasses NewApp and doesn't register the callback.
+	a, cleanup, err := NewApp(cfg, reg, migrations.FS)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	// Spawn the watcher in a goroutine, mimicking what cmd/serve.go does.
+	ctx, cancel := context.WithCancel(t.Context())
+	watchDone := make(chan struct{})
+	go func() {
+		defer close(watchDone)
+		_ = a.Registry.Watch(ctx)
+	}()
+
+	// Let fsnotify install its watch — same pattern as the existing
+	// TestWatch_* tests in internal/ledger/registry_test.go.
+	time.Sleep(200 * time.Millisecond)
+
+	// External writer: a second Registry instance loads ledgers.yaml fresh
+	// (simulating a separate CLI process), then calls Switch which writes
+	// the file. fsnotify in the first process picks up the write, reload()
+	// fires the OnSwitch callback, the callback swaps the store and updates cfg.
+	extReg, err := ledger.Load(tempDir)
+	if err != nil {
+		t.Fatalf("load external registry: %v", err)
+	}
+	if err := extReg.Switch("b"); err != nil {
+		t.Fatalf("external switch: %v", err)
+	}
+
+	// Poll for the callback to fire. Debounce is 100ms; allow generous timeout
+	// for slow CI environments.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if a.Config().ActiveLedger == "b" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if a.Config().ActiveLedger != "b" {
+		t.Fatalf("ActiveLedger: got %q, want %q (external switch did not propagate)",
+			a.Config().ActiveLedger, "b")
+	}
+	if a.Config().Database.Path != pathB {
+		t.Errorf("Database.Path: got %q, want %q after external switch",
+			a.Config().Database.Path, pathB)
+	}
+
+	// Cancel and confirm the watcher exits cleanly.
+	cancel()
+	select {
+	case <-watchDone:
+		// OK
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher goroutine did not exit after context cancel")
 	}
 }


### PR DESCRIPTION
## Summary

- \`cmd/serve.go\` never called \`Registry.Watch(ctx)\`, so the fsnotify watcher hardened in PR #181 never ran in the server process. External \`kea ledger switch\` writes updated \`ledgers.yaml\` but the running server had no listener and kept serving the old DB — issue #119's split-brain materialized in practice.
- Spawn \`Watch\` in a goroutine bound to the server's context. The watcher exits on context cancellation; \`app.NewApp\`'s cleanup calls \`StopWatch\` defensively for double-safety. The OnSwitch callback wired in \`app.go:50\` then swaps the store and updates cfg, so the very next request hits the new DB.
- Adds \`TestApp_WatchSwapsStoreOnExternalSwitch\` covering the full chain: external file mutation → fsnotify → reload → callback → swap → cfg update.
- Reported in-session: user running \`make run\`, \`make spa-dev\`, and \`kea ledger switch\` in three terminals observed no update on the SPA. \`curl /api/balances\` confirmed the API was serving stale data. Without this fix, the CLI-switch-during-serve workflow that the pre-dev review §8 promised does not actually work.

Spec/plan (local-only, gitignored): \`docs/superpowers/specs/2026-06-07-fix-serve-registry-watcher-wire-design.md\`, \`docs/superpowers/plans/2026-06-07-fix-serve-registry-watcher-wire.md\`.

## Test plan

- [x] \`go test ./internal/app/ -run TestApp_WatchSwapsStoreOnExternalSwitch -v\` — PASS.
- [x] \`go test ./internal/app/ -v\` — all 4 tests pass (3 existing + 1 new).
- [x] \`go test ./...\` — green across all packages.
- [x] \`go build ./...\` — clean.
- [x] \`go test -race ./internal/app/...\` — fires on the deferred \`app.cfg\` mutation race chip (writes at \`app.go:55-56\` vs the test's poll-loop reads). Pre-existing surface, spec-noted as out of scope, tracked separately.
- [ ] Manual smoke (recommended): \`make run\` + \`make spa-dev\` + \`kea ledger switch <other>\` in three terminals; reload SPA. Net Worth dashboard should reflect the other ledger's accounts after the switch.

## Related

- Builds on PR #181's registry-mutex hardening. PR #181 made \`Registry.Watch\` safe to run; this PR actually runs it.
- Closes the pre-dev review §8 known limitation about CLI ledger switch being invisible to the running web server.