### PR TITLE
feat: read default currency from GET /api/config instead of VITE env var

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package api
+
+import "net/http"
+
+type configResponse struct {
+	Defaults configDefaults `json:"defaults"`
+}
+
+type configDefaults struct {
+	Currency string `json:"currency"`
+}
+
+func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) error {
+	return writeJSON(w, http.StatusOK, configResponse{
+		Defaults: configDefaults{
+			Currency: s.svc.Config().Defaults.Currency,
+		},
+	})
+}

--- a/internal/api/config_test.go
+++ b/internal/api/config_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestGetConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		currency string
+		wantBody string
+	}{
+		{"populated", "USD", `{"defaults":{"currency":"USD"}}`},
+		{"empty", "", `{"defaults":{"currency":""}}`},
+		{"non_default", "TWD", `{"defaults":{"currency":"TWD"}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, _, _ := newServerForWriteWithCurrency(t, tt.currency)
+
+			resp, err := http.Get(ts.URL + "/api/config")
+			if err != nil {
+				t.Fatalf("GET /api/config: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("status: got %d, want 200", resp.StatusCode)
+			}
+			if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+				t.Errorf("Content-Type: got %q, want application/json", ct)
+			}
+
+			raw, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			got := strings.TrimSpace(string(raw))
+			if got != tt.wantBody {
+				t.Errorf("body: got %q, want %q", got, tt.wantBody)
+			}
+
+			var parsed struct {
+				Defaults struct {
+					Currency string `json:"currency"`
+				} `json:"defaults"`
+			}
+			if err := json.Unmarshal(raw, &parsed); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if parsed.Defaults.Currency != tt.currency {
+				t.Errorf("parsed currency: got %q, want %q", parsed.Defaults.Currency, tt.currency)
+			}
+		})
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -22,6 +22,7 @@ func (s *Server) routes() http.Handler {
 	r.Route("/api", func(r chi.Router) {
 		r.Method(http.MethodGet, "/health", apiHandler(s.handleHealth))
 		r.Method(http.MethodGet, "/version", apiHandler(s.handleVersion))
+		r.Method(http.MethodGet, "/config", apiHandler(s.handleGetConfig))
 		r.Method(http.MethodGet, "/accounts", apiHandler(s.handleListAccounts))
 		r.Method(http.MethodPost, "/accounts", apiHandler(s.handleCreateAccount))
 		r.Method(http.MethodGet, "/accounts/tree", apiHandler(s.handleAccountTree))

--- a/internal/api/testhelper_test.go
+++ b/internal/api/testhelper_test.go
@@ -65,11 +65,10 @@ func seedTransaction(t *testing.T, svc *service.Service, from, to string, amount
 	return *full
 }
 
-// newServerForWrite is a variant of newServerWithStore that also returns the
-// underlying *store.Store, so write tests can manipulate reconcile state and
-// inject a parent cycle directly via the repo (bypassing the service layer
-// where convenient).
-func newServerForWrite(t *testing.T) (*httptest.Server, *service.Service, *store.Store) {
+// newServerForWriteWithCurrency is a variant of newServerForWrite that lets the
+// caller choose cfg.Defaults.Currency. Used by /api/config tests that exercise
+// both populated and empty defaults.
+func newServerForWriteWithCurrency(t *testing.T, currency string) (*httptest.Server, *service.Service, *store.Store) {
 	t.Helper()
 
 	dbPath := filepath.Join(t.TempDir(), "test.db")
@@ -80,7 +79,7 @@ func newServerForWrite(t *testing.T) (*httptest.Server, *service.Service, *store
 	t.Cleanup(func() { _ = st.Close() })
 
 	cfg := config.NewDefault()
-	cfg.Defaults.Currency = "USD"
+	cfg.Defaults.Currency = currency
 
 	svc := service.NewService(st, st, st, cfg)
 	srv := NewServer(cfg, svc, nil, nil, "", nil, discardLogger())
@@ -88,6 +87,15 @@ func newServerForWrite(t *testing.T) (*httptest.Server, *service.Service, *store
 	t.Cleanup(ts.Close)
 
 	return ts, svc, st
+}
+
+// newServerForWrite is a variant of newServerWithStore that also returns the
+// underlying *store.Store, so write tests can manipulate reconcile state and
+// inject a parent cycle directly via the repo (bypassing the service layer
+// where convenient).
+func newServerForWrite(t *testing.T) (*httptest.Server, *service.Service, *store.Store) {
+	t.Helper()
+	return newServerForWriteWithCurrency(t, "USD")
 }
 
 // seedReconciledTransaction flips a Cleared transaction to Reconciled by

--- a/spa/.env.example
+++ b/spa/.env.example
@@ -1,2 +1,0 @@
-# Currency used for the Balances headline. Falls back to USD if unset.
-VITE_DEFAULT_CURRENCY=USD

--- a/spa/README.md
+++ b/spa/README.md
@@ -45,8 +45,6 @@ Open <http://localhost:5173>. Vite proxies `/api/**` to `http://localhost:8080`.
 
 ## Configuration
 
-`VITE_DEFAULT_CURRENCY` — currency used for the Net Worth headline. Defaults to `USD` if unset. Copy `.env.example` to `.env` to override.
-
 `as_of` — not configurable in the UI; balances always reflect the current server time. Add a date picker to override if needed.
 
 ## Status
@@ -54,4 +52,3 @@ Open <http://localhost:5173>. Vite proxies `/api/**` to `http://localhost:8080`.
 - `/balances` — Net Worth dashboard
 - `/accounts`, `/transactions`, `/reports`, `/reconcile` — sidebar stubs (disabled)
 - Embed via `go:embed` for single-binary distribution
-- `GET /api/config` endpoint for server-side default currency

--- a/spa/src/lib/api.ts
+++ b/spa/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { AccountBalance, ListResult } from './types';
+import type { AccountBalance, ListResult, ServerConfig } from './types';
 
 export class ApiError extends Error {
   readonly status: number;
@@ -32,4 +32,8 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
 
 export function getBalances(): Promise<ListResult<AccountBalance>> {
   return apiFetch<ListResult<AccountBalance>>('/api/balances');
+}
+
+export function getConfig(): Promise<ServerConfig> {
+  return apiFetch<ServerConfig>('/api/config');
 }

--- a/spa/src/lib/server-config.tsx
+++ b/spa/src/lib/server-config.tsx
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+import { type ReactNode, createContext, useContext } from 'react';
+import { getConfig } from './api';
+import type { ServerConfig } from './types';
+
+const ServerConfigContext = createContext<ServerConfig | null>(null);
+
+interface ServerConfigProviderProps {
+  fallback: ReactNode;
+  children: (cfg: ServerConfig) => ReactNode;
+}
+
+export function ServerConfigProvider({ fallback, children }: ServerConfigProviderProps) {
+  const query = useQuery({
+    queryKey: ['server-config'],
+    queryFn: getConfig,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  if (query.isPending || query.isError) {
+    return <>{fallback}</>;
+  }
+
+  return (
+    <ServerConfigContext.Provider value={query.data}>
+      {children(query.data)}
+    </ServerConfigContext.Provider>
+  );
+}
+
+export function useServerConfig(): ServerConfig {
+  const cfg = useContext(ServerConfigContext);
+  if (!cfg) {
+    throw new Error('useServerConfig must be used inside ServerConfigProvider');
+  }
+  return cfg;
+}

--- a/spa/src/lib/types.ts
+++ b/spa/src/lib/types.ts
@@ -16,3 +16,9 @@ export interface ListResult<T> {
   limit: number;
   offset: number;
 }
+
+export interface ServerConfig {
+  defaults: {
+    currency: string;
+  };
+}

--- a/spa/src/main.tsx
+++ b/spa/src/main.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { ServerConfigProvider } from './lib/server-config';
 import { routeTree } from './routeTree.gen';
 
 const queryClient = new QueryClient({
@@ -25,7 +26,15 @@ if (!rootEl) throw new Error('root element not found');
 createRoot(rootEl).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <ServerConfigProvider
+        fallback={
+          <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">
+            Loading…
+          </div>
+        }
+      >
+        {() => <RouterProvider router={router} />}
+      </ServerConfigProvider>
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/spa/src/routes/balances.tsx
+++ b/spa/src/routes/balances.tsx
@@ -6,16 +6,17 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { getBalances } from '@/lib/api';
 import { summarizeBalances } from '@/lib/balances';
+import { useServerConfig } from '@/lib/server-config';
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-
-const DEFAULT_CURRENCY = import.meta.env.VITE_DEFAULT_CURRENCY || 'USD';
 
 export const Route = createFileRoute('/balances')({
   component: BalancesPage,
 });
 
 function BalancesPage() {
+  const { defaults } = useServerConfig();
+  const DEFAULT_CURRENCY = defaults.currency;
   const query = useQuery({ queryKey: ['balances'], queryFn: getBalances });
 
   if (query.isPending) {

--- a/spa/src/test/balances.test.tsx
+++ b/spa/src/test/balances.test.tsx
@@ -11,39 +11,47 @@ const okResponse = (body: unknown) =>
 beforeEach(() => {
   vi.stubGlobal(
     'fetch',
-    vi.fn(() =>
-      okResponse({
-        items: [
-          {
-            account_id: 1,
-            name: 'Assets:Bank',
-            type: 'A',
-            currency: 'USD',
-            amount: 125000,
-            is_hidden: false,
-          },
-          {
-            account_id: 2,
-            name: 'Assets:Cash',
-            type: 'A',
-            currency: 'USD',
-            amount: 3500,
-            is_hidden: false,
-          },
-          {
-            account_id: 3,
-            name: 'Liab:Card',
-            type: 'L',
-            currency: 'USD',
-            amount: -42000,
-            is_hidden: false,
-          },
-        ],
-        total_count: 3,
-        limit: 0,
-        offset: 0,
-      }),
-    ),
+    vi.fn((url: string) => {
+      if (url === '/api/config') {
+        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+      }
+      if (url === '/api/balances') {
+        return Promise.resolve(
+          okResponse({
+            items: [
+              {
+                account_id: 1,
+                name: 'Assets:Bank',
+                type: 'A',
+                currency: 'USD',
+                amount: 125000,
+                is_hidden: false,
+              },
+              {
+                account_id: 2,
+                name: 'Assets:Cash',
+                type: 'A',
+                currency: 'USD',
+                amount: 3500,
+                is_hidden: false,
+              },
+              {
+                account_id: 3,
+                name: 'Liab:Card',
+                type: 'L',
+                currency: 'USD',
+                amount: -42000,
+                is_hidden: false,
+              },
+            ],
+            total_count: 3,
+            limit: 0,
+            offset: 0,
+          }),
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }),
   );
 });
 

--- a/spa/src/test/server-config.test.tsx
+++ b/spa/src/test/server-config.test.tsx
@@ -1,0 +1,61 @@
+import { ServerConfigProvider, useServerConfig } from '@/lib/server-config';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+const okResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+function CurrencyReadout() {
+  const cfg = useServerConfig();
+  return <div data-testid="currency">{cfg.defaults.currency}</div>;
+}
+
+function renderWithProvider() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ServerConfigProvider fallback={<div data-testid="loading">Loading...</div>}>
+        {() => <CurrencyReadout />}
+      </ServerConfigProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string) => {
+      if (url === '/api/config') {
+        return Promise.resolve(okResponse({ defaults: { currency: 'TWD' } }));
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test('renders fallback while /api/config is pending, then exposes config to children', async () => {
+  renderWithProvider();
+  expect(screen.getByTestId('loading')).toBeInTheDocument();
+  expect(await screen.findByTestId('currency')).toHaveTextContent('TWD');
+});
+
+test('keeps fallback visible when /api/config fails', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve(new Response('{}', { status: 500 }))),
+  );
+  renderWithProvider();
+  await Promise.resolve();
+  expect(screen.getByTestId('loading')).toBeInTheDocument();
+  expect(screen.queryByTestId('currency')).not.toBeInTheDocument();
+});

--- a/spa/src/test/setup.tsx
+++ b/spa/src/test/setup.tsx
@@ -1,15 +1,15 @@
 import '@testing-library/jest-dom/vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+// Re-export a TestApp helper for routing-aware tests.
+import { RouterProvider, createMemoryHistory, createRouter } from '@tanstack/react-router';
 import { cleanup } from '@testing-library/react';
 import { afterEach } from 'vitest';
+import { ServerConfigProvider } from '../lib/server-config';
+import { routeTree } from '../routeTree.gen';
 
 afterEach(() => {
   cleanup();
 });
-
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-// Re-export a TestApp helper for routing-aware tests.
-import { RouterProvider, createMemoryHistory, createRouter } from '@tanstack/react-router';
-import { routeTree } from '../routeTree.gen';
 
 export function makeTestApp(initialPath: string) {
   const history = createMemoryHistory({ initialEntries: [initialPath] });
@@ -19,7 +19,9 @@ export function makeTestApp(initialPath: string) {
   });
   return (
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <ServerConfigProvider fallback={<div>Loading…</div>}>
+        {() => <RouterProvider router={router} />}
+      </ServerConfigProvider>
     </QueryClientProvider>
   );
 }

--- a/spa/src/vite-env.d.ts
+++ b/spa/src/vite-env.d.ts
@@ -1,9 +1,1 @@
 /// <reference types="vite/client" />
-
-interface ImportMetaEnv {
-  readonly VITE_DEFAULT_CURRENCY?: string;
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}


### PR DESCRIPTION
## Summary

- Add `GET /api/config` returning `{"defaults": {"currency": "..."}}` so the SPA can read the server's startup defaults at runtime.
- Wire the SPA to fetch it at app boot via TanStack Query through a new `ServerConfigProvider` + `useServerConfig` hook; the root gates child render until config resolves.
- Remove `VITE_DEFAULT_CURRENCY` entirely (`spa/.env`, `.env.example`, `vite-env.d.ts` declaration, README section, `routes/balances.tsx` consumer) so the SPA and Go server agree on a single source of truth.

## Why

Previously the SPA read its default currency from `import.meta.env.VITE_DEFAULT_CURRENCY` at Vite build/dev startup, falling back to `'USD'`. A user setting `cfg.Defaults.Currency = "TWD"` in `~/.config/kea/config.yaml` would silently leave the SPA on USD until they also remembered to set `spa/.env`. Empty-currency accounts get normalized server-side to one value and excluded client-side by another, producing a broken-looking dashboard.

## Design

- Response shape mirrors the Go `Config.Defaults.Currency` layout (`{"defaults": {"currency": "..."}}`) rather than flat, so future fields (`defaults.locale`, `defaults.date_format`) extend without breaking changes.
- `/api/config` returns only **immutable startup config**; mutable runtime state (active ledger) stays on `/api/ledgers/active`.
- Empty-currency case returns `""` rather than substituting USD; the SPA treats it as "everything excluded," which is the correct signal of misconfiguration.

Spec: `docs/superpowers/specs/2026-06-09-api-config-endpoint-design.md`
Plan: `docs/superpowers/plans/2026-06-09-api-config-endpoint.md`

## Test plan

- [x] `go test ./...` (Go side, all packages)
- [x] `go build ./...`
- [x] `cd spa && npm run check` (Biome)
- [x] `cd spa && npm run test` (13/13 passing across 4 files)
- [x] `cd spa && npm run build`
- [x] Manual: `curl http://localhost:PORT/api/config` returns the configured currency dynamically across config changes (verified TWD→USD)
- [x] Manual: `kea serve` + `cd spa && npm run dev` + open `/balances` in browser, confirm Net Worth headline formats in the configured currency without touching `spa/.env`