### PR TITLE
fix(spa): polyfill crypto.randomUUID for non-secure contexts

### DIFF
--- a/spa/src/components/transactions/SplitsEditor.tsx
+++ b/spa/src/components/transactions/SplitsEditor.tsx
@@ -7,6 +7,7 @@ import { buildCurrencyFilter, buildLeafFilter, combineFilters } from '@/lib/acco
 import { listAccounts } from '@/lib/accounts';
 import { determineType } from '@/lib/determineType';
 import type { Account, AccountType, TransactionType } from '@/lib/types';
+import { safeRandomUUID } from '@/lib/uuid';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
@@ -23,7 +24,7 @@ interface SplitRow {
 
 export function newSplitRow(initial?: Partial<SplitRow>): SplitRow {
   return {
-    clientKey: crypto.randomUUID(),
+    clientKey: safeRandomUUID(),
     account_name: '',
     amountStr: '',
     currency: 'USD',

--- a/spa/src/lib/uuid.test.ts
+++ b/spa/src/lib/uuid.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { safeRandomUUID } from './uuid';
+
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('safeRandomUUID', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('returns a valid UUIDv4', () => {
+    expect(safeRandomUUID()).toMatch(UUID_V4_RE);
+  });
+
+  test('returns different values on consecutive calls', () => {
+    expect(safeRandomUUID()).not.toBe(safeRandomUUID());
+  });
+
+  test('falls back to getRandomValues when crypto.randomUUID is unavailable', () => {
+    const originalCrypto = globalThis.crypto;
+    vi.stubGlobal('crypto', {
+      getRandomValues: originalCrypto.getRandomValues.bind(originalCrypto),
+      randomUUID: undefined,
+    });
+
+    expect(safeRandomUUID()).toMatch(UUID_V4_RE);
+  });
+});

--- a/spa/src/lib/uuid.ts
+++ b/spa/src/lib/uuid.ts
@@ -1,0 +1,13 @@
+export function safeRandomUUID(): string {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+  if (!globalThis.crypto?.getRandomValues) {
+    throw new Error('No secure random source available (crypto.getRandomValues is missing)');
+  }
+  const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = 0x40 | (bytes[6] & 0x0f);
+  bytes[8] = 0x80 | (bytes[8] & 0x3f);
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}


### PR DESCRIPTION
## Summary
- Add `safeRandomUUID()` in `spa/src/lib/uuid.ts` that prefers `crypto.randomUUID` and falls back to a UUIDv4 built on `crypto.getRandomValues` when the page isn't in a secure context (plain HTTP from a non-loopback host).
- Throw a clear error if even `getRandomValues` is missing — no `Math.random` fallback.
- Replace the lone call site at `spa/src/components/transactions/SplitsEditor.tsx:26`.
- Add vitest coverage for both the primary path and the forced fallback.

## Why
Running `KEA_SERVER_HOST=0.0.0.0 ./kea serve` and opening the SPA from another LAN machine over plain HTTP caused `TypeError: crypto.randomUUID is not a function` when clicking "New transaction". `crypto.randomUUID` is only defined in secure contexts (HTTPS, localhost, 127.0.0.1, file://); `crypto.getRandomValues` is available on plain HTTP and is enough to build a UUIDv4.

## Test plan
- [x] `cd spa && npm run check` — Biome clean on changed files.
- [x] `cd spa && npm test` — 142/142 tests pass (including 3 new tests in `uuid.test.ts`).
- [ ] Manual smoke test: `make build-all && KEA_SERVER_HOST=0.0.0.0 ./kea serve`, then from a different machine on the LAN open `http://<host-ip>:8080`, click "New transaction", confirm no console error and the form opens.

## Out of scope
- HTTPS / TLS termination.
- Switching to a `uuid` npm dependency — a 6-line inline fallback is enough.
- Auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)