### PR TITLE
feat: add monthly balance sparkline to account cards

### DIFF
--- a/internal/api/reports.go
+++ b/internal/api/reports.go
@@ -6,6 +6,8 @@ package api
 import (
 	"net/http"
 	"time"
+
+	"github.com/hance08/kea/internal/model"
 )
 
 func (s *Server) handleIncomeStatement(w http.ResponseWriter, r *http.Request) error {
@@ -73,4 +75,19 @@ func (s *Server) handleNetWorth(w http.ResponseWriter, r *http.Request) error {
 		nw = map[string]int64{}
 	}
 	return writeJSON(w, http.StatusOK, netWorthResponse{At: at, NetWorth: nw})
+}
+
+type balanceHistoryResponse struct {
+	Items []model.AccountMonthlySeries `json:"items"`
+}
+
+func (s *Server) handleBalanceHistory(w http.ResponseWriter, r *http.Request) error {
+	items, err := s.svc.Transaction().GetMonthlyBalanceHistory(r.Context())
+	if err != nil {
+		return err
+	}
+	if items == nil {
+		items = []model.AccountMonthlySeries{}
+	}
+	return writeJSON(w, http.StatusOK, balanceHistoryResponse{Items: items})
 }

--- a/internal/api/reports_test.go
+++ b/internal/api/reports_test.go
@@ -201,3 +201,52 @@ func TestHandleNetWorth_BadAt(t *testing.T) {
 		t.Errorf("status: got %d, want 400", resp.StatusCode)
 	}
 }
