### PR TITLE
refactor(app): move runtime state off *config.Config onto *App

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/hance08/kea/internal/app"
 	"github.com/hance08/kea/internal/config"
-	"github.com/hance08/kea/internal/service"
 	"github.com/hance08/kea/ui/views"
 	"github.com/spf13/cobra"
 )
 
 type InfoProvider interface {
 	Config() *config.Config
+	RuntimeState() app.RuntimeState
 }
 
 type SystemInfoView interface {
@@ -32,14 +32,14 @@ type infoRunner struct {
 	json bool
 }
 
-func NewInfoCmd(svc *service.Service) *cobra.Command {
+func NewInfoCmd(application *app.App) *cobra.Command {
 	flags := &infoFlags{}
 	cmd := &cobra.Command{
 		Use:   "info",
 		Short: "Display application information",
 		Long:  `Display current configuration, database path, and system details.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runner := &infoRunner{svc: svc, view: views.NewSystemInfoView(), json: flags.JSON}
+			runner := &infoRunner{svc: application, view: views.NewSystemInfoView(), json: flags.JSON}
 			return runner.Run()
 		},
 	}
@@ -53,7 +53,8 @@ func (r *infoRunner) Run() error {
 		configPath = "(None, using defaults)"
 	}
 
-	rawDBPath := r.svc.Config().Database.Path
+	rt := r.svc.RuntimeState()
+	rawDBPath := rt.DatabasePath
 	if rawDBPath == "" {
 		appDir := getAppDataDirOrPanic()
 		rawDBPath = filepath.Join(appDir, "kea.db")
@@ -67,7 +68,7 @@ func (r *infoRunner) Run() error {
 
 	info := views.SystemInfo{
 		ConfigPath:      configPath,
-		ActiveLedger:    r.svc.Config().ActiveLedger,
+		ActiveLedger:    rt.ActiveLedger,
 		DBPath:          expandedDBPath,
 		DBExists:        dbExists,
 		DefaultCurrency: r.svc.Config().Defaults.Currency,

--- a/cmd/info_test.go
+++ b/cmd/info_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/hance08/kea/internal/app"
+	"github.com/hance08/kea/internal/config"
+	"github.com/hance08/kea/ui/views"
+)
+
+type fakeInfoProvider struct {
+	cfg     *config.Config
+	runtime app.RuntimeState
+}
+
+func (f *fakeInfoProvider) Config() *config.Config        { return f.cfg }
+func (f *fakeInfoProvider) RuntimeState() app.RuntimeState { return f.runtime }
+
+type capturingView struct {
+	got views.SystemInfo
+}
+
+func (c *capturingView) Render(info views.SystemInfo) error {
+	c.got = info
+	return nil
+}
+
+// TestInfoRunner_UsesRuntimeStateNotConfig asserts that the info command
+// displays the path the store is actually open against (RuntimeState), not
+// the value originally loaded from yaml (Config.Database.Path).
+func TestInfoRunner_UsesRuntimeStateNotConfig(t *testing.T) {
+	cfg := config.NewDefault()
+	cfg.Database.Path = "/yaml/loaded/path.db"
+	cfg.Defaults.Currency = "USD"
+
+	provider := &fakeInfoProvider{
+		cfg: cfg,
+		runtime: app.RuntimeState{
+			ActiveLedger: "alpha",
+			DatabasePath: "/runtime/active/path.db",
+		},
+	}
+	view := &capturingView{}
+
+	runner := &infoRunner{svc: provider, view: view, json: false}
+	if err := runner.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if view.got.ActiveLedger != "alpha" {
+		t.Errorf("ActiveLedger: got %q, want %q", view.got.ActiveLedger, "alpha")
+	}
+	// expandPath leaves absolute paths untouched.
+	if view.got.DBPath != "/runtime/active/path.db" {
+		t.Errorf("DBPath: got %q, want %q (should come from RuntimeState, not Config)",
+			view.got.DBPath, "/runtime/active/path.db")
+	}
+}
+
+// TestInfoRunner_FallsBackToDefaultWhenRuntimePathEmpty pins the existing
+// fallback: if RuntimeState.DatabasePath is empty, the runner falls back to
+// <appDataDir>/kea.db. This branch is reachable in unit tests where a fake
+// provider returns an empty runtime; production NewApp always seeds a
+// non-empty path because registry.Active() guarantees one.
+func TestInfoRunner_FallsBackToDefaultWhenRuntimePathEmpty(t *testing.T) {
+	cfg := config.NewDefault()
+	cfg.Defaults.Currency = "USD"
+
+	provider := &fakeInfoProvider{
+		cfg:     cfg,
+		runtime: app.RuntimeState{},
+	}
+	view := &capturingView{}
+
+	runner := &infoRunner{svc: provider, view: view, json: false}
+	if err := runner.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if view.got.DBPath == "" {
+		t.Errorf("DBPath fell through to empty; expected <appDataDir>/kea.db fallback")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -107,8 +107,7 @@ func Execute(migrations fs.FS) {
 			return 0
 		}
 
-		activePath, err := registry.Active()
-		if err != nil {
+		if _, err := registry.Active(); err != nil {
 			// No active ledger — only ledger commands are useful.
 			pterm.Warning.Println("No ledger configured. Run: kea ledger add <name>")
 			if err := rootCmd.ExecuteContext(context.Background()); err != nil {
@@ -117,9 +116,6 @@ func Execute(migrations fs.FS) {
 			}
 			return 0
 		}
-
-		// Inject the resolved DB path so app.NewApp and kea info both see it.
-		cfg.Database.Path = activePath
 
 		application, cleanup, err := app.NewApp(cfg, registry, migrations)
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -120,7 +120,6 @@ func Execute(migrations fs.FS) {
 
 		// Inject the resolved DB path so app.NewApp and kea info both see it.
 		cfg.Database.Path = activePath
-		cfg.ActiveLedger = registry.ActiveName()
 
 		application, cleanup, err := app.NewApp(cfg, registry, migrations)
 		if err != nil {
@@ -145,7 +144,7 @@ func Execute(migrations fs.FS) {
 		rootCmd.AddCommand(account.NewAccountCmd(application.Service))
 		rootCmd.AddCommand(transaction.NewTransactionCmd(application.Service))
 		rootCmd.AddCommand(NewAddCmd(application.Service))
-		rootCmd.AddCommand(NewInfoCmd(application.Service))
+		rootCmd.AddCommand(NewInfoCmd(application))
 		rootCmd.AddCommand(NewReportCmd(application.Service))
 		rootCmd.AddCommand(NewReconcileCmd(application.Service))
 		rootCmd.AddCommand(NewServeCmd(application, migrations, appDir))

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/hance08/kea/internal/backup"
 	"github.com/hance08/kea/internal/config"
@@ -22,6 +23,33 @@ type App struct {
 	store      *store.Store
 	migrations fs.FS
 	cfg        *config.Config
+
+	runtimeMu sync.RWMutex
+	runtime   RuntimeState
+}
+
+// RuntimeState is a value-type snapshot of the active ledger name and the
+// database path the store is currently open against. Returned by value from
+// App.RuntimeState so callers get a consistent pair under one lock.
+type RuntimeState struct {
+	ActiveLedger string
+	DatabasePath string
+}
+
+// RuntimeState returns a snapshot of the currently-active ledger name and
+// the database path the store is open against. Safe for concurrent callers.
+func (a *App) RuntimeState() RuntimeState {
+	a.runtimeMu.RLock()
+	defer a.runtimeMu.RUnlock()
+	return a.runtime
+}
+
+// setRuntime atomically replaces the runtime state. Internal — called from
+// NewApp's OnSwitch callback and from SwitchLedger.
+func (a *App) setRuntime(s RuntimeState) {
+	a.runtimeMu.Lock()
+	a.runtime = s
+	a.runtimeMu.Unlock()
 }
 
 // NewApp initialize config, database and core logic, then return App entity

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -81,7 +81,7 @@ func NewApp(cfg *config.Config, registry *ledger.Registry, migrationFS fs.FS) (*
 		store:      dbStore,
 		migrations: migrationFS,
 		cfg:        cfg,
-		runtime:    RuntimeState{ActiveLedger: cfg.ActiveLedger, DatabasePath: dbPathRaw},
+		runtime:    RuntimeState{ActiveLedger: registry.ActiveName(), DatabasePath: dbPathRaw},
 	}
 
 	registry.OnSwitch(func(name, path string) {
@@ -90,7 +90,6 @@ func NewApp(cfg *config.Config, registry *ledger.Registry, migrationFS fs.FS) (*
 			return
 		}
 		app.setRuntime(RuntimeState{ActiveLedger: name, DatabasePath: path})
-		cfg.ActiveLedger = name
 		cfg.Database.Path = path
 	})
 
@@ -118,9 +117,8 @@ func GetAppDataDir() (string, error) {
 }
 
 // SwitchLedger atomically swaps the active store to the named ledger,
-// updates the in-memory config, and persists the active-name change to
-// ledgers.yaml. The registry's fsnotify watcher subsequently fires reload(),
-// which short-circuits because ActiveLedger already matches.
+// updates RuntimeState and cfg.Database.Path, and persists the active-name
+// change to ledgers.yaml.
 func (a *App) SwitchLedger(name string) error {
 	entry, ok := a.Registry.EntryFor(name)
 	if !ok {
@@ -130,7 +128,6 @@ func (a *App) SwitchLedger(name string) error {
 		return fmt.Errorf("swap store: %w", err)
 	}
 	a.setRuntime(RuntimeState{ActiveLedger: name, DatabasePath: entry.Path})
-	a.cfg.ActiveLedger = name
 	a.cfg.Database.Path = entry.Path
 	return a.Registry.Switch(name)
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -110,8 +110,12 @@ func GetAppDataDir() (string, error) {
 	return filepath.Join(configDir, "kea"), nil
 }
 
-// SwitchLedger atomically swaps the active store to the named ledger,
-// updates RuntimeState, and persists the active-name change to ledgers.yaml.
+// SwitchLedger swaps the active store to the named ledger, updates
+// RuntimeState, and persists the active-name change to ledgers.yaml. The
+// registry's fsnotify watcher subsequently fires reload(), which short-
+// circuits because the active name already matches. If the final persist
+// fails the runtime state still reflects the new ledger; the next process
+// start reseeds from the registry on disk.
 func (a *App) SwitchLedger(name string) error {
 	entry, ok := a.Registry.EntryFor(name)
 	if !ok {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -75,11 +75,21 @@ func NewApp(cfg *config.Config, registry *ledger.Registry, migrationFS fs.FS) (*
 
 	svc := service.NewService(dbStore, dbStore, dbStore, cfg)
 
+	app := &App{
+		Service:    svc,
+		Registry:   registry,
+		store:      dbStore,
+		migrations: migrationFS,
+		cfg:        cfg,
+		runtime:    RuntimeState{ActiveLedger: cfg.ActiveLedger, DatabasePath: dbPathRaw},
+	}
+
 	registry.OnSwitch(func(name, path string) {
 		if err := dbStore.Swap(path, migrationFS); err != nil {
 			fmt.Fprintf(os.Stderr, "ledger switch failed: %v\n", err)
 			return
 		}
+		app.setRuntime(RuntimeState{ActiveLedger: name, DatabasePath: path})
 		cfg.ActiveLedger = name
 		cfg.Database.Path = path
 	})
@@ -91,13 +101,7 @@ func NewApp(cfg *config.Config, registry *ledger.Registry, migrationFS fs.FS) (*
 		}
 	}
 
-	return &App{
-		Service:    svc,
-		Registry:   registry,
-		store:      dbStore,
-		migrations: migrationFS,
-		cfg:        cfg,
-	}, cleanup, nil
+	return app, cleanup, nil
 }
 
 func GetAppDataDir() (string, error) {
@@ -125,6 +129,7 @@ func (a *App) SwitchLedger(name string) error {
 	if err := a.store.Swap(entry.Path, a.migrations); err != nil {
 		return fmt.Errorf("swap store: %w", err)
 	}
+	a.setRuntime(RuntimeState{ActiveLedger: name, DatabasePath: entry.Path})
 	a.cfg.ActiveLedger = name
 	a.cfg.Database.Path = entry.Path
 	return a.Registry.Switch(name)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -54,21 +54,16 @@ func (a *App) setRuntime(s RuntimeState) {
 
 // NewApp initialize config, database and core logic, then return App entity
 func NewApp(cfg *config.Config, registry *ledger.Registry, migrationFS fs.FS) (*App, func(), error) {
-	dbPathRaw := cfg.Database.Path
-
-	if dbPathRaw == "" {
-		appDir, err := GetAppDataDir()
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to determine data directory: %w", err)
-		}
-		dbPathRaw = filepath.Join(appDir, "kea.db")
+	dbPath, err := registry.Active()
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve active ledger: %w", err)
 	}
 
-	if err := backup.Run(dbPathRaw, nil); err != nil {
+	if err := backup.Run(dbPath, nil); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: backup failed: %v\n", err)
 	}
 
-	dbStore, err := store.NewStore(dbPathRaw, migrationFS)
+	dbStore, err := store.NewStore(dbPath, migrationFS)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to initialize database: %w", err)
 	}
@@ -81,7 +76,7 @@ func NewApp(cfg *config.Config, registry *ledger.Registry, migrationFS fs.FS) (*
 		store:      dbStore,
 		migrations: migrationFS,
 		cfg:        cfg,
-		runtime:    RuntimeState{ActiveLedger: registry.ActiveName(), DatabasePath: dbPathRaw},
+		runtime:    RuntimeState{ActiveLedger: registry.ActiveName(), DatabasePath: dbPath},
 	}
 
 	registry.OnSwitch(func(name, path string) {
@@ -90,7 +85,6 @@ func NewApp(cfg *config.Config, registry *ledger.Registry, migrationFS fs.FS) (*
 			return
 		}
 		app.setRuntime(RuntimeState{ActiveLedger: name, DatabasePath: path})
-		cfg.Database.Path = path
 	})
 
 	cleanup := func() {
@@ -117,8 +111,7 @@ func GetAppDataDir() (string, error) {
 }
 
 // SwitchLedger atomically swaps the active store to the named ledger,
-// updates RuntimeState and cfg.Database.Path, and persists the active-name
-// change to ledgers.yaml.
+// updates RuntimeState, and persists the active-name change to ledgers.yaml.
 func (a *App) SwitchLedger(name string) error {
 	entry, ok := a.Registry.EntryFor(name)
 	if !ok {
@@ -128,7 +121,6 @@ func (a *App) SwitchLedger(name string) error {
 		return fmt.Errorf("swap store: %w", err)
 	}
 	a.setRuntime(RuntimeState{ActiveLedger: name, DatabasePath: entry.Path})
-	a.cfg.Database.Path = entry.Path
 	return a.Registry.Switch(name)
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -70,18 +70,19 @@ func newTestApp(t *testing.T) (a *App, tempDir string, pathA, pathB string) {
 	}, tempDir, pathA, pathB
 }
 
-func TestSwitchLedger_SwapsStoreAndUpdatesConfig(t *testing.T) {
+func TestSwitchLedger_SwapsStoreAndUpdatesRuntimeState(t *testing.T) {
 	a, _, _, pathB := newTestApp(t)
 
 	if err := a.SwitchLedger("b"); err != nil {
 		t.Fatalf("SwitchLedger: %v", err)
 	}
 
-	if a.cfg.ActiveLedger != "b" {
-		t.Errorf("cfg.ActiveLedger: got %q, want %q", a.cfg.ActiveLedger, "b")
+	got := a.RuntimeState()
+	if got.ActiveLedger != "b" {
+		t.Errorf("RuntimeState.ActiveLedger: got %q, want %q", got.ActiveLedger, "b")
 	}
-	if a.cfg.Database.Path != pathB {
-		t.Errorf("cfg.Database.Path: got %q, want %q", a.cfg.Database.Path, pathB)
+	if got.DatabasePath != pathB {
+		t.Errorf("RuntimeState.DatabasePath: got %q, want %q", got.DatabasePath, pathB)
 	}
 	if a.Registry.ActiveLedger != "b" {
 		t.Errorf("registry.ActiveLedger: got %q, want %q", a.Registry.ActiveLedger, "b")
@@ -105,11 +106,12 @@ func TestSwitchLedger_UnknownNameReturnsErrLedgerNotFound(t *testing.T) {
 	if !errors.Is(err, ledger.ErrLedgerNotFound) {
 		t.Fatalf("err: got %v, want ErrLedgerNotFound", err)
 	}
-	if a.cfg.ActiveLedger != "a" {
-		t.Errorf("cfg.ActiveLedger leaked: got %q, want %q", a.cfg.ActiveLedger, "a")
+	got := a.RuntimeState()
+	if got.ActiveLedger != "a" {
+		t.Errorf("RuntimeState.ActiveLedger leaked: got %q, want %q", got.ActiveLedger, "a")
 	}
-	if a.cfg.Database.Path != pathA {
-		t.Errorf("cfg.Database.Path leaked: got %q, want %q", a.cfg.Database.Path, pathA)
+	if got.DatabasePath != pathA {
+		t.Errorf("RuntimeState.DatabasePath leaked: got %q, want %q", got.DatabasePath, pathA)
 	}
 	if a.Registry.ActiveLedger != "a" {
 		t.Errorf("registry.ActiveLedger leaked: got %q, want %q", a.Registry.ActiveLedger, "a")
@@ -138,11 +140,12 @@ func TestSwitchLedger_FailedSwapLeavesStateUnchanged(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from SwitchLedger to nonexistent path")
 	}
-	if a.cfg.ActiveLedger != "a" {
-		t.Errorf("cfg.ActiveLedger leaked: got %q, want %q", a.cfg.ActiveLedger, "a")
+	got := a.RuntimeState()
+	if got.ActiveLedger != "a" {
+		t.Errorf("RuntimeState.ActiveLedger leaked: got %q, want %q", got.ActiveLedger, "a")
 	}
-	if a.cfg.Database.Path != pathA {
-		t.Errorf("cfg.Database.Path leaked: got %q, want %q", a.cfg.Database.Path, pathA)
+	if got.DatabasePath != pathA {
+		t.Errorf("RuntimeState.DatabasePath leaked: got %q, want %q", got.DatabasePath, pathA)
 	}
 	if a.Registry.ActiveLedger != "a" {
 		t.Errorf("registry.ActiveLedger leaked: got %q, want %q", a.Registry.ActiveLedger, "a")
@@ -232,19 +235,20 @@ func TestApp_WatchSwapsStoreOnExternalSwitch(t *testing.T) {
 	// for slow CI environments.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if a.Config().ActiveLedger == "b" {
+		if a.RuntimeState().ActiveLedger == "b" {
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	if a.Config().ActiveLedger != "b" {
-		t.Fatalf("ActiveLedger: got %q, want %q (external switch did not propagate)",
-			a.Config().ActiveLedger, "b")
+	got := a.RuntimeState()
+	if got.ActiveLedger != "b" {
+		t.Fatalf("RuntimeState.ActiveLedger: got %q, want %q (external switch did not propagate)",
+			got.ActiveLedger, "b")
 	}
-	if a.Config().Database.Path != pathB {
-		t.Errorf("Database.Path: got %q, want %q after external switch",
-			a.Config().Database.Path, pathB)
+	if got.DatabasePath != pathB {
+		t.Errorf("RuntimeState.DatabasePath: got %q, want %q after external switch",
+			got.DatabasePath, pathB)
 	}
 
 	// Cancel and confirm the watcher exits cleanly.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -256,3 +256,17 @@ func TestApp_WatchSwapsStoreOnExternalSwitch(t *testing.T) {
 		t.Fatal("watcher goroutine did not exit after context cancel")
 	}
 }
+
+func TestApp_RuntimeStateAfterSwitchLedger(t *testing.T) {
+	a, _, _, pathB := newTestApp(t)
+
+	if err := a.SwitchLedger("b"); err != nil {
+		t.Fatalf("SwitchLedger: %v", err)
+	}
+
+	got := a.RuntimeState()
+	want := RuntimeState{ActiveLedger: "b", DatabasePath: pathB}
+	if got != want {
+		t.Errorf("RuntimeState after switch: got %+v, want %+v", got, want)
+	}
+}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -66,6 +66,7 @@ func newTestApp(t *testing.T) (a *App, tempDir string, pathA, pathB string) {
 		store:      st,
 		migrations: migrations.FS,
 		cfg:        cfg,
+		runtime:    RuntimeState{ActiveLedger: "a", DatabasePath: pathA},
 	}, tempDir, pathA, pathB
 }
 
@@ -145,6 +146,16 @@ func TestSwitchLedger_FailedSwapLeavesStateUnchanged(t *testing.T) {
 	}
 	if a.Registry.ActiveLedger != "a" {
 		t.Errorf("registry.ActiveLedger leaked: got %q, want %q", a.Registry.ActiveLedger, "a")
+	}
+}
+
+func TestApp_RuntimeStateInitialFromRegistry(t *testing.T) {
+	a, _, pathA, _ := newTestApp(t)
+
+	got := a.RuntimeState()
+	want := RuntimeState{ActiveLedger: "a", DatabasePath: pathA}
+	if got != want {
+		t.Errorf("RuntimeState: got %+v, want %+v", got, want)
 	}
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -53,7 +53,6 @@ func newTestApp(t *testing.T) (a *App, tempDir string, pathA, pathB string) {
 
 	cfg := config.NewDefault()
 	cfg.Database.Path = pathA
-	cfg.ActiveLedger = "a"
 
 	st, err := store.NewStore(pathA, migrations.FS)
 	if err != nil {
@@ -197,7 +196,6 @@ func TestApp_WatchSwapsStoreOnExternalSwitch(t *testing.T) {
 
 	cfg := config.NewDefault()
 	cfg.Database.Path = pathA
-	cfg.ActiveLedger = "a"
 
 	// Use NewApp so the OnSwitch callback (app.go:50) is wired. The existing
 	// newTestApp helper bypasses NewApp and doesn't register the callback.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -272,3 +272,100 @@ func TestApp_RuntimeStateAfterSwitchLedger(t *testing.T) {
 		t.Errorf("RuntimeState after switch: got %+v, want %+v", got, want)
 	}
 }
+
+// TestApp_RuntimeStateRace asserts that a reader hammering RuntimeState() while
+// the watcher's OnSwitch callback fires produces no race reports under -race.
+// Run with: go test -race ./internal/app/ -run TestApp_RuntimeStateRace
+func TestApp_RuntimeStateRace(t *testing.T) {
+	tempDir := t.TempDir()
+	pathA := filepath.Join(tempDir, "a.db")
+	pathB := filepath.Join(tempDir, "b.db")
+
+	if err := InitLedgerDB(pathA, migrations.FS); err != nil {
+		t.Fatalf("init a: %v", err)
+	}
+	if err := InitLedgerDB(pathB, migrations.FS); err != nil {
+		t.Fatalf("init b: %v", err)
+	}
+
+	reg, err := ledger.Load(tempDir)
+	if err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+	delete(reg.Ledgers, "default")
+	reg.ActiveLedger = ""
+	if err := reg.Add("a", pathA); err != nil {
+		t.Fatalf("add a: %v", err)
+	}
+	if err := reg.Add("b", pathB); err != nil {
+		t.Fatalf("add b: %v", err)
+	}
+	if err := reg.Switch("a"); err != nil {
+		t.Fatalf("switch a: %v", err)
+	}
+
+	cfg := config.NewDefault()
+
+	a, cleanup, err := NewApp(cfg, reg, migrations.FS)
+	if err != nil {
+		t.Fatalf("NewApp: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	watchDone := make(chan struct{})
+	go func() {
+		defer close(watchDone)
+		_ = a.Registry.Watch(ctx)
+	}()
+
+	// Let fsnotify install its watch.
+	time.Sleep(200 * time.Millisecond)
+
+	// Reader: hammer RuntimeState until the test signals stop.
+	stop := make(chan struct{})
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = a.RuntimeState()
+			}
+		}
+	}()
+
+	// Writer: trigger an external switch that fires OnSwitch.
+	extReg, err := ledger.Load(tempDir)
+	if err != nil {
+		t.Fatalf("load external registry: %v", err)
+	}
+	if err := extReg.Switch("b"); err != nil {
+		t.Fatalf("external switch: %v", err)
+	}
+
+	// Wait for the callback to land.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if a.RuntimeState().ActiveLedger == "b" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	close(stop)
+	<-readerDone
+
+	if got := a.RuntimeState(); got.ActiveLedger != "b" || got.DatabasePath != pathB {
+		t.Errorf("RuntimeState: got %+v, want {b %s}", got, pathB)
+	}
+
+	cancel()
+	select {
+	case <-watchDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher goroutine did not exit after context cancel")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,11 +4,10 @@
 package config
 
 type Config struct {
-	Database     DatabaseConfig `mapstructure:"database"`
-	Defaults     DefaultsConfig `mapstructure:"defaults"`
-	Server       ServerConfig   `mapstructure:"server"`
-	ConfigPath   string         `mapstructure:"-"`
-	ActiveLedger string         `mapstructure:"-"` // name of the active ledger, set at startup
+	Database   DatabaseConfig `mapstructure:"database"`
+	Defaults   DefaultsConfig `mapstructure:"defaults"`
+	Server     ServerConfig   `mapstructure:"server"`
+	ConfigPath string         `mapstructure:"-"`
 }
 
 type ServerConfig struct {


### PR DESCRIPTION
## Summary

Moves the two runtime-mutable fields (`ActiveLedger`, `Database.Path`) off `*config.Config` and onto `*app.App` behind a `sync.RWMutex`, exposed via a value-type snapshot accessor `App.RuntimeState() RuntimeState`. Eliminates the data race surfaced by `TestApp_WatchSwapsStoreOnExternalSwitch` after #186 wired the fsnotify watcher into `kea serve` — that test previously raced on the watcher goroutine writing `cfg.ActiveLedger` / `cfg.Database.Path` while the test's poll-loop read them.

`cfg.Database.Path` continues to exist on `Config` as the yaml-loaded settings value (with the existing `~`-expansion at startup), but no production code mutates it at runtime anymore. `NewApp` reads the active path from `Registry.Active()` directly. `cmd/info.go`'s `InfoProvider` interface widens to require `RuntimeState() app.RuntimeState`; `NewInfoCmd` now takes `*app.App` instead of `*service.Service`.

Semantic split:
- `cfg.Database.Path` — what the user wrote in yaml (immutable after load)
- `App.RuntimeState().DatabasePath` — what the store is actually open against (mutable, thread-safe)

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` green
- [x] `go test -race ./...` clean (no race reports)
- [x] `go test -race -count=10 ./internal/app/ -run 'TestApp_RuntimeStateRace|TestApp_WatchSwapsStoreOnExternalSwitch'` — 20/20 PASS
- [x] New regression test `TestApp_RuntimeStateRace` pins race-free reads under watcher writes
- [x] New `cmd/info_test.go` pins that `kea info` displays the runtime path, not the yaml-loaded path
- [ ] Manual: `kea ledger switch <name>` still works; `kea info` still displays the active ledger + path; `kea serve` watcher still picks up external switches

## Out of scope

- The `~`-expansion at `cmd/root.go` (settings-load behavior on the yaml value).
- `/api/ledgers/*` handlers — already read from the registry, not from cfg.
- Fate of the now-inert `cfg.Database.Path` yaml field (loaded but never read in production) — tracked as a follow-up.