+
+func TestHandleBalanceHistory(t *testing.T) {
+	ts, svc := newServerWithStore(t)
+	seedAccount(t, svc, "Assets:Cash", model.AccountTypeAsset, 0)
+	seedAccount(t, svc, "Revenue:Salary", model.AccountTypeRevenue, 0)
+
+	jan1 := time.Date(2026, 1, 5, 12, 0, 0, 0, time.UTC).Unix()
+	feb1 := time.Date(2026, 2, 5, 12, 0, 0, 0, time.UTC).Unix()
+	seedTransaction(t, svc, "Revenue:Salary", "Assets:Cash", 100000, jan1, "pay1", model.TxTypeIncome, model.StatusCleared)
+	seedTransaction(t, svc, "Revenue:Salary", "Assets:Cash", 200000, feb1, "pay2", model.TxTypeIncome, model.StatusCleared)
+
+	resp, err := http.Get(ts.URL + "/api/balances/history")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+
+	var got struct {
+		Items []struct {
+			AccountID int64  `json:"account_id"`
+			Currency  string `json:"currency"`
+			Points    []struct {
+				Month   string `json:"month"`
+				Balance int64  `json:"balance"`
+			} `json:"points"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Only the Asset account should appear; Revenue is excluded.
+	if len(got.Items) != 1 {
+		t.Fatalf("items: got %d, want 1: %+v", len(got.Items), got)
+	}
+	pts := got.Items[0].Points
+	if len(pts) != 2 {
+		t.Fatalf("points: got %d, want 2", len(pts))
+	}
+	if pts[0].Month != "2026-01" || pts[0].Balance != 100000 {
+		t.Errorf("pts[0]: got %+v, want {2026-01 100000}", pts[0])
+	}
+	if pts[1].Month != "2026-02" || pts[1].Balance != 300000 {
+		t.Errorf("pts[1]: got %+v, want {2026-02 300000}", pts[1])
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -34,6 +34,7 @@ func (s *Server) routes() http.Handler {
 		r.Method(http.MethodDelete, "/accounts/{id}", apiHandler(s.handleDeleteAccount))
 		r.Method(http.MethodGet, "/accounts/{id}/balance", apiHandler(s.handleAccountBalance))
 		r.Method(http.MethodGet, "/balances", apiHandler(s.handleListBalances))
+		r.Method(http.MethodGet, "/balances/history", apiHandler(s.handleBalanceHistory))
 		r.Method(http.MethodGet, "/accounts/{id}/unreconciled", apiHandler(s.handleListUnreconciled))
 		r.Method(http.MethodPost, "/accounts/{id}/reconcile/preview", apiHandler(s.handleReconcilePreview))
 		r.Method(http.MethodPost, "/accounts/{id}/reconcile", apiHandler(s.handleReconcileCommit))

--- a/internal/model/balance_history.go
+++ b/internal/model/balance_history.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package model
+
+// MonthlyBalancePoint is one end-of-month balance for an account, in cents,
+// expressed in the account's natural-amount direction.
+type MonthlyBalancePoint struct {
+	Month   string `json:"month"`   // "YYYY-MM" (UTC year-month)
+	Balance int64  `json:"balance"` // cents, natural-amount
+}
+
+// AccountMonthlySeries is the full monthly balance history for one account.
+// The points slice is ordered ascending by month and starts at the account's
+// earliest month with activity (no front-fill of zero months).
+type AccountMonthlySeries struct {
+	AccountID int64                 `json:"account_id"`
+	Currency  string                `json:"currency"`
+	Points    []MonthlyBalancePoint `json:"points"`
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -95,6 +95,13 @@ type TransactionRepository interface {
 	// that dimension). When filter.AccountID is set the query joins on splits.
 	// Results are ordered by timestamp DESC, id DESC.
 	FilterTransactions(ctx context.Context, filter model.TransactionFilter, opts model.ListOptions) (*model.ListResult[*model.Transaction], error)
+
+	// GetMonthlySplitTotalsForAssetsAndLiabilities returns, for every
+	// (account_id, month) with activity on an Asset or Liability account,
+	// the sum of split amounts in that month. Months are UTC "YYYY-MM"
+	// strings derived from transaction timestamps. Ordered by account_id
+	// ASC, month ASC. Used to build per-account monthly balance series.
+	GetMonthlySplitTotalsForAssetsAndLiabilities(ctx context.Context) ([]MonthlySplitTotal, error)
 }
 
 type Repository interface {
@@ -104,4 +111,15 @@ type Repository interface {
 
 type TransactionManager interface {
 	ExecTx(ctx context.Context, fn func(Repository) error) error
+}
+
+// MonthlySplitTotal is one (account, month) bucket of summed split amounts.
+// Amount is stored-sign (not natural-amount); the service layer applies the
+// natural-amount conversion based on AccountType.
+type MonthlySplitTotal struct {
+	AccountID   int64
+	AccountType model.AccountType
+	Currency    string
+	Month       string // "YYYY-MM" UTC
+	Amount      int64  // cents, stored sign, sum within the month
 }

--- a/internal/service/testhelper_test.go
+++ b/internal/service/testhelper_test.go
@@ -311,6 +311,10 @@ type mockTransactionRepo struct {
 	listTxErr          error
 	listTxByAccountErr error
 	filterErr          error
+
+	// monthly history support
+	monthlySplitTotals    []repository.MonthlySplitTotal
+	monthlySplitTotalsErr error
 }
 
 func newMockTransactionRepo() *mockTransactionRepo {
@@ -667,6 +671,13 @@ func (m *mockTransactionRepo) FilterTransactions(_ context.Context, filter model
 		Limit:      opts.Limit,
 		Offset:     opts.Offset,
 	}, nil
+}
+
+func (m *mockTransactionRepo) GetMonthlySplitTotalsForAssetsAndLiabilities(_ context.Context) ([]repository.MonthlySplitTotal, error) {
+	if m.monthlySplitTotalsErr != nil {
+		return nil, m.monthlySplitTotalsErr
+	}
+	return m.monthlySplitTotals, nil
 }
 
 // ──────────────────────────────────────────────

--- a/internal/service/transaction_service.go
+++ b/internal/service/transaction_service.go
@@ -158,3 +158,41 @@ func (ts *TransactionService) GetTransactionHistory(ctx context.Context, account
 
 	return transactions, nil
 }
+
+// GetMonthlyBalanceHistory returns, for every Asset and Liability account
+// with activity, the full monthly end-of-month balance series in the
+// account's natural-amount direction. Accounts with no activity are omitted.
+// Series are ordered by AccountID ASC; points within each series ascend by month.
+func (ts *TransactionService) GetMonthlyBalanceHistory(ctx context.Context) ([]model.AccountMonthlySeries, error) {
+	rows, err := ts.txRepo.GetMonthlySplitTotalsForAssetsAndLiabilities(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get monthly split totals: %w", err)
+	}
+
+	// rows are already ordered by account_id, month ASC.
+	var out []model.AccountMonthlySeries
+	var cur *model.AccountMonthlySeries
+	var running int64
+	for _, r := range rows {
+		if cur == nil || cur.AccountID != r.AccountID {
+			out = append(out, model.AccountMonthlySeries{
+				AccountID: r.AccountID,
+				Currency:  r.Currency,
+				Points:    nil,
+			})
+			cur = &out[len(out)-1]
+			running = 0
+		}
+		running += r.Amount
+		balance := running
+		// Liability: stored is negative when the debt grows, so natural-amount = -stored.
+		if r.AccountType == model.AccountTypeLiability {
+			balance = -balance
+		}
+		cur.Points = append(cur.Points, model.MonthlyBalancePoint{
+			Month:   r.Month,
+			Balance: balance,
+		})
+	}
+	return out, nil
+}

--- a/internal/service/transaction_service.go
+++ b/internal/service/transaction_service.go
@@ -163,6 +163,7 @@ func (ts *TransactionService) GetTransactionHistory(ctx context.Context, account
 // with activity, the full monthly end-of-month balance series in the
 // account's natural-amount direction. Accounts with no activity are omitted.
 // Series are ordered by AccountID ASC; points within each series ascend by month.
+// Accounts whose cumulative balance is zero at every month are also omitted.
 func (ts *TransactionService) GetMonthlyBalanceHistory(ctx context.Context) ([]model.AccountMonthlySeries, error) {
 	rows, err := ts.txRepo.GetMonthlySplitTotalsForAssetsAndLiabilities(ctx)
 	if err != nil {
@@ -171,16 +172,22 @@ func (ts *TransactionService) GetMonthlyBalanceHistory(ctx context.Context) ([]m
 
 	// rows are already ordered by account_id, month ASC.
 	var out []model.AccountMonthlySeries
-	var cur *model.AccountMonthlySeries
+	var cur model.AccountMonthlySeries
 	var running int64
 	for _, r := range rows {
-		if cur == nil || cur.AccountID != r.AccountID {
-			out = append(out, model.AccountMonthlySeries{
+		if cur.AccountID != 0 && cur.AccountID != r.AccountID {
+			// Transitioning to a new account: evaluate the just-completed series.
+			if hasNonZeroBalance(cur.Points) {
+				out = append(out, cur)
+			}
+		}
+		if cur.AccountID != r.AccountID {
+			// Starting a new account.
+			cur = model.AccountMonthlySeries{
 				AccountID: r.AccountID,
 				Currency:  r.Currency,
 				Points:    nil,
-			})
-			cur = &out[len(out)-1]
+			}
 			running = 0
 		}
 		running += r.Amount
@@ -194,5 +201,19 @@ func (ts *TransactionService) GetMonthlyBalanceHistory(ctx context.Context) ([]m
 			Balance: balance,
 		})
 	}
+	// Don't forget the last series.
+	if len(cur.Points) > 0 && hasNonZeroBalance(cur.Points) {
+		out = append(out, cur)
+	}
 	return out, nil
+}
+
+// hasNonZeroBalance reports whether the given points list contains at least one non-zero balance.
+func hasNonZeroBalance(points []model.MonthlyBalancePoint) bool {
+	for _, p := range points {
+		if p.Balance != 0 {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/service/transaction_service_test.go
+++ b/internal/service/transaction_service_test.go
@@ -170,3 +170,34 @@ func TestGetMonthlyBalanceHistory_RepoError(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 }
+
+func TestGetMonthlyBalanceHistory_SkipsAllZeroSeries(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+	accRepo.accountsByID[40] = &model.Account{
+		ID: 40, Name: "Assets:Wash", Type: model.AccountTypeAsset, Currency: "USD",
+	}
+	accRepo.accountsByID[41] = &model.Account{
+		ID: 41, Name: "Assets:Real", Type: model.AccountTypeAsset, Currency: "USD",
+	}
+	txRepo.monthlySplitTotals = []repository.MonthlySplitTotal{
+		// Account 40: every cumulative balance is zero — series should be skipped.
+		{AccountID: 40, AccountType: model.AccountTypeAsset, Currency: "USD", Month: "2024-01", Amount: 0},
+		{AccountID: 40, AccountType: model.AccountTypeAsset, Currency: "USD", Month: "2024-02", Amount: 0},
+		// Account 41: real activity — should appear.
+		{AccountID: 41, AccountType: model.AccountTypeAsset, Currency: "USD", Month: "2024-01", Amount: 5000},
+	}
+
+	got, err := svc.GetMonthlyBalanceHistory(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("series count: got %d, want 1 (account 40 should be skipped): %+v", len(got), got)
+	}
+	if got[0].AccountID != 41 {
+		t.Errorf("AccountID: got %d, want 41", got[0].AccountID)
+	}
+}

--- a/internal/service/transaction_service_test.go
+++ b/internal/service/transaction_service_test.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/hance08/kea/internal/model"
 	"github.com/hance08/kea/internal/repository"
 )
 
@@ -52,5 +54,119 @@ func TestGetTransactionByID_NotFound_WrapsServiceErrNotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "transaction") {
 		t.Errorf("expected 'transaction' in error message, got: %s", err.Error())
+	}
+}
+
+func TestGetMonthlyBalanceHistory_AssetRunningBalance(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+
+	// Asset account id=10
+	accRepo.accountsByID[10] = &model.Account{
+		ID: 10, Name: "Assets:Bank", Type: model.AccountTypeAsset, Currency: "USD",
+	}
+	txRepo.monthlySplitTotals = []repository.MonthlySplitTotal{
+		{AccountID: 10, AccountType: model.AccountTypeAsset, Currency: "USD", Month: "2024-01", Amount: 100000},
+		{AccountID: 10, AccountType: model.AccountTypeAsset, Currency: "USD", Month: "2024-02", Amount: 50000},
+		{AccountID: 10, AccountType: model.AccountTypeAsset, Currency: "USD", Month: "2024-03", Amount: -20000},
+	}
+
+	got, err := svc.GetMonthlyBalanceHistory(context.Background())
+	if err != nil {
+		t.Fatalf("GetMonthlyBalanceHistory: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("series count: got %d, want 1", len(got))
+	}
+	if got[0].AccountID != 10 {
+		t.Errorf("AccountID: got %d, want 10", got[0].AccountID)
+	}
+	if got[0].Currency != "USD" {
+		t.Errorf("Currency: got %q, want USD", got[0].Currency)
+	}
+	want := []model.MonthlyBalancePoint{
+		{Month: "2024-01", Balance: 100000},
+		{Month: "2024-02", Balance: 150000},
+		{Month: "2024-03", Balance: 130000},
+	}
+	if !reflect.DeepEqual(got[0].Points, want) {
+		t.Errorf("Points: got %+v, want %+v", got[0].Points, want)
+	}
+}
+
+func TestGetMonthlyBalanceHistory_LiabilityNaturalSign(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+	accRepo.accountsByID[20] = &model.Account{
+		ID: 20, Name: "Liabilities:Card", Type: model.AccountTypeLiability, Currency: "USD",
+	}
+	txRepo.monthlySplitTotals = []repository.MonthlySplitTotal{
+		// Liability balances are stored negative when the debt grows.
+		{AccountID: 20, AccountType: model.AccountTypeLiability, Currency: "USD", Month: "2024-01", Amount: -50000},
+		{AccountID: 20, AccountType: model.AccountTypeLiability, Currency: "USD", Month: "2024-02", Amount: -30000},
+	}
+
+	got, err := svc.GetMonthlyBalanceHistory(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []model.MonthlyBalancePoint{
+		{Month: "2024-01", Balance: 50000}, // -(-50000)
+		{Month: "2024-02", Balance: 80000}, // -(-50000 + -30000)
+	}
+	if !reflect.DeepEqual(got[0].Points, want) {
+		t.Errorf("Points: got %+v, want %+v", got[0].Points, want)
+	}
+}
+
+func TestGetMonthlyBalanceHistory_SingleMonth(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+	accRepo.accountsByID[30] = &model.Account{
+		ID: 30, Name: "Assets:Cash", Type: model.AccountTypeAsset, Currency: "USD",
+	}
+	txRepo.monthlySplitTotals = []repository.MonthlySplitTotal{
+		{AccountID: 30, AccountType: model.AccountTypeAsset, Currency: "USD", Month: "2024-05", Amount: 1234},
+	}
+	got, err := svc.GetMonthlyBalanceHistory(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 1 || len(got[0].Points) != 1 {
+		t.Fatalf("expected 1 series with 1 point, got %+v", got)
+	}
+	if got[0].Points[0].Balance != 1234 {
+		t.Errorf("Balance: got %d, want 1234", got[0].Points[0].Balance)
+	}
+}
+
+func TestGetMonthlyBalanceHistory_EmptyLedger(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+	txRepo.monthlySplitTotals = nil
+
+	got, err := svc.GetMonthlyBalanceHistory(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty series list, got %+v", got)
+	}
+}
+
+func TestGetMonthlyBalanceHistory_RepoError(t *testing.T) {
+	accRepo := newMockAccountRepo()
+	txRepo := newMockTransactionRepo()
+	svc := newTestTransactionService(accRepo, txRepo)
+	txRepo.monthlySplitTotalsErr = errors.New("boom")
+
+	_, err := svc.GetMonthlyBalanceHistory(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
 }

--- a/internal/store/sqlite_transaction.go
+++ b/internal/store/sqlite_transaction.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/hance08/kea/internal/model"
+	"github.com/hance08/kea/internal/repository"
 	sqlite "github.com/mattn/go-sqlite3"
 )
 
@@ -662,5 +663,46 @@ func (s *Store) FilterTransactions(ctx context.Context, filter model.Transaction
 		items = []*model.Transaction{}
 	}
 	result.Items = items
+	return result, nil
+}
+
+// GetMonthlySplitTotalsForAssetsAndLiabilities returns, for every
+// (account_id, month) with activity on an Asset or Liability account,
+// the sum of split amounts in that month. Months are UTC "YYYY-MM"
+// strings derived from each transaction's Unix timestamp.
+func (s *Store) GetMonthlySplitTotalsForAssetsAndLiabilities(ctx context.Context) ([]repository.MonthlySplitTotal, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	rows, err := s.db.QueryContext(ctx, `
+        SELECT
+            s.account_id,
+            a.type,
+            a.currency,
+            strftime('%Y-%m', t.timestamp, 'unixepoch') AS month,
+            SUM(s.amount) AS total
+        FROM splits s
+        JOIN transactions t ON t.id = s.transaction_id
+        JOIN accounts     a ON a.id = s.account_id
+        WHERE a.type IN ('A', 'L')
+        GROUP BY s.account_id, month
+        ORDER BY s.account_id, month
+    `)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query monthly split totals: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []repository.MonthlySplitTotal
+	for rows.Next() {
+		var r repository.MonthlySplitTotal
+		if err := rows.Scan(&r.AccountID, &r.AccountType, &r.Currency, &r.Month, &r.Amount); err != nil {
+			return nil, fmt.Errorf("failed to scan monthly split total: %w", err)
+		}
+		result = append(result, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows iteration error: %w", err)
+	}
 	return result, nil
 }

--- a/spa/src/components/balances/BalanceCard.tsx
+++ b/spa/src/components/balances/BalanceCard.tsx
@@ -1,13 +1,15 @@
-import { balanceColor } from '@/lib/accounts';
+import { Sparkline } from '@/components/balances/Sparkline';
+import { balanceColor, balanceStrokeColor } from '@/lib/accounts';
 import { cn } from '@/lib/cn';
 import { formatBalanceAbs } from '@/lib/format';
-import type { AccountBalance } from '@/lib/types';
+import type { AccountBalance, BalanceHistoryPoint } from '@/lib/types';
 import { Link } from '@tanstack/react-router';
 
 interface Props {
   row: AccountBalance;
   columnLabel: 'Assets' | 'Liabilities';
   share: number | null;
+  points?: BalanceHistoryPoint[];
 }
 
 // Strip the canonical column-type prefix when present; leave non-canonical
@@ -17,7 +19,7 @@ function stripColumnPrefix(name: string, columnLabel: 'Assets' | 'Liabilities'):
   return name.startsWith(prefix) ? name.slice(prefix.length) : name;
 }
 
-export function BalanceCard({ row, columnLabel, share }: Props) {
+export function BalanceCard({ row, columnLabel, share, points }: Props) {
   const displayName = stripColumnPrefix(row.name, columnLabel);
   const shareWording = columnLabel.toLowerCase(); // 'assets' | 'liabilities'
 
@@ -36,15 +38,25 @@ export function BalanceCard({ row, columnLabel, share }: Props) {
           {row.currency}
         </span>
       </div>
-      <div className="mt-2">
-        <div className={cn('text-lg font-bold tabular-nums', balanceColor(row.type, row.amount))}>
-          {formatBalanceAbs(row.amount)}
-        </div>
-        {share !== null && (
-          <div className="mt-0.5 text-[11px] text-muted-foreground">
-            {share}% of {shareWording}
+      <div className="mt-2 flex items-end justify-between gap-2">
+        <div className="min-w-0">
+          <div className={cn('text-lg font-bold tabular-nums', balanceColor(row.type, row.amount))}>
+            {formatBalanceAbs(row.amount)}
           </div>
-        )}
+          {share !== null && (
+            <div className="mt-0.5 text-[11px] text-muted-foreground">
+              {share}% of {shareWording}
+            </div>
+          )}
+        </div>
+        <div className="shrink-0">
+          {points && points.length >= 2 && (
+            <Sparkline
+              points={points}
+              strokeClassName={balanceStrokeColor(row.type, row.amount)}
+            />
+          )}
+        </div>
       </div>
     </Link>
   );

--- a/spa/src/components/balances/BalanceCard.tsx
+++ b/spa/src/components/balances/BalanceCard.tsx
@@ -51,10 +51,7 @@ export function BalanceCard({ row, columnLabel, share, points }: Props) {
         </div>
         <div className="shrink-0">
           {points && points.length >= 2 && (
-            <Sparkline
-              points={points}
-              strokeClassName={balanceStrokeColor(row.type, row.amount)}
-            />
+            <Sparkline points={points} strokeClassName={balanceStrokeColor(row.type, row.amount)} />
           )}
         </div>
       </div>

--- a/spa/src/components/balances/BalanceCardGrid.tsx
+++ b/spa/src/components/balances/BalanceCardGrid.tsx
@@ -1,14 +1,15 @@
 import { BalanceCard } from '@/components/balances/BalanceCard';
 import { CARDS_PAGE_SIZE } from '@/components/balances/BalanceColumn';
-import type { AccountBalance } from '@/lib/types';
+import type { AccountBalance, BalanceHistoryPoint } from '@/lib/types';
 
 interface Props {
   rows: AccountBalance[]; // already sorted and sliced by the parent
   shares: (number | null)[]; // aligned with rows, same length
   columnLabel: 'Assets' | 'Liabilities';
+  historyByAccount?: Map<number, BalanceHistoryPoint[]>;
 }
 
-export function BalanceCardGrid({ rows, shares, columnLabel }: Props) {
+export function BalanceCardGrid({ rows, shares, columnLabel, historyByAccount }: Props) {
   const placeholderCount = CARDS_PAGE_SIZE - rows.length;
   return (
     <div className="grid grid-cols-2 gap-3 p-3">
@@ -18,6 +19,7 @@ export function BalanceCardGrid({ rows, shares, columnLabel }: Props) {
           row={row}
           columnLabel={columnLabel}
           share={shares[i] ?? null}
+          points={historyByAccount?.get(row.account_id)}
         />
       ))}
       {Array.from({ length: placeholderCount }).map((_, i) => (
@@ -25,7 +27,7 @@ export function BalanceCardGrid({ rows, shares, columnLabel }: Props) {
           // biome-ignore lint/suspicious/noArrayIndexKey: placeholder cards have no identity
           key={`placeholder-${i}`}
           aria-hidden="true"
-          className="h-[88px] rounded-md"
+          className="h-[112px] rounded-md"
         />
       ))}
     </div>

--- a/spa/src/components/balances/BalanceColumn.tsx
+++ b/spa/src/components/balances/BalanceColumn.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { balanceColor } from '@/lib/accounts';
 import { cn } from '@/lib/cn';
 import { formatBalanceAbs } from '@/lib/format';
-import type { AccountBalance } from '@/lib/types';
+import type { AccountBalance, BalanceHistoryPoint } from '@/lib/types';
 
 export const LIST_PAGE_SIZE = 8;
 export const CARDS_PAGE_SIZE = 6;
@@ -30,6 +30,7 @@ interface Props {
   onOffsetChange: (offset: number) => void;
   emptyText: string;
   view: 'list' | 'cards';
+  historyByAccount?: Map<number, BalanceHistoryPoint[]>;
 }
 
 export function BalanceColumn({
@@ -44,6 +45,7 @@ export function BalanceColumn({
   onOffsetChange,
   emptyText,
   view,
+  historyByAccount,
 }: Props) {
   const isEmpty = rows.length === 0;
   const totalType = label === 'Assets' ? 'A' : 'L';
@@ -120,7 +122,12 @@ export function BalanceColumn({
         </>
       ) : (
         <>
-          <BalanceCardGrid rows={rows} shares={shares} columnLabel={label} />
+          <BalanceCardGrid
+            rows={rows}
+            shares={shares}
+            columnLabel={label}
+            historyByAccount={historyByAccount}
+          />
           <div className="px-3 pb-3">
             <Pagination
               total={totalRowCount}

--- a/spa/src/components/balances/Sparkline.tsx
+++ b/spa/src/components/balances/Sparkline.tsx
@@ -1,0 +1,46 @@
+import { cn } from '@/lib/cn';
+import type { BalanceHistoryPoint } from '@/lib/types';
+
+interface Props {
+  points: BalanceHistoryPoint[];
+  strokeClassName: string;
+  className?: string;
+}
+
+const VIEWBOX_W = 100;
+const VIEWBOX_H = 30;
+
+export function Sparkline({ points, strokeClassName, className }: Props) {
+  if (points.length < 2) return null;
+
+  const balances = points.map((p) => p.balance);
+  const min = Math.min(...balances);
+  const max = Math.max(...balances);
+  const range = max - min;
+  const xStep = VIEWBOX_W / (points.length - 1);
+
+  const coords = points
+    .map((p, i) => {
+      const x = i * xStep;
+      const y = range === 0 ? VIEWBOX_H / 2 : VIEWBOX_H - ((p.balance - min) / range) * VIEWBOX_H;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <svg
+      viewBox={`0 0 ${VIEWBOX_W} ${VIEWBOX_H}`}
+      preserveAspectRatio="none"
+      aria-hidden="true"
+      className={cn('h-6 w-20', className)}
+    >
+      <polyline
+        points={coords}
+        fill="none"
+        strokeWidth={1.5}
+        vectorEffect="non-scaling-stroke"
+        className={strokeClassName}
+      />
+    </svg>
+  );
+}

--- a/spa/src/components/balances/Sparkline.tsx
+++ b/spa/src/components/balances/Sparkline.tsx
@@ -9,6 +9,8 @@ interface Props {
 
 const VIEWBOX_W = 100;
 const VIEWBOX_H = 30;
+// Inset the drawing area so the line's stroke isn't clipped at the viewBox edges.
+const PAD = 2;
 
 export function Sparkline({ points, strokeClassName, className }: Props) {
   if (points.length < 2) return null;
@@ -17,12 +19,17 @@ export function Sparkline({ points, strokeClassName, className }: Props) {
   const min = Math.min(...balances);
   const max = Math.max(...balances);
   const range = max - min;
-  const xStep = VIEWBOX_W / (points.length - 1);
+  const drawW = VIEWBOX_W - PAD * 2;
+  const drawH = VIEWBOX_H - PAD * 2;
+  const xStep = drawW / (points.length - 1);
 
   const coords = points
     .map((p, i) => {
-      const x = i * xStep;
-      const y = range === 0 ? VIEWBOX_H / 2 : VIEWBOX_H - ((p.balance - min) / range) * VIEWBOX_H;
+      const x = PAD + i * xStep;
+      const y =
+        range === 0
+          ? VIEWBOX_H / 2
+          : PAD + drawH - ((p.balance - min) / range) * drawH;
       return `${x},${y}`;
     })
     .join(' ');

--- a/spa/src/lib/accounts.ts
+++ b/spa/src/lib/accounts.ts
@@ -121,6 +121,16 @@ export function balanceColor(type: AccountType, amount: number): string {
   return '';
 }
 
+// Same rule as balanceColor, but returns an SVG stroke-* Tailwind class for
+// use with the Sparkline component. Zero amount stays neutral (no stroke
+// override; caller may default to a muted color).
+export function balanceStrokeColor(type: AccountType, amount: number): string {
+  const inverted = type === 'R' || type === 'E';
+  if (amount > 0) return inverted ? 'stroke-red-600' : 'stroke-green-600';
+  if (amount < 0) return inverted ? 'stroke-green-600' : 'stroke-red-600';
+  return 'stroke-muted-foreground';
+}
+
 export function searchAccounts(query: string): Promise<ListResult<Account>> {
   return apiFetch<ListResult<Account>>(`/api/accounts${buildQuery({ q: query, limit: 20 })}`);
 }

--- a/spa/src/lib/api.ts
+++ b/spa/src/lib/api.ts
@@ -1,5 +1,6 @@
 import type {
   AccountBalance,
+  BalanceHistoryResponse,
   LedgerInfo,
   LedgerListResponse,
   ListResult,
@@ -38,6 +39,10 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
 
 export function getBalances(): Promise<ListResult<AccountBalance>> {
   return apiFetch<ListResult<AccountBalance>>('/api/balances');
+}
+
+export function getBalanceHistory(): Promise<BalanceHistoryResponse> {
+  return apiFetch<BalanceHistoryResponse>('/api/balances/history');
 }
 
 export function getConfig(): Promise<ServerConfig> {

--- a/spa/src/lib/types.ts
+++ b/spa/src/lib/types.ts
@@ -133,3 +133,18 @@ export interface BalanceResponse {
   amount: number;
   currency: string;
 }
+
+export interface BalanceHistoryPoint {
+  month: string;   // "YYYY-MM"
+  balance: number; // cents, natural-amount
+}
+
+export interface AccountBalanceHistory {
+  account_id: number;
+  currency: string;
+  points: BalanceHistoryPoint[];
+}
+
+export interface BalanceHistoryResponse {
+  items: AccountBalanceHistory[];
+}

--- a/spa/src/lib/types.ts
+++ b/spa/src/lib/types.ts
@@ -135,7 +135,7 @@ export interface BalanceResponse {
 }
 
 export interface BalanceHistoryPoint {
-  month: string;   // "YYYY-MM"
+  month: string; // "YYYY-MM"
   balance: number; // cents, natural-amount
 }
 

--- a/spa/src/routes/balances.tsx
+++ b/spa/src/routes/balances.tsx
@@ -5,11 +5,11 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { naturalAmount } from '@/lib/accounts';
-import { getBalances } from '@/lib/api';
+import { getBalanceHistory, getBalances } from '@/lib/api';
 import { summarizeBalances } from '@/lib/balances';
 import { type BalancesSearch, parseBalancesSearch } from '@/lib/balances-search-params';
 import { useServerConfig } from '@/lib/server-config';
-import type { AccountBalance } from '@/lib/types';
+import type { AccountBalance, BalanceHistoryPoint } from '@/lib/types';
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useMemo } from 'react';
@@ -43,6 +43,21 @@ function BalancesPage() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: '/balances' });
   const query = useQuery({ queryKey: ['balances'], queryFn: getBalances });
+
+  const historyQuery = useQuery({
+    queryKey: ['balance-history'],
+    queryFn: getBalanceHistory,
+  });
+
+  const historyByAccount = useMemo(() => {
+    const m = new Map<number, BalanceHistoryPoint[]>();
+    if (historyQuery.data) {
+      for (const s of historyQuery.data.items) {
+        m.set(s.account_id, s.points);
+      }
+    }
+    return m;
+  }, [historyQuery.data]);
 
   const toggleSort = (side: 'a' | 'l') => {
     const key = side === 'a' ? 'a_sort' : 'l_sort';
@@ -182,6 +197,7 @@ function BalancesPage() {
           onOffsetChange={(off) => setOffset('a', off)}
           emptyText="No assets"
           view={search.view}
+          historyByAccount={historyByAccount}
         />
         <BalanceColumn
           label="Liabilities"
@@ -195,6 +211,7 @@ function BalancesPage() {
           onOffsetChange={(off) => setOffset('l', off)}
           emptyText="No liabilities"
           view={search.view}
+          historyByAccount={historyByAccount}
         />
       </div>
     </div>

--- a/spa/src/test/balances.test.tsx
+++ b/spa/src/test/balances.test.tsx
@@ -59,6 +59,22 @@ beforeEach(() => {
           }),
         );
       }
+      if (url === '/api/balances/history') {
+        return Promise.resolve(
+          okResponse({
+            items: [
+              {
+                account_id: 1,
+                currency: 'USD',
+                points: [
+                  { month: '2024-01', balance: 100000 },
+                  { month: '2024-02', balance: 125000 },
+                ],
+              },
+            ],
+          }),
+        );
+      }
       throw new Error(`unexpected fetch: ${url}`);
     }),
   );

--- a/spa/src/test/sparkline.test.tsx
+++ b/spa/src/test/sparkline.test.tsx
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { Sparkline } from '@/components/balances/Sparkline';
+
+test('renders nothing when fewer than 2 points', () => {
+  const { container } = render(
+    <Sparkline points={[{ month: '2024-01', balance: 100 }]} strokeClassName="stroke-green-600" />,
+  );
+  expect(container.querySelector('svg')).toBeNull();
+});
+
+test('renders a polyline when given >= 2 points', () => {
+  const { container } = render(
+    <Sparkline
+      points={[
+        { month: '2024-01', balance: 100 },
+        { month: '2024-02', balance: 200 },
+      ]}
+      strokeClassName="stroke-green-600"
+    />,
+  );
+  const line = container.querySelector('polyline');
+  expect(line).not.toBeNull();
+  expect(line?.getAttribute('class')).toContain('stroke-green-600');
+});
+
+test('flat history renders a horizontal line at vertical center', () => {
+  const { container } = render(
+    <Sparkline
+      points={[
+        { month: '2024-01', balance: 500 },
+        { month: '2024-02', balance: 500 },
+        { month: '2024-03', balance: 500 },
+      ]}
+      strokeClassName="stroke-green-600"
+    />,
+  );
+  const line = container.querySelector('polyline');
+  // viewBox is 0 0 100 30 → vertical center y = 15.
+  const points = line?.getAttribute('points') ?? '';
+  const ys = points.split(' ').map((p) => Number(p.split(',')[1]));
+  for (const y of ys) {
+    expect(y).toBeCloseTo(15);
+  }
+});
+
+test('scales points to the line min/max', () => {
+  const { container } = render(
+    <Sparkline
+      points={[
+        { month: '2024-01', balance: 0 },
+        { month: '2024-02', balance: 100 },
+      ]}
+      strokeClassName="stroke-green-600"
+    />,
+  );
+  // 2 points → x = 0 and 100. Min balance maps to y=30 (bottom), max to y=0 (top).
+  const points = container.querySelector('polyline')?.getAttribute('points') ?? '';
+  expect(points).toBe('0,30 100,0');
+});

--- a/spa/src/test/sparkline.test.tsx
+++ b/spa/src/test/sparkline.test.tsx
@@ -54,7 +54,7 @@ test('scales points to the line min/max', () => {
       strokeClassName="stroke-green-600"
     />,
   );
-  // 2 points → x = 0 and 100. Min balance maps to y=30 (bottom), max to y=0 (top).
+  // viewBox 0 0 100 30, PAD=2 → x spans 2→98, y spans 2 (top, max) → 28 (bottom, min).
   const points = container.querySelector('polyline')?.getAttribute('points') ?? '';
-  expect(points).toBe('0,30 100,0');
+  expect(points).toBe('2,28 98,2');
 });

--- a/spa/src/test/sparkline.test.tsx
+++ b/spa/src/test/sparkline.test.tsx
@@ -1,6 +1,6 @@
+import { Sparkline } from '@/components/balances/Sparkline';
 import { render } from '@testing-library/react';
 import { expect, test } from 'vitest';
-import { Sparkline } from '@/components/balances/Sparkline';
 
 test('renders nothing when fewer than 2 points', () => {
   const { container } = render(


### PR DESCRIPTION
## Summary

- Adds a small line chart (sparkline) to the bottom-right of each card in the **cards view** on `/balances`, showing the account's full balance history at monthly granularity.
- New batched server endpoint `GET /api/balances/history` returns end-of-month balances per Asset/Liability account in one call.
- Card body grows ~88px → ~112px to host the chart; list view is unchanged.

## Design choices

- **Monthly granularity, full history** — at sparkline size the curve shape is what matters; monthly saturates the visible resolution.
- **Y-axis = each line's own min/max** — sparkline shows shape, not absolute value; otherwise low-balance accounts would look like flat lines next to a big-balance one.
- **Hand-rolled SVG**, no chart library — the visual is ~80×24px with no axes/tooltips/interactivity, so a 30–80 KB chart dep wasn't justified.
- **Independent history query** — the page renders on the existing `/api/balances` call; if `/api/balances/history` fails or is slow, cards just render without sparklines (no error UI).
- **Stroke color** mirrors the amount color via a new `balanceStrokeColor` helper.
- **All-zero series omitted** — accounts whose cumulative monthly balance is zero at every month (e.g., recurring wash transactions) are dropped from the response.

## Architecture

```
splits + transactions + accounts
        │ (one SQL pass, GROUP BY account_id, %Y-%m UTC)
        ▼
TransactionRepository.GetMonthlySplitTotalsForAssetsAndLiabilities
        │
        ▼
TransactionService.GetMonthlyBalanceHistory  (running cum-sum + natural-amount sign + skip all-zero)
        │
        ▼
GET /api/balances/history  →  { items: [{ account_id, currency, points: [{ month, balance }] }] }
        │
        ▼
balances.tsx: useQuery → Map<account_id, points[]>
        │
        ▼
BalanceColumn → BalanceCardGrid → BalanceCard → <Sparkline points={…} />
```

## Test plan

- [x] `go test ./...` — service unit tests (6 cases including liability sign, single-month, empty ledger, repo error, skip-all-zero) and a handler integration test (asserts Revenue is excluded) all pass.
- [x] `cd spa && npm test` — Sparkline unit tests (4) cover null-render for <2 points, polyline rendering with stroke class, flat-line at vertical center, exact scaled coords; full SPA suite is 146 / 146 green.
- [x] `npx tsc --noEmit` clean; `npx biome check` clean on changed files.
- [x] Manual smoke: cards view renders sparklines bottom-right, line stays inside the SVG bounds (no edge clipping), color matches the amount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)