### PR TITLE
feat(spa): add Reports page (5 routes + shared components)

### DIFF
--- a/internal/web/dist/index.html
+++ b/internal/web/dist/index.html
@@ -1,14 +1,17 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <title>kea — SPA not built</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>kea</title>
-    <script type="module" crossorigin src="/assets/index-U8DE_5wA.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DjK2yyTj.css">
+    <style>
+      body { font-family: system-ui, sans-serif; max-width: 40rem; margin: 4rem auto; padding: 0 1rem; color: #222; }
+      code { background: #f4f4f4; padding: 0.15rem 0.35rem; border-radius: 3px; }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <h1>kea — SPA not built</h1>
+    <p>This is the placeholder shell that ships with the Go binary when the SPA has not been built.</p>
+    <p>Run <code>make spa-build</code> (or <code>make build-all</code>) to produce the real SPA bundle.</p>
   </body>
 </html>

--- a/internal/web/dist/index.html
+++ b/internal/web/dist/index.html
@@ -1,17 +1,14 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>kea — SPA not built</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <style>
-      body { font-family: system-ui, sans-serif; max-width: 40rem; margin: 4rem auto; padding: 0 1rem; color: #222; }
-      code { background: #f4f4f4; padding: 0.15rem 0.35rem; border-radius: 3px; }
-    </style>
+    <title>kea</title>
+    <script type="module" crossorigin src="/assets/index-U8DE_5wA.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DjK2yyTj.css">
   </head>
   <body>
-    <h1>kea — SPA not built</h1>
-    <p>This is the placeholder shell that ships with the Go binary when the SPA has not been built.</p>
-    <p>Run <code>make spa-build</code> (or <code>make build-all</code>) to produce the real SPA bundle.</p>
+    <div id="root"></div>
   </body>
 </html>

--- a/spa/src/components/NetWorthCard.tsx
+++ b/spa/src/components/NetWorthCard.tsx
@@ -1,5 +1,5 @@
-import { Card, CardContent } from "@/components/ui/card";
-import { formatCents } from "@/lib/format";
+import { Card, CardContent } from '@/components/ui/card';
+import { formatCents } from '@/lib/format';
 
 interface Props {
   netWorth: number;
@@ -11,16 +11,13 @@ export function NetWorthCard({ netWorth, currency, excludedCount }: Props) {
   return (
     <Card className="mb-4 bg-gradient-to-br from-blue-700 to-blue-500 text-white">
       <CardContent className="p-6">
-        <div className="text-xs uppercase tracking-wider opacity-80">
-          Net Worth
-        </div>
+        <div className="text-xs uppercase tracking-wider opacity-80">Net Worth</div>
         <div className="mt-1 text-4xl font-extrabold tabular-nums">
           {formatCents(netWorth, currency)}
         </div>
         {excludedCount > 0 && (
           <div className="mt-3 text-xs opacity-80">
-            {excludedCount} account{excludedCount === 1 ? "" : "s"} in other
-            currencies not included
+            {excludedCount} account{excludedCount === 1 ? '' : 's'} in other currencies not included
           </div>
         )}
       </CardContent>

--- a/spa/src/components/Sidebar.tsx
+++ b/spa/src/components/Sidebar.tsx
@@ -5,13 +5,14 @@ import { Link, useRouterState } from '@tanstack/react-router';
 interface NavItem {
   label: string;
   to?: string;
+  prefix?: boolean; // when true, isActive matches any pathname starting with `to`
 }
 
 const NAV: NavItem[] = [
   { label: 'Balances', to: '/balances' },
   { label: 'Accounts', to: '/accounts' },
   { label: 'Transactions', to: '/transactions' },
-  { label: 'Reports', to: '/reports' },
+  { label: 'Reports', to: '/reports', prefix: true },
   { label: 'Reconcile' },
 ];
 
@@ -35,7 +36,9 @@ export function Sidebar() {
               </li>
             );
           }
-          const isActive = location.pathname === item.to;
+          const isActive = item.prefix
+            ? location.pathname === item.to || location.pathname.startsWith(`${item.to}/`)
+            : location.pathname === item.to;
           return (
             <li key={item.label}>
               <Link

--- a/spa/src/components/Sidebar.tsx
+++ b/spa/src/components/Sidebar.tsx
@@ -11,7 +11,7 @@ const NAV: NavItem[] = [
   { label: 'Balances', to: '/balances' },
   { label: 'Accounts', to: '/accounts' },
   { label: 'Transactions', to: '/transactions' },
-  { label: 'Reports' },
+  { label: 'Reports', to: '/reports' },
   { label: 'Reconcile' },
 ];
 

--- a/spa/src/components/balances/Sparkline.tsx
+++ b/spa/src/components/balances/Sparkline.tsx
@@ -26,10 +26,7 @@ export function Sparkline({ points, strokeClassName, className }: Props) {
   const coords = points
     .map((p, i) => {
       const x = PAD + i * xStep;
-      const y =
-        range === 0
-          ? VIEWBOX_H / 2
-          : PAD + drawH - ((p.balance - min) / range) * drawH;
+      const y = range === 0 ? VIEWBOX_H / 2 : PAD + drawH - ((p.balance - min) / range) * drawH;
       return `${x},${y}`;
     })
     .join(' ');

--- a/spa/src/components/reports/AsOfPicker.tsx
+++ b/spa/src/components/reports/AsOfPicker.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/ui/button';
 
 interface Props {
-  label: string;       // "As of" or "At"
+  label: string; // "As of" or "At"
   value: number | undefined; // Unix seconds; undefined = now
   onChange: (next: number | undefined) => void;
 }

--- a/spa/src/components/reports/AsOfPicker.tsx
+++ b/spa/src/components/reports/AsOfPicker.tsx
@@ -1,0 +1,46 @@
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  label: string;       // "As of" or "At"
+  value: number | undefined; // Unix seconds; undefined = now
+  onChange: (next: number | undefined) => void;
+}
+
+function unixToInputDate(unix: number): string {
+  const d = new Date(unix * 1000);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function inputDateToUnix(s: string): number | undefined {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return undefined;
+  const [y, m, d] = s.split('-').map(Number);
+  // Treat the picked date as end-of-day UTC so the snapshot includes the full day.
+  return Math.floor(Date.UTC(y, m - 1, d, 23, 59, 59) / 1000);
+}
+
+export function AsOfPicker({ label, value, onChange }: Props) {
+  return (
+    <div className="mb-4 flex items-center gap-2 text-sm">
+      <label className="flex items-center gap-2">
+        <span className="font-medium">{label}</span>
+        <input
+          type="date"
+          aria-label={label}
+          className="rounded border bg-background px-2 py-1"
+          value={value === undefined ? '' : unixToInputDate(value)}
+          onChange={(e) => onChange(inputDateToUnix(e.target.value))}
+        />
+      </label>
+      {value === undefined ? (
+        <span className="text-muted-foreground">Now</span>
+      ) : (
+        <Button size="sm" variant="ghost" onClick={() => onChange(undefined)}>
+          Now
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/spa/src/components/reports/CurrencyFooter.tsx
+++ b/spa/src/components/reports/CurrencyFooter.tsx
@@ -1,0 +1,35 @@
+import { formatCents } from '@/lib/format';
+
+export interface CurrencyEntry {
+  label: string;
+  byCurrency: Record<string, number>;
+}
+
+interface Props {
+  defaultCurrency: string;
+  entries: CurrencyEntry[];
+}
+
+export function CurrencyFooter({ defaultCurrency, entries }: Props) {
+  const lines = entries
+    .map((entry) => {
+      const others = Object.entries(entry.byCurrency).filter(([cur]) => cur !== defaultCurrency);
+      if (others.length === 0) return null;
+      const parts = others.map(([cur, amt]) => formatCents(amt, cur)).join(', ');
+      return { label: entry.label, parts };
+    })
+    .filter((x): x is { label: string; parts: string } => x !== null);
+
+  if (lines.length === 0) return null;
+
+  return (
+    <div className="mt-3 text-xs text-muted-foreground">
+      <div className="font-medium">Also in this report:</div>
+      {lines.map((line) => (
+        <div key={line.label} data-testid="cur-footer-line">
+          {line.label}: {line.parts}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/spa/src/components/reports/KpiCard.tsx
+++ b/spa/src/components/reports/KpiCard.tsx
@@ -1,0 +1,37 @@
+import { cn } from '@/lib/cn';
+import { formatCents } from '@/lib/format';
+
+export type KpiVariant = 'green' | 'red' | 'neutral';
+
+interface Props {
+  label: string;
+  amount: number;
+  currency: string;
+  variant: KpiVariant;
+  subLine?: string;
+}
+
+const VARIANT_CLASS: Record<KpiVariant, string> = {
+  green: 'text-green-700 dark:text-green-400',
+  red: 'text-red-700 dark:text-red-400',
+  neutral: 'text-foreground',
+};
+
+export function KpiCard({ label, amount, currency, variant, subLine }: Props) {
+  return (
+    <div className="rounded-md border bg-card p-4">
+      <div className="text-xs uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div
+        data-testid="kpi-amount"
+        className={cn('mt-1 text-2xl font-semibold', VARIANT_CLASS[variant])}
+      >
+        {formatCents(amount, currency)}
+      </div>
+      {subLine && (
+        <div data-testid="kpi-subline" className="mt-1 text-xs text-muted-foreground">
+          {subLine}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/spa/src/components/reports/PeriodPicker.tsx
+++ b/spa/src/components/reports/PeriodPicker.tsx
@@ -55,9 +55,7 @@ export function PeriodPicker({ value, onChange, label }: Props) {
               type="date"
               className="rounded border bg-background px-2 py-1"
               value={value.to ?? ''}
-              onChange={(e) =>
-                onChange({ range: 'custom', from: value.from, to: e.target.value })
-              }
+              onChange={(e) => onChange({ range: 'custom', from: value.from, to: e.target.value })}
             />
           </label>
         </div>

--- a/spa/src/components/reports/PeriodPicker.tsx
+++ b/spa/src/components/reports/PeriodPicker.tsx
@@ -1,0 +1,67 @@
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/cn';
+import type { PeriodRange } from '@/lib/period';
+import type { PeriodSearchParams } from '@/lib/reports-search-params';
+
+const CHIPS: { range: PeriodRange; label: string }[] = [
+  { range: 'this-month', label: 'This month' },
+  { range: 'last-month', label: 'Last month' },
+  { range: 'ytd', label: 'YTD' },
+  { range: 'last-12mo', label: 'Last 12 months' },
+  { range: 'custom', label: 'Custom…' },
+];
+
+interface Props {
+  value: PeriodSearchParams;
+  onChange: (next: Partial<PeriodSearchParams>) => void;
+  label: string;
+}
+
+export function PeriodPicker({ value, onChange, label }: Props) {
+  return (
+    <div className="mb-4 space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="mr-2 text-sm font-medium">{label}</span>
+        {CHIPS.map((chip) => {
+          const active = value.range === chip.range;
+          return (
+            <Button
+              key={chip.range}
+              size="sm"
+              variant={active ? 'default' : 'outline'}
+              aria-pressed={active}
+              onClick={() => onChange({ range: chip.range })}
+              className={cn(!active && 'text-muted-foreground')}
+            >
+              {chip.label}
+            </Button>
+          );
+        })}
+      </div>
+      {value.range === 'custom' && (
+        <div className="flex items-center gap-2 text-sm">
+          <label className="flex items-center gap-1">
+            <span>From</span>
+            <input
+              type="date"
+              className="rounded border bg-background px-2 py-1"
+              value={value.from ?? ''}
+              onChange={(e) => onChange({ range: 'custom', from: e.target.value, to: value.to })}
+            />
+          </label>
+          <label className="flex items-center gap-1">
+            <span>To</span>
+            <input
+              type="date"
+              className="rounded border bg-background px-2 py-1"
+              value={value.to ?? ''}
+              onChange={(e) =>
+                onChange({ range: 'custom', from: value.from, to: e.target.value })
+              }
+            />
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/spa/src/components/reports/ProportionBar.tsx
+++ b/spa/src/components/reports/ProportionBar.tsx
@@ -1,0 +1,70 @@
+import { Button } from '@/components/ui/button';
+import { formatCents } from '@/lib/format';
+import type { ReportRow } from '@/lib/types';
+import { useState } from 'react';
+
+interface Props {
+  rows: ReportRow[];
+  total: number; // same currency as rows; may be negative or zero
+  currency: string;
+  // If set, only the first `limit` rows render until the user expands.
+  // Omit (or undefined) to render everything.
+  limit?: number;
+  variant?: 'income' | 'expense';
+}
+
+const COLOR: Record<NonNullable<Props['variant']>, string> = {
+  income: 'bg-green-600',
+  expense: 'bg-red-600',
+};
+
+export function ProportionBar({ rows, total, currency, limit, variant = 'income' }: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (rows.length === 0) {
+    return <p className="text-sm text-muted-foreground">No data to display.</p>;
+  }
+
+  // When total is positive (income/asset side), scale bars relative to the
+  // largest row so the biggest item always fills 100%.  When total is
+  // negative (expense side), scale against |total| so each bar shows its
+  // share of the overall pool.
+  const denom =
+    total >= 0
+      ? Math.max(...rows.map((r) => Math.abs(r.amount)))
+      : Math.abs(total);
+  const shown = limit && !expanded ? rows.slice(0, limit) : rows;
+  const hiddenCount = rows.length - shown.length;
+
+  return (
+    <div className="space-y-2">
+      {shown.map((row) => {
+        const pct = denom === 0 ? 0 : (Math.abs(row.amount) / denom) * 100;
+        return (
+          <div key={row.account_name} data-testid="prop-bar" className="text-sm">
+            <div className="flex items-baseline justify-between gap-2">
+              <span className="truncate" title={row.account_name}>
+                {row.account_name}
+              </span>
+              <span className="font-mono text-xs tabular-nums">
+                {formatCents(row.amount, currency)}
+              </span>
+            </div>
+            <div className="mt-1 h-2 w-full overflow-hidden rounded bg-muted">
+              <div
+                data-testid="bar-fill"
+                className={COLOR[variant]}
+                style={{ width: `${pct}%`, height: '100%' }}
+              />
+            </div>
+          </div>
+        );
+      })}
+      {hiddenCount > 0 && (
+        <Button variant="ghost" size="sm" onClick={() => setExpanded(true)}>
+          + {hiddenCount} more
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/spa/src/components/reports/ProportionBar.tsx
+++ b/spa/src/components/reports/ProportionBar.tsx
@@ -25,14 +25,7 @@ export function ProportionBar({ rows, total, currency, limit, variant = 'income'
     return <p className="text-sm text-muted-foreground">No data to display.</p>;
   }
 
-  // When total is positive (income/asset side), scale bars relative to the
-  // largest row so the biggest item always fills 100%.  When total is
-  // negative (expense side), scale against |total| so each bar shows its
-  // share of the overall pool.
-  const denom =
-    total >= 0
-      ? Math.max(...rows.map((r) => Math.abs(r.amount)))
-      : Math.abs(total);
+  const denom = Math.abs(total);
   const shown = limit && !expanded ? rows.slice(0, limit) : rows;
   const hiddenCount = rows.length - shown.length;
 

--- a/spa/src/components/reports/ReportRowTable.tsx
+++ b/spa/src/components/reports/ReportRowTable.tsx
@@ -1,4 +1,5 @@
 import { formatCents } from '@/lib/format';
+import { DEFAULT_TRANSACTIONS_LIMIT } from '@/lib/transactions-search-params';
 import type { ReportRow } from '@/lib/types';
 import { Link } from '@tanstack/react-router';
 
@@ -40,6 +41,7 @@ export function ReportRowTable({ rows, currency, nameToId, period }: Props) {
                     <Link
                       to="/accounts/$id"
                       params={{ id: String(id) }}
+                      search={{ include_hidden: false, show_parents: false, limit: 10, offset: 0 }}
                       className="hover:underline"
                     >
                       {linkContent}
@@ -54,6 +56,8 @@ export function ReportRowTable({ rows, currency, nameToId, period }: Props) {
                       ...(id !== undefined ? { account_id: id } : {}),
                       start_time: period.startUnix,
                       end_time: period.endUnix,
+                      limit: DEFAULT_TRANSACTIONS_LIMIT,
+                      offset: 0,
                     }}
                     className="hover:underline"
                   >

--- a/spa/src/components/reports/ReportRowTable.tsx
+++ b/spa/src/components/reports/ReportRowTable.tsx
@@ -1,0 +1,75 @@
+import { formatCents } from '@/lib/format';
+import type { ReportRow } from '@/lib/types';
+import { Link } from '@tanstack/react-router';
+
+interface Props {
+  rows: ReportRow[];
+  currency: string;
+  nameToId: Map<string, number>;
+  // null → link to /accounts/{id} (Balance Sheet); otherwise drill into Transactions
+  period: { startUnix: number; endUnix: number } | null;
+}
+
+export function ReportRowTable({ rows, currency, nameToId, period }: Props) {
+  if (rows.length === 0) {
+    return <p className="text-sm text-muted-foreground">No rows.</p>;
+  }
+  return (
+    <table className="w-full text-sm">
+      <thead className="text-xs uppercase text-muted-foreground">
+        <tr>
+          <th className="py-1 text-left font-medium">Account</th>
+          <th className="py-1 text-left font-medium">Offset</th>
+          <th className="py-1 text-right font-medium">Amount</th>
+          <th className="py-1 text-right font-medium">Tx</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => {
+          const id = nameToId.get(row.account_name);
+          const linkContent = (
+            <span className="truncate" title={row.account_name}>
+              {row.account_name}
+            </span>
+          );
+          return (
+            <tr key={row.account_name} className="border-t hover:bg-muted/40">
+              <td className="py-1.5 max-w-[260px]">
+                {period === null ? (
+                  id !== undefined ? (
+                    <Link
+                      to="/accounts/$id"
+                      params={{ id: String(id) }}
+                      className="hover:underline"
+                    >
+                      {linkContent}
+                    </Link>
+                  ) : (
+                    linkContent
+                  )
+                ) : (
+                  <Link
+                    to="/transactions"
+                    search={{
+                      ...(id !== undefined ? { account_id: id } : {}),
+                      start_time: period.startUnix,
+                      end_time: period.endUnix,
+                    }}
+                    className="hover:underline"
+                  >
+                    {linkContent}
+                  </Link>
+                )}
+              </td>
+              <td className="py-1.5 text-muted-foreground">{row.offset_account}</td>
+              <td className="py-1.5 text-right font-mono tabular-nums">
+                {formatCents(row.amount, currency)}
+              </td>
+              <td className="py-1.5 text-right text-muted-foreground">{row.tx_count}</td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/spa/src/components/reports/TabNav.tsx
+++ b/spa/src/components/reports/TabNav.tsx
@@ -1,0 +1,36 @@
+import { cn } from '@/lib/cn';
+import { Link, useRouterState } from '@tanstack/react-router';
+
+const TABS = [
+  { to: '/reports/income-statement', label: 'Income Statement' },
+  { to: '/reports/income-breakdown', label: 'Income Breakdown' },
+  { to: '/reports/expense-breakdown', label: 'Expense Breakdown' },
+  { to: '/reports/balance-sheet', label: 'Balance Sheet' },
+  { to: '/reports/net-worth', label: 'Net Worth' },
+] as const;
+
+export function TabNav() {
+  const { location } = useRouterState();
+  return (
+    <nav aria-label="Report types" className="mb-4 flex flex-wrap gap-1 border-b">
+      {TABS.map((tab) => {
+        const isActive = location.pathname === tab.to;
+        return (
+          <Link
+            key={tab.to}
+            to={tab.to as string}
+            aria-current={isActive ? 'page' : undefined}
+            className={cn(
+              '-mb-px border-b-2 px-3 py-2 text-sm transition-colors',
+              isActive
+                ? 'border-primary font-medium text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/spa/src/components/transactions/FilterBar.tsx
+++ b/spa/src/components/transactions/FilterBar.tsx
@@ -1,20 +1,20 @@
-import { AccountCombobox } from "@/components/transactions/AccountCombobox";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import type { TransactionsSearch } from "@/lib/transactions-search-params";
-import type { TransactionStatus, TransactionType } from "@/lib/types";
+import { AccountCombobox } from '@/components/transactions/AccountCombobox';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { TransactionsSearch } from '@/lib/transactions-search-params';
+import type { TransactionStatus, TransactionType } from '@/lib/types';
 
 const TYPES: TransactionType[] = [
-  "Expense",
-  "Income",
-  "Transfer",
-  "Opening",
-  "Deposit",
-  "Withdrawal",
-  "Other",
+  'Expense',
+  'Income',
+  'Transfer',
+  'Opening',
+  'Deposit',
+  'Withdrawal',
+  'Other',
 ];
-const STATUSES: TransactionStatus[] = ["Pending", "Cleared", "Reconciled"];
+const STATUSES: TransactionStatus[] = ['Pending', 'Cleared', 'Reconciled'];
 
 interface Props {
   search: TransactionsSearch;
@@ -23,13 +23,13 @@ interface Props {
 }
 
 function unixToDate(u?: number): string {
-  if (!u) return "";
+  if (!u) return '';
   return new Date(u * 1000).toISOString().slice(0, 10);
 }
 
 function dateToUnix(d: string, endOfDay: boolean): number | undefined {
   if (!d) return undefined;
-  const ms = new Date(`${d}T${endOfDay ? "23:59:59" : "00:00:00"}Z`).getTime();
+  const ms = new Date(`${d}T${endOfDay ? '23:59:59' : '00:00:00'}Z`).getTime();
   return Number.isNaN(ms) ? undefined : Math.floor(ms / 1000);
 }
 
@@ -40,7 +40,7 @@ export function FilterBar({ search, onChange, onClear }: Props) {
     search.status !== undefined ||
     search.start_time !== undefined ||
     search.end_time !== undefined ||
-    (search.description !== undefined && search.description !== "");
+    (search.description !== undefined && search.description !== '');
 
   return (
     // Use 6 columns only at xl (>=1280px) where the inputs comfortably
@@ -62,12 +62,10 @@ export function FilterBar({ search, onChange, onClear }: Props) {
         <select
           id="f-type"
           className="flex h-10 w-full rounded-md border border-input bg-background px-2 text-sm"
-          value={search.type ?? ""}
+          value={search.type ?? ''}
           onChange={(e) =>
             onChange({
-              type: (e.target.value || undefined) as
-                | TransactionType
-                | undefined,
+              type: (e.target.value || undefined) as TransactionType | undefined,
             })
           }
         >
@@ -85,12 +83,10 @@ export function FilterBar({ search, onChange, onClear }: Props) {
         <select
           id="f-status"
           className="flex h-10 w-full rounded-md border border-input bg-background px-2 text-sm"
-          value={search.status ?? ""}
+          value={search.status ?? ''}
           onChange={(e) =>
             onChange({
-              status: (e.target.value || undefined) as
-                | TransactionStatus
-                | undefined,
+              status: (e.target.value || undefined) as TransactionStatus | undefined,
             })
           }
         >
@@ -109,9 +105,7 @@ export function FilterBar({ search, onChange, onClear }: Props) {
           id="f-from"
           type="date"
           value={unixToDate(search.start_time)}
-          onChange={(e) =>
-            onChange({ start_time: dateToUnix(e.target.value, false) })
-          }
+          onChange={(e) => onChange({ start_time: dateToUnix(e.target.value, false) })}
         />
       </div>
 
@@ -121,9 +115,7 @@ export function FilterBar({ search, onChange, onClear }: Props) {
           id="f-to"
           type="date"
           value={unixToDate(search.end_time)}
-          onChange={(e) =>
-            onChange({ end_time: dateToUnix(e.target.value, true) })
-          }
+          onChange={(e) => onChange({ end_time: dateToUnix(e.target.value, true) })}
         />
       </div>
 
@@ -131,10 +123,10 @@ export function FilterBar({ search, onChange, onClear }: Props) {
         <Input
           id="f-desc"
           type="text"
-          value={search.description ?? ""}
+          value={search.description ?? ''}
           onChange={(e) =>
             onChange({
-              description: e.target.value === "" ? undefined : e.target.value,
+              description: e.target.value === '' ? undefined : e.target.value,
             })
           }
           placeholder="Search description…"

--- a/spa/src/lib/api/reports.ts
+++ b/spa/src/lib/api/reports.ts
@@ -30,10 +30,16 @@ export function fetchExpenseBreakdown(params: PeriodApiParams): Promise<ReportRe
   return apiFetch<ReportResult>(`/api/reports/expense-breakdown${buildQuery(params)}`);
 }
 
-export function fetchBalanceSheet(params: { [k: string]: number | undefined; as_of?: number }): Promise<BalanceSheetResult> {
+export function fetchBalanceSheet(params: {
+  [k: string]: number | undefined;
+  as_of?: number;
+}): Promise<BalanceSheetResult> {
   return apiFetch<BalanceSheetResult>(`/api/reports/balance-sheet${buildQuery(params)}`);
 }
 
-export function fetchNetWorth(params: { [k: string]: number | undefined; at?: number }): Promise<NetWorthResponse> {
+export function fetchNetWorth(params: {
+  [k: string]: number | undefined;
+  at?: number;
+}): Promise<NetWorthResponse> {
   return apiFetch<NetWorthResponse>(`/api/reports/net-worth${buildQuery(params)}`);
 }

--- a/spa/src/lib/api/reports.ts
+++ b/spa/src/lib/api/reports.ts
@@ -1,0 +1,38 @@
+import { apiFetch } from '../api';
+import type { BalanceSheetResult, NetWorthResponse, ReportResult } from '../types';
+
+function buildQuery(params: Record<string, string | number | undefined>): string {
+  const usp = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === '') continue;
+    usp.set(k, String(v));
+  }
+  const s = usp.toString();
+  return s ? `?${s}` : '';
+}
+
+export interface PeriodApiParams {
+  month?: string;
+  from?: string;
+  to?: string;
+}
+
+export function fetchIncomeStatement(params: PeriodApiParams): Promise<ReportResult> {
+  return apiFetch<ReportResult>(`/api/reports/income-statement${buildQuery(params as Record<string, string | undefined>)}`);
+}
+
+export function fetchIncomeBreakdown(params: PeriodApiParams): Promise<ReportResult> {
+  return apiFetch<ReportResult>(`/api/reports/income-breakdown${buildQuery(params as Record<string, string | undefined>)}`);
+}
+
+export function fetchExpenseBreakdown(params: PeriodApiParams): Promise<ReportResult> {
+  return apiFetch<ReportResult>(`/api/reports/expense-breakdown${buildQuery(params as Record<string, string | undefined>)}`);
+}
+
+export function fetchBalanceSheet(params: { as_of?: number }): Promise<BalanceSheetResult> {
+  return apiFetch<BalanceSheetResult>(`/api/reports/balance-sheet${buildQuery(params as Record<string, number | undefined>)}`);
+}
+
+export function fetchNetWorth(params: { at?: number }): Promise<NetWorthResponse> {
+  return apiFetch<NetWorthResponse>(`/api/reports/net-worth${buildQuery(params as Record<string, number | undefined>)}`);
+}

--- a/spa/src/lib/api/reports.ts
+++ b/spa/src/lib/api/reports.ts
@@ -1,7 +1,7 @@
 import { apiFetch } from '../api';
 import type { BalanceSheetResult, NetWorthResponse, ReportResult } from '../types';
 
-function buildQuery(params: Record<string, string | number | undefined>): string {
+function buildQuery(params: { [k: string]: string | number | undefined }): string {
   const usp = new URLSearchParams();
   for (const [k, v] of Object.entries(params)) {
     if (v === undefined || v === '') continue;
@@ -12,27 +12,28 @@ function buildQuery(params: Record<string, string | number | undefined>): string
 }
 
 export interface PeriodApiParams {
+  [k: string]: string | undefined;
   month?: string;
   from?: string;
   to?: string;
 }
 
 export function fetchIncomeStatement(params: PeriodApiParams): Promise<ReportResult> {
-  return apiFetch<ReportResult>(`/api/reports/income-statement${buildQuery(params as Record<string, string | undefined>)}`);
+  return apiFetch<ReportResult>(`/api/reports/income-statement${buildQuery(params)}`);
 }
 
 export function fetchIncomeBreakdown(params: PeriodApiParams): Promise<ReportResult> {
-  return apiFetch<ReportResult>(`/api/reports/income-breakdown${buildQuery(params as Record<string, string | undefined>)}`);
+  return apiFetch<ReportResult>(`/api/reports/income-breakdown${buildQuery(params)}`);
 }
 
 export function fetchExpenseBreakdown(params: PeriodApiParams): Promise<ReportResult> {
-  return apiFetch<ReportResult>(`/api/reports/expense-breakdown${buildQuery(params as Record<string, string | undefined>)}`);
+  return apiFetch<ReportResult>(`/api/reports/expense-breakdown${buildQuery(params)}`);
 }
 
-export function fetchBalanceSheet(params: { as_of?: number }): Promise<BalanceSheetResult> {
-  return apiFetch<BalanceSheetResult>(`/api/reports/balance-sheet${buildQuery(params as Record<string, number | undefined>)}`);
+export function fetchBalanceSheet(params: { [k: string]: number | undefined; as_of?: number }): Promise<BalanceSheetResult> {
+  return apiFetch<BalanceSheetResult>(`/api/reports/balance-sheet${buildQuery(params)}`);
 }
 
-export function fetchNetWorth(params: { at?: number }): Promise<NetWorthResponse> {
-  return apiFetch<NetWorthResponse>(`/api/reports/net-worth${buildQuery(params as Record<string, number | undefined>)}`);
+export function fetchNetWorth(params: { [k: string]: number | undefined; at?: number }): Promise<NetWorthResponse> {
+  return apiFetch<NetWorthResponse>(`/api/reports/net-worth${buildQuery(params)}`);
 }

--- a/spa/src/lib/hooks/useReport.ts
+++ b/spa/src/lib/hooks/useReport.ts
@@ -1,0 +1,44 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  type PeriodApiParams,
+  fetchBalanceSheet,
+  fetchExpenseBreakdown,
+  fetchIncomeBreakdown,
+  fetchIncomeStatement,
+  fetchNetWorth,
+} from '../api/reports';
+
+export function useIncomeStatement(params: PeriodApiParams) {
+  return useQuery({
+    queryKey: ['reports', 'income-statement', params],
+    queryFn: () => fetchIncomeStatement(params),
+  });
+}
+
+export function useIncomeBreakdown(params: PeriodApiParams) {
+  return useQuery({
+    queryKey: ['reports', 'income-breakdown', params],
+    queryFn: () => fetchIncomeBreakdown(params),
+  });
+}
+
+export function useExpenseBreakdown(params: PeriodApiParams) {
+  return useQuery({
+    queryKey: ['reports', 'expense-breakdown', params],
+    queryFn: () => fetchExpenseBreakdown(params),
+  });
+}
+
+export function useBalanceSheet(params: { as_of?: number }) {
+  return useQuery({
+    queryKey: ['reports', 'balance-sheet', params],
+    queryFn: () => fetchBalanceSheet(params),
+  });
+}
+
+export function useNetWorth(params: { at?: number }) {
+  return useQuery({
+    queryKey: ['reports', 'net-worth', params],
+    queryFn: () => fetchNetWorth(params),
+  });
+}

--- a/spa/src/lib/period.test.ts
+++ b/spa/src/lib/period.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { expect, test } from 'vitest';
 import { resolvePeriod, type PeriodSearch } from './period';
 
 // Fix "now" so tests are deterministic. 2026-06-16T12:00:00Z → 1781697600.

--- a/spa/src/lib/period.test.ts
+++ b/spa/src/lib/period.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'vitest';
+import { resolvePeriod, type PeriodSearch } from './period';
+
+// Fix "now" so tests are deterministic. 2026-06-16T12:00:00Z → 1781697600.
+const NOW = new Date('2026-06-16T12:00:00Z').getTime() / 1000;
+
+function call(search: Partial<PeriodSearch>) {
+  return resolvePeriod({ range: 'this-month', ...search }, NOW);
+}
+
+test('this-month resolves to current month', () => {
+  const r = call({ range: 'this-month' });
+  expect(r.apiParams).toEqual({ month: '2026-06' });
+  expect(r.label).toBe('June 2026');
+  expect(new Date(r.startUnix * 1000).toISOString()).toBe('2026-06-01T00:00:00.000Z');
+  // end is last second of the month
+  expect(new Date(r.endUnix * 1000).toISOString()).toBe('2026-06-30T23:59:59.000Z');
+});
+
+test('last-month resolves to previous month', () => {
+  const r = call({ range: 'last-month' });
+  expect(r.apiParams).toEqual({ month: '2026-05' });
+  expect(r.label).toBe('May 2026');
+});
+
+test('last-month rolls over from January', () => {
+  const jan = new Date('2026-01-15T00:00:00Z').getTime() / 1000;
+  const r = resolvePeriod({ range: 'last-month' }, jan);
+  expect(r.apiParams).toEqual({ month: '2025-12' });
+  expect(r.label).toBe('December 2025');
+});
+
+test('ytd resolves from Jan 1 to today', () => {
+  const r = call({ range: 'ytd' });
+  expect(r.apiParams).toEqual({ from: '2026-01-01', to: '2026-06-16' });
+  expect(r.label).toBe('YTD 2026');
+});
+
+test('last-12mo resolves to a 12-month window ending today', () => {
+  const r = call({ range: 'last-12mo' });
+  expect(r.apiParams).toEqual({ from: '2025-06-16', to: '2026-06-16' });
+  expect(r.label).toBe('Last 12 months');
+});
+
+test('custom uses provided from/to dates', () => {
+  const r = call({ range: 'custom', from: '2026-03-01', to: '2026-03-31' });
+  expect(r.apiParams).toEqual({ from: '2026-03-01', to: '2026-03-31' });
+  expect(r.label).toBe('Mar 1 – Mar 31, 2026');
+});
+
+test('custom spans a year boundary', () => {
+  const r = call({ range: 'custom', from: '2025-12-01', to: '2026-01-31' });
+  expect(r.label).toBe('Dec 1, 2025 – Jan 31, 2026');
+});
+
+test('custom without from/to falls back to this-month', () => {
+  const r = call({ range: 'custom' });
+  expect(r.apiParams).toEqual({ month: '2026-06' });
+});
+
+test('this-month with month override uses that month', () => {
+  const r = call({ range: 'this-month', month: '2026-02' });
+  expect(r.apiParams).toEqual({ month: '2026-02' });
+  expect(r.label).toBe('February 2026');
+  // Feb 2026 has 28 days
+  expect(new Date(r.endUnix * 1000).toISOString()).toBe('2026-02-28T23:59:59.000Z');
+});
+
+test('leap year February gets 29 days', () => {
+  const r = call({ range: 'this-month', month: '2024-02' });
+  expect(new Date(r.endUnix * 1000).toISOString()).toBe('2024-02-29T23:59:59.000Z');
+});

--- a/spa/src/lib/period.test.ts
+++ b/spa/src/lib/period.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { resolvePeriod, type PeriodSearch } from './period';
+import { type PeriodSearch, resolvePeriod } from './period';
 
 // Fix "now" so tests are deterministic. 2026-06-16T12:00:00Z → 1781697600.
 const NOW = new Date('2026-06-16T12:00:00Z').getTime() / 1000;

--- a/spa/src/lib/period.ts
+++ b/spa/src/lib/period.ts
@@ -1,0 +1,155 @@
+export type PeriodRange = 'this-month' | 'last-month' | 'ytd' | 'last-12mo' | 'custom';
+
+export interface PeriodSearch {
+  range: PeriodRange;
+  month?: string; // 'YYYY-MM'
+  from?: string;  // 'YYYY-MM-DD'
+  to?: string;    // 'YYYY-MM-DD'
+}
+
+export interface ResolvedPeriod {
+  apiParams: { month?: string; from?: string; to?: string };
+  startUnix: number;
+  endUnix: number;
+  label: string;
+}
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+const MONTH_SHORT = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+function utcDate(year: number, month1to12: number, day: number): Date {
+  return new Date(Date.UTC(year, month1to12 - 1, day));
+}
+
+// Days in a given month using JS Date overflow (day 0 of next month = last day).
+function daysInMonth(year: number, month1to12: number): number {
+  return new Date(Date.UTC(year, month1to12, 0)).getUTCDate();
+}
+
+function monthBounds(year: number, month1to12: number): { startUnix: number; endUnix: number } {
+  const start = utcDate(year, month1to12, 1).getTime() / 1000;
+  const last = daysInMonth(year, month1to12);
+  // 23:59:59 of the last day
+  const endDate = new Date(Date.UTC(year, month1to12 - 1, last, 23, 59, 59));
+  return { startUnix: start, endUnix: endDate.getTime() / 1000 };
+}
+
+function isoDate(unix: number): string {
+  const d = new Date(unix * 1000);
+  return `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+}
+
+function parseMonth(s: string): { year: number; month: number } | null {
+  const m = /^(\d{4})-(\d{2})$/.exec(s);
+  if (!m) return null;
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  if (month < 1 || month > 12) return null;
+  return { year, month };
+}
+
+function parseDate(s: string): { year: number; month: number; day: number } | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+  if (!m) return null;
+  return { year: Number(m[1]), month: Number(m[2]), day: Number(m[3]) };
+}
+
+function formatRangeLabel(from: string, to: string): string {
+  const f = parseDate(from);
+  const t = parseDate(to);
+  if (!f || !t) return `${from} – ${to}`;
+  const sameYear = f.year === t.year;
+  const fStr = `${MONTH_SHORT[f.month - 1]} ${f.day}`;
+  const tStr = `${MONTH_SHORT[t.month - 1]} ${t.day}, ${t.year}`;
+  return sameYear ? `${fStr} – ${tStr}` : `${fStr}, ${f.year} – ${tStr}`;
+}
+
+export function resolvePeriod(search: PeriodSearch, nowUnix: number = Date.now() / 1000): ResolvedPeriod {
+  const now = new Date(nowUnix * 1000);
+  const curYear = now.getUTCFullYear();
+  const curMonth = now.getUTCMonth() + 1; // 1-12
+
+  if (search.range === 'this-month') {
+    const parsed = search.month ? parseMonth(search.month) : null;
+    const y = parsed?.year ?? curYear;
+    const m = parsed?.month ?? curMonth;
+    const monthStr = `${y}-${pad2(m)}`;
+    const { startUnix, endUnix } = monthBounds(y, m);
+    return {
+      apiParams: { month: monthStr },
+      startUnix,
+      endUnix,
+      label: `${MONTH_NAMES[m - 1]} ${y}`,
+    };
+  }
+
+  if (search.range === 'last-month') {
+    let y = curYear;
+    let m = curMonth - 1;
+    if (m === 0) {
+      m = 12;
+      y -= 1;
+    }
+    const monthStr = `${y}-${pad2(m)}`;
+    const { startUnix, endUnix } = monthBounds(y, m);
+    return {
+      apiParams: { month: monthStr },
+      startUnix,
+      endUnix,
+      label: `${MONTH_NAMES[m - 1]} ${y}`,
+    };
+  }
+
+  if (search.range === 'ytd') {
+    const from = `${curYear}-01-01`;
+    const to = isoDate(nowUnix);
+    const start = utcDate(curYear, 1, 1).getTime() / 1000;
+    return {
+      apiParams: { from, to },
+      startUnix: start,
+      endUnix: nowUnix,
+      label: `YTD ${curYear}`,
+    };
+  }
+
+  if (search.range === 'last-12mo') {
+    const fromUnix = utcDate(curYear - 1, curMonth, now.getUTCDate()).getTime() / 1000;
+    const from = isoDate(fromUnix);
+    const to = isoDate(nowUnix);
+    return {
+      apiParams: { from, to },
+      startUnix: fromUnix,
+      endUnix: nowUnix,
+      label: 'Last 12 months',
+    };
+  }
+
+  // custom
+  if (search.from && search.to) {
+    const f = parseDate(search.from);
+    const t = parseDate(search.to);
+    if (f && t) {
+      const startUnix = utcDate(f.year, f.month, f.day).getTime() / 1000;
+      const endUnix = new Date(Date.UTC(t.year, t.month - 1, t.day, 23, 59, 59)).getTime() / 1000;
+      return {
+        apiParams: { from: search.from, to: search.to },
+        startUnix,
+        endUnix,
+        label: formatRangeLabel(search.from, search.to),
+      };
+    }
+  }
+
+  // fallback: this-month
+  return resolvePeriod({ range: 'this-month' }, nowUnix);
+}

--- a/spa/src/lib/period.ts
+++ b/spa/src/lib/period.ts
@@ -3,8 +3,8 @@ export type PeriodRange = 'this-month' | 'last-month' | 'ytd' | 'last-12mo' | 'c
 export interface PeriodSearch {
   range: PeriodRange;
   month?: string; // 'YYYY-MM'
-  from?: string;  // 'YYYY-MM-DD'
-  to?: string;    // 'YYYY-MM-DD'
+  from?: string; // 'YYYY-MM-DD'
+  to?: string; // 'YYYY-MM-DD'
 }
 
 export interface ResolvedPeriod {
@@ -15,12 +15,32 @@ export interface ResolvedPeriod {
 }
 
 const MONTH_NAMES = [
-  'January', 'February', 'March', 'April', 'May', 'June',
-  'July', 'August', 'September', 'October', 'November', 'December',
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
 ];
 const MONTH_SHORT = [
-  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
 ];
 
 function pad2(n: number): string {
@@ -74,7 +94,10 @@ function formatRangeLabel(from: string, to: string): string {
   return sameYear ? `${fStr} – ${tStr}` : `${fStr}, ${f.year} – ${tStr}`;
 }
 
-export function resolvePeriod(search: PeriodSearch, nowUnix: number = Date.now() / 1000): ResolvedPeriod {
+export function resolvePeriod(
+  search: PeriodSearch,
+  nowUnix: number = Date.now() / 1000,
+): ResolvedPeriod {
   const now = new Date(nowUnix * 1000);
   const curYear = now.getUTCFullYear();
   const curMonth = now.getUTCMonth() + 1; // 1-12

--- a/spa/src/lib/reports-search-params.test.ts
+++ b/spa/src/lib/reports-search-params.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from 'vitest';
+import {
+  parseAsOfSearch,
+  parseAtSearch,
+  parsePeriodSearch,
+} from './reports-search-params';
+
+test('period schema defaults to this-month with no params', () => {
+  expect(parsePeriodSearch({})).toEqual({ range: 'this-month' });
+});
+
+test('period schema preserves valid range', () => {
+  expect(parsePeriodSearch({ range: 'ytd' })).toEqual({ range: 'ytd' });
+});
+
+test('period schema accepts custom with from/to', () => {
+  expect(parsePeriodSearch({ range: 'custom', from: '2026-01-01', to: '2026-01-31' })).toEqual({
+    range: 'custom',
+    from: '2026-01-01',
+    to: '2026-01-31',
+  });
+});
+
+test('period schema accepts month override', () => {
+  expect(parsePeriodSearch({ range: 'this-month', month: '2025-12' })).toEqual({
+    range: 'this-month',
+    month: '2025-12',
+  });
+});
+
+test('period schema rejects bad range and falls back to this-month', () => {
+  expect(parsePeriodSearch({ range: 'forever' })).toEqual({ range: 'this-month' });
+});
+
+test('period schema rejects bad month format', () => {
+  expect(parsePeriodSearch({ range: 'this-month', month: '2026-13' })).toEqual({
+    range: 'this-month',
+  });
+});
+
+test('as-of schema accepts a numeric as_of', () => {
+  expect(parseAsOfSearch({ as_of: 1781697600 })).toEqual({ as_of: 1781697600 });
+});
+
+test('as-of schema coerces string', () => {
+  expect(parseAsOfSearch({ as_of: '1781697600' })).toEqual({ as_of: 1781697600 });
+});
+
+test('as-of schema returns empty object when missing', () => {
+  expect(parseAsOfSearch({})).toEqual({});
+});
+
+test('at schema accepts numeric at', () => {
+  expect(parseAtSearch({ at: 1781697600 })).toEqual({ at: 1781697600 });
+});
+
+test('at schema returns empty object when missing', () => {
+  expect(parseAtSearch({})).toEqual({});
+});

--- a/spa/src/lib/reports-search-params.test.ts
+++ b/spa/src/lib/reports-search-params.test.ts
@@ -1,9 +1,5 @@
 import { expect, test } from 'vitest';
-import {
-  parseAsOfSearch,
-  parseAtSearch,
-  parsePeriodSearch,
-} from './reports-search-params';
+import { parseAsOfSearch, parseAtSearch, parsePeriodSearch } from './reports-search-params';
 
 test('period schema defaults to this-month with no params', () => {
   expect(parsePeriodSearch({})).toEqual({ range: 'this-month' });

--- a/spa/src/lib/reports-search-params.ts
+++ b/spa/src/lib/reports-search-params.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+import type { PeriodRange } from './period';
+
+const monthPattern = /^\d{4}-(0[1-9]|1[0-2])$/;
+const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+const rangeSchema = z.enum(['this-month', 'last-month', 'ytd', 'last-12mo', 'custom']);
+
+export const periodSearchSchema = z.object({
+  range: rangeSchema.default('this-month'),
+  month: z.string().regex(monthPattern).optional(),
+  from: z.string().regex(datePattern).optional(),
+  to: z.string().regex(datePattern).optional(),
+});
+
+export type PeriodSearchParams = {
+  range: PeriodRange;
+  month?: string;
+  from?: string;
+  to?: string;
+};
+
+export function parsePeriodSearch(input: unknown): PeriodSearchParams {
+  const result = periodSearchSchema.safeParse(input);
+  if (result.success) {
+    const out: PeriodSearchParams = { range: result.data.range };
+    if (result.data.month !== undefined) out.month = result.data.month;
+    if (result.data.from !== undefined) out.from = result.data.from;
+    if (result.data.to !== undefined) out.to = result.data.to;
+    return out;
+  }
+  return { range: 'this-month' };
+}
+
+export const asOfSearchSchema = z.object({
+  as_of: z.coerce.number().int().positive().optional(),
+});
+
+export type AsOfSearchParams = z.infer<typeof asOfSearchSchema>;
+
+export function parseAsOfSearch(input: unknown): AsOfSearchParams {
+  const result = asOfSearchSchema.safeParse(input);
+  if (!result.success) return {};
+  return result.data.as_of === undefined ? {} : { as_of: result.data.as_of };
+}
+
+export const atSearchSchema = z.object({
+  at: z.coerce.number().int().positive().optional(),
+});
+
+export type AtSearchParams = z.infer<typeof atSearchSchema>;
+
+export function parseAtSearch(input: unknown): AtSearchParams {
+  const result = atSearchSchema.safeParse(input);
+  if (!result.success) return {};
+  return result.data.at === undefined ? {} : { at: result.data.at };
+}

--- a/spa/src/lib/types.ts
+++ b/spa/src/lib/types.ts
@@ -148,3 +148,42 @@ export interface AccountBalanceHistory {
 export interface BalanceHistoryResponse {
   items: AccountBalanceHistory[];
 }
+
+// Report shapes (mirror Go JSON from internal/model/report.go
+// and internal/api/reports.go).
+
+export interface ReportRow {
+  account_name: string;
+  offset_account: string;
+  amount: number;
+  currency: string;
+  tx_count: number;
+}
+
+export interface ReportResult {
+  period: string;
+  total_income: Record<string, number>;
+  total_expense: Record<string, number>;
+  net_amount: Record<string, number>;
+  net_worth: Record<string, number>;
+  previous_net_worth: Record<string, number>;
+  net_worth_growth_pct: Record<string, number>;
+  income_rows: ReportRow[];
+  expense_rows: ReportRow[];
+}
+
+export interface BalanceSheetResult {
+  assets: ReportRow[];
+  liabilities: ReportRow[];
+  equity: ReportRow[];
+  total_assets: Record<string, number>;
+  total_liabilities: Record<string, number>;
+  total_equity: Record<string, number>;
+  net_worth: Record<string, number>;
+  as_of: number;
+}
+
+export interface NetWorthResponse {
+  at: number;
+  net_worth: Record<string, number>;
+}

--- a/spa/src/routeTree.gen.ts
+++ b/spa/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as ReportsIndexRouteImport } from './routes/reports.index'
 import { Route as AccountsIndexRouteImport } from './routes/accounts.index'
 import { Route as TransactionsNewRouteImport } from './routes/transactions.new'
 import { Route as TransactionsIdRouteImport } from './routes/transactions.$id'
+import { Route as ReportsNetWorthRouteImport } from './routes/reports.net-worth'
 import { Route as ReportsIncomeStatementRouteImport } from './routes/reports.income-statement'
 import { Route as ReportsIncomeBreakdownRouteImport } from './routes/reports.income-breakdown'
 import { Route as ReportsExpenseBreakdownRouteImport } from './routes/reports.expense-breakdown'
@@ -79,6 +80,11 @@ const TransactionsIdRoute = TransactionsIdRouteImport.update({
   id: '/$id',
   path: '/$id',
   getParentRoute: () => TransactionsRoute,
+} as any)
+const ReportsNetWorthRoute = ReportsNetWorthRouteImport.update({
+  id: '/net-worth',
+  path: '/net-worth',
+  getParentRoute: () => ReportsRoute,
 } as any)
 const ReportsIncomeStatementRoute = ReportsIncomeStatementRouteImport.update({
   id: '/income-statement',
@@ -143,6 +149,7 @@ export interface FileRoutesByFullPath {
   '/reports/expense-breakdown': typeof ReportsExpenseBreakdownRoute
   '/reports/income-breakdown': typeof ReportsIncomeBreakdownRoute
   '/reports/income-statement': typeof ReportsIncomeStatementRoute
+  '/reports/net-worth': typeof ReportsNetWorthRoute
   '/transactions/$id': typeof TransactionsIdRouteWithChildren
   '/transactions/new': typeof TransactionsNewRoute
   '/accounts/': typeof AccountsIndexRoute
@@ -161,6 +168,7 @@ export interface FileRoutesByTo {
   '/reports/expense-breakdown': typeof ReportsExpenseBreakdownRoute
   '/reports/income-breakdown': typeof ReportsIncomeBreakdownRoute
   '/reports/income-statement': typeof ReportsIncomeStatementRoute
+  '/reports/net-worth': typeof ReportsNetWorthRoute
   '/transactions/new': typeof TransactionsNewRoute
   '/accounts': typeof AccountsIndexRoute
   '/reports': typeof ReportsIndexRoute
@@ -183,6 +191,7 @@ export interface FileRoutesById {
   '/reports/expense-breakdown': typeof ReportsExpenseBreakdownRoute
   '/reports/income-breakdown': typeof ReportsIncomeBreakdownRoute
   '/reports/income-statement': typeof ReportsIncomeStatementRoute
+  '/reports/net-worth': typeof ReportsNetWorthRoute
   '/transactions/$id': typeof TransactionsIdRouteWithChildren
   '/transactions/new': typeof TransactionsNewRoute
   '/accounts/': typeof AccountsIndexRoute
@@ -207,6 +216,7 @@ export interface FileRouteTypes {
     | '/reports/expense-breakdown'
     | '/reports/income-breakdown'
     | '/reports/income-statement'
+    | '/reports/net-worth'
     | '/transactions/$id'
     | '/transactions/new'
     | '/accounts/'
@@ -225,6 +235,7 @@ export interface FileRouteTypes {
     | '/reports/expense-breakdown'
     | '/reports/income-breakdown'
     | '/reports/income-statement'
+    | '/reports/net-worth'
     | '/transactions/new'
     | '/accounts'
     | '/reports'
@@ -246,6 +257,7 @@ export interface FileRouteTypes {
     | '/reports/expense-breakdown'
     | '/reports/income-breakdown'
     | '/reports/income-statement'
+    | '/reports/net-worth'
     | '/transactions/$id'
     | '/transactions/new'
     | '/accounts/'
@@ -336,6 +348,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/transactions/$id'
       preLoaderRoute: typeof TransactionsIdRouteImport
       parentRoute: typeof TransactionsRoute
+    }
+    '/reports/net-worth': {
+      id: '/reports/net-worth'
+      path: '/net-worth'
+      fullPath: '/reports/net-worth'
+      preLoaderRoute: typeof ReportsNetWorthRouteImport
+      parentRoute: typeof ReportsRoute
     }
     '/reports/income-statement': {
       id: '/reports/income-statement'
@@ -445,6 +464,7 @@ interface ReportsRouteChildren {
   ReportsExpenseBreakdownRoute: typeof ReportsExpenseBreakdownRoute
   ReportsIncomeBreakdownRoute: typeof ReportsIncomeBreakdownRoute
   ReportsIncomeStatementRoute: typeof ReportsIncomeStatementRoute
+  ReportsNetWorthRoute: typeof ReportsNetWorthRoute
   ReportsIndexRoute: typeof ReportsIndexRoute
 }
 
@@ -453,6 +473,7 @@ const ReportsRouteChildren: ReportsRouteChildren = {
   ReportsExpenseBreakdownRoute: ReportsExpenseBreakdownRoute,
   ReportsIncomeBreakdownRoute: ReportsIncomeBreakdownRoute,
   ReportsIncomeStatementRoute: ReportsIncomeStatementRoute,
+  ReportsNetWorthRoute: ReportsNetWorthRoute,
   ReportsIndexRoute: ReportsIndexRoute,
 }
 

--- a/spa/src/routeTree.gen.ts
+++ b/spa/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as AccountsIndexRouteImport } from './routes/accounts.index'
 import { Route as TransactionsNewRouteImport } from './routes/transactions.new'
 import { Route as TransactionsIdRouteImport } from './routes/transactions.$id'
 import { Route as ReportsIncomeStatementRouteImport } from './routes/reports.income-statement'
+import { Route as ReportsIncomeBreakdownRouteImport } from './routes/reports.income-breakdown'
 import { Route as AccountsNewRouteImport } from './routes/accounts.new'
 import { Route as AccountsIdRouteImport } from './routes/accounts.$id'
 import { Route as TransactionsIdIndexRouteImport } from './routes/transactions.$id.index'
@@ -82,6 +83,11 @@ const ReportsIncomeStatementRoute = ReportsIncomeStatementRouteImport.update({
   path: '/income-statement',
   getParentRoute: () => ReportsRoute,
 } as any)
+const ReportsIncomeBreakdownRoute = ReportsIncomeBreakdownRouteImport.update({
+  id: '/income-breakdown',
+  path: '/income-breakdown',
+  getParentRoute: () => ReportsRoute,
+} as any)
 const AccountsNewRoute = AccountsNewRouteImport.update({
   id: '/new',
   path: '/new',
@@ -121,6 +127,7 @@ export interface FileRoutesByFullPath {
   '/transactions': typeof TransactionsRouteWithChildren
   '/accounts/$id': typeof AccountsIdRouteWithChildren
   '/accounts/new': typeof AccountsNewRoute
+  '/reports/income-breakdown': typeof ReportsIncomeBreakdownRoute
   '/reports/income-statement': typeof ReportsIncomeStatementRoute
   '/transactions/$id': typeof TransactionsIdRouteWithChildren
   '/transactions/new': typeof TransactionsNewRoute
@@ -136,6 +143,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/balances': typeof BalancesRoute
   '/accounts/new': typeof AccountsNewRoute
+  '/reports/income-breakdown': typeof ReportsIncomeBreakdownRoute
   '/reports/income-statement': typeof ReportsIncomeStatementRoute
   '/transactions/new': typeof TransactionsNewRoute
   '/accounts': typeof AccountsIndexRoute
@@ -155,6 +163,7 @@ export interface FileRoutesById {
   '/transactions': typeof TransactionsRouteWithChildren
   '/accounts/$id': typeof AccountsIdRouteWithChildren
   '/accounts/new': typeof AccountsNewRoute
+  '/reports/income-breakdown': typeof ReportsIncomeBreakdownRoute
   '/reports/income-statement': typeof ReportsIncomeStatementRoute
   '/transactions/$id': typeof TransactionsIdRouteWithChildren
   '/transactions/new': typeof TransactionsNewRoute
@@ -176,6 +185,7 @@ export interface FileRouteTypes {
     | '/transactions'
     | '/accounts/$id'
     | '/accounts/new'
+    | '/reports/income-breakdown'
     | '/reports/income-statement'
     | '/transactions/$id'
     | '/transactions/new'
@@ -191,6 +201,7 @@ export interface FileRouteTypes {
     | '/'
     | '/balances'
     | '/accounts/new'
+    | '/reports/income-breakdown'
     | '/reports/income-statement'
     | '/transactions/new'
     | '/accounts'
@@ -209,6 +220,7 @@ export interface FileRouteTypes {
     | '/transactions'
     | '/accounts/$id'
     | '/accounts/new'
+    | '/reports/income-breakdown'
     | '/reports/income-statement'
     | '/transactions/$id'
     | '/transactions/new'
@@ -308,6 +320,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ReportsIncomeStatementRouteImport
       parentRoute: typeof ReportsRoute
     }
+    '/reports/income-breakdown': {
+      id: '/reports/income-breakdown'
+      path: '/income-breakdown'
+      fullPath: '/reports/income-breakdown'
+      preLoaderRoute: typeof ReportsIncomeBreakdownRouteImport
+      parentRoute: typeof ReportsRoute
+    }
     '/accounts/new': {
       id: '/accounts/new'
       path: '/new'
@@ -384,11 +403,13 @@ const AccountsRouteWithChildren = AccountsRoute._addFileChildren(
 )
 
 interface ReportsRouteChildren {
+  ReportsIncomeBreakdownRoute: typeof ReportsIncomeBreakdownRoute
   ReportsIncomeStatementRoute: typeof ReportsIncomeStatementRoute
   ReportsIndexRoute: typeof ReportsIndexRoute
 }
 
 const ReportsRouteChildren: ReportsRouteChildren = {
+  ReportsIncomeBreakdownRoute: ReportsIncomeBreakdownRoute,
   ReportsIncomeStatementRoute: ReportsIncomeStatementRoute,
   ReportsIndexRoute: ReportsIndexRoute,
 }

--- a/spa/src/routeTree.gen.ts
+++ b/spa/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as TransactionsNewRouteImport } from './routes/transactions.new'
 import { Route as TransactionsIdRouteImport } from './routes/transactions.$id'
 import { Route as ReportsIncomeStatementRouteImport } from './routes/reports.income-statement'
 import { Route as ReportsIncomeBreakdownRouteImport } from './routes/reports.income-breakdown'
+import { Route as ReportsExpenseBreakdownRouteImport } from './routes/reports.expense-breakdown'
 import { Route as AccountsNewRouteImport } from './routes/accounts.new'
 import { Route as AccountsIdRouteImport } from './routes/accounts.$id'
 import { Route as TransactionsIdIndexRouteImport } from './routes/transactions.$id.index'
@@ -88,6 +89,11 @@ const ReportsIncomeBreakdownRoute = ReportsIncomeBreakdownRouteImport.update({
   path: '/income-breakdown',
   getParentRoute: () => ReportsRoute,
 } as any)
+const ReportsExpenseBreakdownRoute = ReportsExpenseBreakdownRouteImport.update({
+  id: '/expense-breakdown',
+  path: '/expense-breakdown',
+  getParentRoute: () => ReportsRoute,
+} as any)
 const AccountsNewRoute = AccountsNewRouteImport.update({
   id: '/new',
   path: '/new',
@@ -127,6 +133,7 @@ export interface FileRoutesByFullPath {
   '/transactions': typeof TransactionsRouteWithChildren
   '/accounts/$id': typeof AccountsIdRouteWithChildren
   '/accounts/new': typeof AccountsNewRoute
+  '/reports/expense-breakdown': typeof ReportsExpenseBreakdownRoute
   '/reports/income-breakdown': typeof ReportsIncomeBreakdownRoute
   '/reports/income-statement': typeof ReportsIncomeStatementRoute
   '/transactions/$id': typeof TransactionsIdRouteWithChildren
@@ -143,6 +150,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/balances': typeof BalancesRoute
   '/accounts/new': typeof AccountsNewRoute
+  '/reports/expense-breakdown': typeof ReportsExpenseBreakdownRoute
   '/reports/income-breakdown': typeof ReportsIncomeBreakdownRoute
   '/reports/income-statement': typeof ReportsIncomeStatementRoute
   '/transactions/new': typeof TransactionsNewRoute
@@ -163,6 +171,7 @@ export interface FileRoutesById {
   '/transactions': typeof TransactionsRouteWithChildren
   '/accounts/$id': typeof AccountsIdRouteWithChildren
   '/accounts/new': typeof AccountsNewRoute
+  '/reports/expense-breakdown': typeof ReportsExpenseBreakdownRoute
   '/reports/income-breakdown': typeof ReportsIncomeBreakdownRoute
   '/reports/income-statement': typeof ReportsIncomeStatementRoute
   '/transactions/$id': typeof TransactionsIdRouteWithChildren
@@ -185,6 +194,7 @@ export interface FileRouteTypes {
     | '/transactions'
     | '/accounts/$id'
     | '/accounts/new'
+    | '/reports/expense-breakdown'
     | '/reports/income-breakdown'
     | '/reports/income-statement'
     | '/transactions/$id'
@@ -201,6 +211,7 @@ export interface FileRouteTypes {
     | '/'
     | '/balances'
     | '/accounts/new'
+    | '/reports/expense-breakdown'
     | '/reports/income-breakdown'
     | '/reports/income-statement'
     | '/transactions/new'
@@ -220,6 +231,7 @@ export interface FileRouteTypes {
     | '/transactions'
     | '/accounts/$id'
     | '/accounts/new'
+    | '/reports/expense-breakdown'
     | '/reports/income-breakdown'
     | '/reports/income-statement'
     | '/transactions/$id'
@@ -327,6 +339,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ReportsIncomeBreakdownRouteImport
       parentRoute: typeof ReportsRoute
     }
+    '/reports/expense-breakdown': {
+      id: '/reports/expense-breakdown'
+      path: '/expense-breakdown'
+      fullPath: '/reports/expense-breakdown'
+      preLoaderRoute: typeof ReportsExpenseBreakdownRouteImport
+      parentRoute: typeof ReportsRoute
+    }
     '/accounts/new': {
       id: '/accounts/new'
       path: '/new'
@@ -403,12 +422,14 @@ const AccountsRouteWithChildren = AccountsRoute._addFileChildren(
 )
 
 interface ReportsRouteChildren {
+  ReportsExpenseBreakdownRoute: typeof ReportsExpenseBreakdownRoute
   ReportsIncomeBreakdownRoute: typeof ReportsIncomeBreakdownRoute
   ReportsIncomeStatementRoute: typeof ReportsIncomeStatementRoute
   ReportsIndexRoute: typeof ReportsIndexRoute
 }
 
 const ReportsRouteChildren: ReportsRouteChildren = {
+  ReportsExpenseBreakdownRoute: ReportsExpenseBreakdownRoute,
   ReportsIncomeBreakdownRoute: ReportsIncomeBreakdownRoute,
   ReportsIncomeStatementRoute: ReportsIncomeStatementRoute,
   ReportsIndexRoute: ReportsIndexRoute,

--- a/spa/src/routeTree.gen.ts
+++ b/spa/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as ReportsIndexRouteImport } from './routes/reports.index'
 import { Route as AccountsIndexRouteImport } from './routes/accounts.index'
 import { Route as TransactionsNewRouteImport } from './routes/transactions.new'
 import { Route as TransactionsIdRouteImport } from './routes/transactions.$id'
+import { Route as ReportsIncomeStatementRouteImport } from './routes/reports.income-statement'
 import { Route as AccountsNewRouteImport } from './routes/accounts.new'
 import { Route as AccountsIdRouteImport } from './routes/accounts.$id'
 import { Route as TransactionsIdIndexRouteImport } from './routes/transactions.$id.index'
@@ -76,6 +77,11 @@ const TransactionsIdRoute = TransactionsIdRouteImport.update({
   path: '/$id',
   getParentRoute: () => TransactionsRoute,
 } as any)
+const ReportsIncomeStatementRoute = ReportsIncomeStatementRouteImport.update({
+  id: '/income-statement',
+  path: '/income-statement',
+  getParentRoute: () => ReportsRoute,
+} as any)
 const AccountsNewRoute = AccountsNewRouteImport.update({
   id: '/new',
   path: '/new',
@@ -115,6 +121,7 @@ export interface FileRoutesByFullPath {
   '/transactions': typeof TransactionsRouteWithChildren
   '/accounts/$id': typeof AccountsIdRouteWithChildren
   '/accounts/new': typeof AccountsNewRoute
+  '/reports/income-statement': typeof ReportsIncomeStatementRoute
   '/transactions/$id': typeof TransactionsIdRouteWithChildren
   '/transactions/new': typeof TransactionsNewRoute
   '/accounts/': typeof AccountsIndexRoute
@@ -129,6 +136,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/balances': typeof BalancesRoute
   '/accounts/new': typeof AccountsNewRoute
+  '/reports/income-statement': typeof ReportsIncomeStatementRoute
   '/transactions/new': typeof TransactionsNewRoute
   '/accounts': typeof AccountsIndexRoute
   '/reports': typeof ReportsIndexRoute
@@ -147,6 +155,7 @@ export interface FileRoutesById {
   '/transactions': typeof TransactionsRouteWithChildren
   '/accounts/$id': typeof AccountsIdRouteWithChildren
   '/accounts/new': typeof AccountsNewRoute
+  '/reports/income-statement': typeof ReportsIncomeStatementRoute
   '/transactions/$id': typeof TransactionsIdRouteWithChildren
   '/transactions/new': typeof TransactionsNewRoute
   '/accounts/': typeof AccountsIndexRoute
@@ -167,6 +176,7 @@ export interface FileRouteTypes {
     | '/transactions'
     | '/accounts/$id'
     | '/accounts/new'
+    | '/reports/income-statement'
     | '/transactions/$id'
     | '/transactions/new'
     | '/accounts/'
@@ -181,6 +191,7 @@ export interface FileRouteTypes {
     | '/'
     | '/balances'
     | '/accounts/new'
+    | '/reports/income-statement'
     | '/transactions/new'
     | '/accounts'
     | '/reports'
@@ -198,6 +209,7 @@ export interface FileRouteTypes {
     | '/transactions'
     | '/accounts/$id'
     | '/accounts/new'
+    | '/reports/income-statement'
     | '/transactions/$id'
     | '/transactions/new'
     | '/accounts/'
@@ -289,6 +301,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TransactionsIdRouteImport
       parentRoute: typeof TransactionsRoute
     }
+    '/reports/income-statement': {
+      id: '/reports/income-statement'
+      path: '/income-statement'
+      fullPath: '/reports/income-statement'
+      preLoaderRoute: typeof ReportsIncomeStatementRouteImport
+      parentRoute: typeof ReportsRoute
+    }
     '/accounts/new': {
       id: '/accounts/new'
       path: '/new'
@@ -365,10 +384,12 @@ const AccountsRouteWithChildren = AccountsRoute._addFileChildren(
 )
 
 interface ReportsRouteChildren {
+  ReportsIncomeStatementRoute: typeof ReportsIncomeStatementRoute
   ReportsIndexRoute: typeof ReportsIndexRoute
 }
 
 const ReportsRouteChildren: ReportsRouteChildren = {
+  ReportsIncomeStatementRoute: ReportsIncomeStatementRoute,
   ReportsIndexRoute: ReportsIndexRoute,
 }
 

--- a/spa/src/routeTree.gen.ts
+++ b/spa/src/routeTree.gen.ts
@@ -10,10 +10,12 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as TransactionsRouteImport } from './routes/transactions'
+import { Route as ReportsRouteImport } from './routes/reports'
 import { Route as BalancesRouteImport } from './routes/balances'
 import { Route as AccountsRouteImport } from './routes/accounts'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TransactionsIndexRouteImport } from './routes/transactions.index'
+import { Route as ReportsIndexRouteImport } from './routes/reports.index'
 import { Route as AccountsIndexRouteImport } from './routes/accounts.index'
 import { Route as TransactionsNewRouteImport } from './routes/transactions.new'
 import { Route as TransactionsIdRouteImport } from './routes/transactions.$id'
@@ -27,6 +29,11 @@ import { Route as AccountsIdEditRouteImport } from './routes/accounts.$id.edit'
 const TransactionsRoute = TransactionsRouteImport.update({
   id: '/transactions',
   path: '/transactions',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ReportsRoute = ReportsRouteImport.update({
+  id: '/reports',
+  path: '/reports',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BalancesRoute = BalancesRouteImport.update({
@@ -48,6 +55,11 @@ const TransactionsIndexRoute = TransactionsIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => TransactionsRoute,
+} as any)
+const ReportsIndexRoute = ReportsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => ReportsRoute,
 } as any)
 const AccountsIndexRoute = AccountsIndexRouteImport.update({
   id: '/',
@@ -99,12 +111,14 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/accounts': typeof AccountsRouteWithChildren
   '/balances': typeof BalancesRoute
+  '/reports': typeof ReportsRouteWithChildren
   '/transactions': typeof TransactionsRouteWithChildren
   '/accounts/$id': typeof AccountsIdRouteWithChildren
   '/accounts/new': typeof AccountsNewRoute
   '/transactions/$id': typeof TransactionsIdRouteWithChildren
   '/transactions/new': typeof TransactionsNewRoute
   '/accounts/': typeof AccountsIndexRoute
+  '/reports/': typeof ReportsIndexRoute
   '/transactions/': typeof TransactionsIndexRoute
   '/accounts/$id/edit': typeof AccountsIdEditRoute
   '/transactions/$id/edit': typeof TransactionsIdEditRoute
@@ -117,6 +131,7 @@ export interface FileRoutesByTo {
   '/accounts/new': typeof AccountsNewRoute
   '/transactions/new': typeof TransactionsNewRoute
   '/accounts': typeof AccountsIndexRoute
+  '/reports': typeof ReportsIndexRoute
   '/transactions': typeof TransactionsIndexRoute
   '/accounts/$id/edit': typeof AccountsIdEditRoute
   '/transactions/$id/edit': typeof TransactionsIdEditRoute
@@ -128,12 +143,14 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/accounts': typeof AccountsRouteWithChildren
   '/balances': typeof BalancesRoute
+  '/reports': typeof ReportsRouteWithChildren
   '/transactions': typeof TransactionsRouteWithChildren
   '/accounts/$id': typeof AccountsIdRouteWithChildren
   '/accounts/new': typeof AccountsNewRoute
   '/transactions/$id': typeof TransactionsIdRouteWithChildren
   '/transactions/new': typeof TransactionsNewRoute
   '/accounts/': typeof AccountsIndexRoute
+  '/reports/': typeof ReportsIndexRoute
   '/transactions/': typeof TransactionsIndexRoute
   '/accounts/$id/edit': typeof AccountsIdEditRoute
   '/transactions/$id/edit': typeof TransactionsIdEditRoute
@@ -146,12 +163,14 @@ export interface FileRouteTypes {
     | '/'
     | '/accounts'
     | '/balances'
+    | '/reports'
     | '/transactions'
     | '/accounts/$id'
     | '/accounts/new'
     | '/transactions/$id'
     | '/transactions/new'
     | '/accounts/'
+    | '/reports/'
     | '/transactions/'
     | '/accounts/$id/edit'
     | '/transactions/$id/edit'
@@ -164,6 +183,7 @@ export interface FileRouteTypes {
     | '/accounts/new'
     | '/transactions/new'
     | '/accounts'
+    | '/reports'
     | '/transactions'
     | '/accounts/$id/edit'
     | '/transactions/$id/edit'
@@ -174,12 +194,14 @@ export interface FileRouteTypes {
     | '/'
     | '/accounts'
     | '/balances'
+    | '/reports'
     | '/transactions'
     | '/accounts/$id'
     | '/accounts/new'
     | '/transactions/$id'
     | '/transactions/new'
     | '/accounts/'
+    | '/reports/'
     | '/transactions/'
     | '/accounts/$id/edit'
     | '/transactions/$id/edit'
@@ -191,6 +213,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AccountsRoute: typeof AccountsRouteWithChildren
   BalancesRoute: typeof BalancesRoute
+  ReportsRoute: typeof ReportsRouteWithChildren
   TransactionsRoute: typeof TransactionsRouteWithChildren
 }
 
@@ -201,6 +224,13 @@ declare module '@tanstack/react-router' {
       path: '/transactions'
       fullPath: '/transactions'
       preLoaderRoute: typeof TransactionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/reports': {
+      id: '/reports'
+      path: '/reports'
+      fullPath: '/reports'
+      preLoaderRoute: typeof ReportsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/balances': {
@@ -230,6 +260,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/transactions/'
       preLoaderRoute: typeof TransactionsIndexRouteImport
       parentRoute: typeof TransactionsRoute
+    }
+    '/reports/': {
+      id: '/reports/'
+      path: '/'
+      fullPath: '/reports/'
+      preLoaderRoute: typeof ReportsIndexRouteImport
+      parentRoute: typeof ReportsRoute
     }
     '/accounts/': {
       id: '/accounts/'
@@ -327,6 +364,17 @@ const AccountsRouteWithChildren = AccountsRoute._addFileChildren(
   AccountsRouteChildren,
 )
 
+interface ReportsRouteChildren {
+  ReportsIndexRoute: typeof ReportsIndexRoute
+}
+
+const ReportsRouteChildren: ReportsRouteChildren = {
+  ReportsIndexRoute: ReportsIndexRoute,
+}
+
+const ReportsRouteWithChildren =
+  ReportsRoute._addFileChildren(ReportsRouteChildren)
+
 interface TransactionsIdRouteChildren {
   TransactionsIdEditRoute: typeof TransactionsIdEditRoute
   TransactionsIdIndexRoute: typeof TransactionsIdIndexRoute
@@ -361,6 +409,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AccountsRoute: AccountsRouteWithChildren,
   BalancesRoute: BalancesRoute,
+  ReportsRoute: ReportsRouteWithChildren,
   TransactionsRoute: TransactionsRouteWithChildren,
 }
 export const routeTree = rootRouteImport

--- a/spa/src/routeTree.gen.ts
+++ b/spa/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as TransactionsIdRouteImport } from './routes/transactions.$id'
 import { Route as ReportsIncomeStatementRouteImport } from './routes/reports.income-statement'
 import { Route as ReportsIncomeBreakdownRouteImport } from './routes/reports.income-breakdown'
 import { Route as ReportsExpenseBreakdownRouteImport } from './routes/reports.expense-breakdown'
+import { Route as ReportsBalanceSheetRouteImport } from './routes/reports.balance-sheet'
 import { Route as AccountsNewRouteImport } from './routes/accounts.new'
 import { Route as AccountsIdRouteImport } from './routes/accounts.$id'
 import { Route as TransactionsIdIndexRouteImport } from './routes/transactions.$id.index'
@@ -94,6 +95,11 @@ const ReportsExpenseBreakdownRoute = ReportsExpenseBreakdownRouteImport.update({
   path: '/expense-breakdown',
   getParentRoute: () => ReportsRoute,
 } as any)
+const ReportsBalanceSheetRoute = ReportsBalanceSheetRouteImport.update({
+  id: '/balance-sheet',
+  path: '/balance-sheet',
+  getParentRoute: () => ReportsRoute,
+} as any)
 const AccountsNewRoute = AccountsNewRouteImport.update({
   id: '/new',
   path: '/new',
@@ -133,6 +139,7 @@ export interface FileRoutesByFullPath {
   '/transactions': typeof TransactionsRouteWithChildren
   '/accounts/$id': typeof AccountsIdRouteWithChildren
   '/accounts/new': typeof AccountsNewRoute
+  '/reports/balance-sheet': typeof ReportsBalanceSheetRoute
   '/reports/expense-breakdown': typeof ReportsExpenseBreakdownRoute
   '/reports/income-breakdown': typeof ReportsIncomeBreakdownRoute
   '/reports/income-statement': typeof ReportsIncomeStatementRoute
@@ -150,6 +157,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/balances': typeof BalancesRoute
   '/accounts/new': typeof AccountsNewRoute
+  '/reports/balance-sheet': typeof ReportsBalanceSheetRoute
   '/reports/expense-breakdown': typeof ReportsExpenseBreakdownRoute
   '/reports/income-breakdown': typeof ReportsIncomeBreakdownRoute
   '/reports/income-statement': typeof ReportsIncomeStatementRoute
@@ -171,6 +179,7 @@ export interface FileRoutesById {
   '/transactions': typeof TransactionsRouteWithChildren
   '/accounts/$id': typeof AccountsIdRouteWithChildren
   '/accounts/new': typeof AccountsNewRoute
+  '/reports/balance-sheet': typeof ReportsBalanceSheetRoute
   '/reports/expense-breakdown': typeof ReportsExpenseBreakdownRoute
   '/reports/income-breakdown': typeof ReportsIncomeBreakdownRoute
   '/reports/income-statement': typeof ReportsIncomeStatementRoute
@@ -194,6 +203,7 @@ export interface FileRouteTypes {
     | '/transactions'
     | '/accounts/$id'
     | '/accounts/new'
+    | '/reports/balance-sheet'
     | '/reports/expense-breakdown'
     | '/reports/income-breakdown'
     | '/reports/income-statement'
@@ -211,6 +221,7 @@ export interface FileRouteTypes {
     | '/'
     | '/balances'
     | '/accounts/new'
+    | '/reports/balance-sheet'
     | '/reports/expense-breakdown'
     | '/reports/income-breakdown'
     | '/reports/income-statement'
@@ -231,6 +242,7 @@ export interface FileRouteTypes {
     | '/transactions'
     | '/accounts/$id'
     | '/accounts/new'
+    | '/reports/balance-sheet'
     | '/reports/expense-breakdown'
     | '/reports/income-breakdown'
     | '/reports/income-statement'
@@ -346,6 +358,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ReportsExpenseBreakdownRouteImport
       parentRoute: typeof ReportsRoute
     }
+    '/reports/balance-sheet': {
+      id: '/reports/balance-sheet'
+      path: '/balance-sheet'
+      fullPath: '/reports/balance-sheet'
+      preLoaderRoute: typeof ReportsBalanceSheetRouteImport
+      parentRoute: typeof ReportsRoute
+    }
     '/accounts/new': {
       id: '/accounts/new'
       path: '/new'
@@ -422,6 +441,7 @@ const AccountsRouteWithChildren = AccountsRoute._addFileChildren(
 )
 
 interface ReportsRouteChildren {
+  ReportsBalanceSheetRoute: typeof ReportsBalanceSheetRoute
   ReportsExpenseBreakdownRoute: typeof ReportsExpenseBreakdownRoute
   ReportsIncomeBreakdownRoute: typeof ReportsIncomeBreakdownRoute
   ReportsIncomeStatementRoute: typeof ReportsIncomeStatementRoute
@@ -429,6 +449,7 @@ interface ReportsRouteChildren {
 }
 
 const ReportsRouteChildren: ReportsRouteChildren = {
+  ReportsBalanceSheetRoute: ReportsBalanceSheetRoute,
   ReportsExpenseBreakdownRoute: ReportsExpenseBreakdownRoute,
   ReportsIncomeBreakdownRoute: ReportsIncomeBreakdownRoute,
   ReportsIncomeStatementRoute: ReportsIncomeStatementRoute,

--- a/spa/src/routes/reports.balance-sheet.tsx
+++ b/spa/src/routes/reports.balance-sheet.tsx
@@ -7,10 +7,10 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { getBalances } from '@/lib/api';
+import { formatCents } from '@/lib/format';
 import { useBalanceSheet } from '@/lib/hooks/useReport';
 import { type AsOfSearchParams, parseAsOfSearch } from '@/lib/reports-search-params';
 import { useServerConfig } from '@/lib/server-config';
-import { formatCents } from '@/lib/format';
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useMemo } from 'react';
@@ -30,7 +30,8 @@ function BalanceSheetPage() {
   const balancesQuery = useQuery({ queryKey: ['balances'], queryFn: getBalances });
   const nameToId = useMemo(() => {
     const m = new Map<string, number>();
-    if (balancesQuery.data) for (const row of balancesQuery.data.items) m.set(row.name, row.account_id);
+    if (balancesQuery.data)
+      for (const row of balancesQuery.data.items) m.set(row.name, row.account_id);
     return m;
   }, [balancesQuery.data]);
 
@@ -54,7 +55,9 @@ function BalanceSheetPage() {
           <AlertTitle>Failed to load balance sheet</AlertTitle>
           <AlertDescription className="mt-2 space-y-3">
             <div>{query.error instanceof Error ? query.error.message : 'Unknown error'}</div>
-            <Button onClick={() => query.refetch()} size="sm">Retry</Button>
+            <Button onClick={() => query.refetch()} size="sm">
+              Retry
+            </Button>
           </AlertDescription>
         </Alert>
       </div>
@@ -117,7 +120,12 @@ function BalanceSheetPage() {
       {liabilities.length > 0 && (
         <section>
           <h2 className="mb-2 text-sm font-semibold">Liabilities</h2>
-          <ReportRowTable rows={liabilities} currency={currency} nameToId={nameToId} period={null} />
+          <ReportRowTable
+            rows={liabilities}
+            currency={currency}
+            nameToId={nameToId}
+            period={null}
+          />
         </section>
       )}
       {equity.length > 0 && (

--- a/spa/src/routes/reports.balance-sheet.tsx
+++ b/spa/src/routes/reports.balance-sheet.tsx
@@ -1,0 +1,141 @@
+import { AsOfPicker } from '@/components/reports/AsOfPicker';
+import { CurrencyFooter } from '@/components/reports/CurrencyFooter';
+import { KpiCard } from '@/components/reports/KpiCard';
+import { ProportionBar } from '@/components/reports/ProportionBar';
+import { ReportRowTable } from '@/components/reports/ReportRowTable';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getBalances } from '@/lib/api';
+import { useBalanceSheet } from '@/lib/hooks/useReport';
+import { type AsOfSearchParams, parseAsOfSearch } from '@/lib/reports-search-params';
+import { useServerConfig } from '@/lib/server-config';
+import { formatCents } from '@/lib/format';
+import { useQuery } from '@tanstack/react-query';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useMemo } from 'react';
+
+export const Route = createFileRoute('/reports/balance-sheet')({
+  validateSearch: (s): AsOfSearchParams => parseAsOfSearch(s),
+  component: BalanceSheetPage,
+});
+
+function BalanceSheetPage() {
+  const { defaults } = useServerConfig();
+  const currency = defaults.currency;
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: '/reports/balance-sheet' });
+  const query = useBalanceSheet(search);
+
+  const balancesQuery = useQuery({ queryKey: ['balances'], queryFn: getBalances });
+  const nameToId = useMemo(() => {
+    const m = new Map<string, number>();
+    if (balancesQuery.data) for (const row of balancesQuery.data.items) m.set(row.name, row.account_id);
+    return m;
+  }, [balancesQuery.data]);
+
+  const setAsOf = (v: number | undefined) =>
+    navigate({ search: () => (v === undefined ? {} : { as_of: v }) });
+
+  if (query.isPending) {
+    return (
+      <div className="space-y-4">
+        <AsOfPicker label="As of" value={search.as_of} onChange={setAsOf} />
+        <Skeleton className="h-20" />
+        <Skeleton className="h-48" />
+      </div>
+    );
+  }
+  if (query.isError) {
+    return (
+      <div className="space-y-3">
+        <AsOfPicker label="As of" value={search.as_of} onChange={setAsOf} />
+        <Alert variant="destructive">
+          <AlertTitle>Failed to load balance sheet</AlertTitle>
+          <AlertDescription className="mt-2 space-y-3">
+            <div>{query.error instanceof Error ? query.error.message : 'Unknown error'}</div>
+            <Button onClick={() => query.refetch()} size="sm">Retry</Button>
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const result = query.data;
+  const ta = result.total_assets[currency] ?? 0;
+  const tl = result.total_liabilities[currency] ?? 0;
+  const te = result.total_equity[currency] ?? 0;
+  const nw = result.net_worth[currency] ?? 0;
+  const assets = result.assets.filter((r) => r.currency === currency);
+  const liabilities = result.liabilities.filter((r) => r.currency === currency);
+  const equity = result.equity.filter((r) => r.currency === currency);
+
+  if (assets.length === 0 && liabilities.length === 0 && equity.length === 0) {
+    return (
+      <div className="space-y-4">
+        <AsOfPicker label="As of" value={search.as_of} onChange={setAsOf} />
+        <p className="text-sm text-muted-foreground">No balance-sheet activity at this date.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <AsOfPicker label="As of" value={search.as_of} onChange={setAsOf} />
+
+      <div className="grid grid-cols-3 gap-3">
+        {assets.length > 0 && (
+          <KpiCard label="Total Assets" amount={ta} currency={currency} variant="green" />
+        )}
+        {liabilities.length > 0 && (
+          <KpiCard label="Total Liabilities" amount={tl} currency={currency} variant="red" />
+        )}
+        {equity.length > 0 && (
+          <KpiCard
+            label="Total Equity"
+            amount={te}
+            currency={currency}
+            variant="neutral"
+            subLine={`Net worth: ${formatCents(nw, currency)}`}
+          />
+        )}
+      </div>
+
+      {assets.length > 0 && (
+        <section>
+          <h2 className="mb-2 text-sm font-semibold">Asset mix</h2>
+          <ProportionBar rows={assets} total={ta} currency={currency} variant="income" />
+        </section>
+      )}
+
+      {assets.length > 0 && (
+        <section>
+          <h2 className="mb-2 text-sm font-semibold">Assets</h2>
+          <ReportRowTable rows={assets} currency={currency} nameToId={nameToId} period={null} />
+        </section>
+      )}
+      {liabilities.length > 0 && (
+        <section>
+          <h2 className="mb-2 text-sm font-semibold">Liabilities</h2>
+          <ReportRowTable rows={liabilities} currency={currency} nameToId={nameToId} period={null} />
+        </section>
+      )}
+      {equity.length > 0 && (
+        <section>
+          <h2 className="mb-2 text-sm font-semibold">Equity</h2>
+          <ReportRowTable rows={equity} currency={currency} nameToId={nameToId} period={null} />
+        </section>
+      )}
+
+      <CurrencyFooter
+        defaultCurrency={currency}
+        entries={[
+          { label: 'Assets', byCurrency: result.total_assets },
+          { label: 'Liabilities', byCurrency: result.total_liabilities },
+          { label: 'Equity', byCurrency: result.total_equity },
+          { label: 'Net worth', byCurrency: result.net_worth },
+        ]}
+      />
+    </div>
+  );
+}

--- a/spa/src/routes/reports.expense-breakdown.tsx
+++ b/spa/src/routes/reports.expense-breakdown.tsx
@@ -31,7 +31,8 @@ function ExpenseBreakdownPage() {
   const balancesQuery = useQuery({ queryKey: ['balances'], queryFn: getBalances });
   const nameToId = useMemo(() => {
     const m = new Map<string, number>();
-    if (balancesQuery.data) for (const row of balancesQuery.data.items) m.set(row.name, row.account_id);
+    if (balancesQuery.data)
+      for (const row of balancesQuery.data.items) m.set(row.name, row.account_id);
     return m;
   }, [balancesQuery.data]);
 
@@ -55,7 +56,9 @@ function ExpenseBreakdownPage() {
           <AlertTitle>Failed to load expense breakdown</AlertTitle>
           <AlertDescription className="mt-2 space-y-3">
             <div>{query.error instanceof Error ? query.error.message : 'Unknown error'}</div>
-            <Button onClick={() => query.refetch()} size="sm">Retry</Button>
+            <Button onClick={() => query.refetch()} size="sm">
+              Retry
+            </Button>
           </AlertDescription>
         </Alert>
       </div>

--- a/spa/src/routes/reports.expense-breakdown.tsx
+++ b/spa/src/routes/reports.expense-breakdown.tsx
@@ -1,0 +1,94 @@
+import { CurrencyFooter } from '@/components/reports/CurrencyFooter';
+import { KpiCard } from '@/components/reports/KpiCard';
+import { PeriodPicker } from '@/components/reports/PeriodPicker';
+import { ProportionBar } from '@/components/reports/ProportionBar';
+import { ReportRowTable } from '@/components/reports/ReportRowTable';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getBalances } from '@/lib/api';
+import { useExpenseBreakdown } from '@/lib/hooks/useReport';
+import { resolvePeriod } from '@/lib/period';
+import { type PeriodSearchParams, parsePeriodSearch } from '@/lib/reports-search-params';
+import { useServerConfig } from '@/lib/server-config';
+import { useQuery } from '@tanstack/react-query';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useMemo } from 'react';
+
+export const Route = createFileRoute('/reports/expense-breakdown')({
+  validateSearch: (s): PeriodSearchParams => parsePeriodSearch(s),
+  component: ExpenseBreakdownPage,
+});
+
+function ExpenseBreakdownPage() {
+  const { defaults } = useServerConfig();
+  const currency = defaults.currency;
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: '/reports/expense-breakdown' });
+  const period = useMemo(() => resolvePeriod(search), [search]);
+  const query = useExpenseBreakdown(period.apiParams);
+
+  const balancesQuery = useQuery({ queryKey: ['balances'], queryFn: getBalances });
+  const nameToId = useMemo(() => {
+    const m = new Map<string, number>();
+    if (balancesQuery.data) for (const row of balancesQuery.data.items) m.set(row.name, row.account_id);
+    return m;
+  }, [balancesQuery.data]);
+
+  const setSearch = (next: Partial<PeriodSearchParams>) =>
+    navigate({ search: () => ({ ...search, ...next }) });
+
+  if (query.isPending) {
+    return (
+      <div className="space-y-4">
+        <PeriodPicker value={search} onChange={setSearch} label={period.label} />
+        <Skeleton className="h-20" />
+        <Skeleton className="h-48" />
+      </div>
+    );
+  }
+  if (query.isError) {
+    return (
+      <div className="space-y-3">
+        <PeriodPicker value={search} onChange={setSearch} label={period.label} />
+        <Alert variant="destructive">
+          <AlertTitle>Failed to load expense breakdown</AlertTitle>
+          <AlertDescription className="mt-2 space-y-3">
+            <div>{query.error instanceof Error ? query.error.message : 'Unknown error'}</div>
+            <Button onClick={() => query.refetch()} size="sm">Retry</Button>
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const result = query.data;
+  const expense = result.total_expense[currency] ?? 0;
+  const rows = result.expense_rows.filter((r) => r.currency === currency);
+
+  return (
+    <div className="space-y-6">
+      <PeriodPicker value={search} onChange={setSearch} label={period.label} />
+      {rows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No expenses in {period.label}.</p>
+      ) : (
+        <>
+          <div className="max-w-xs">
+            <KpiCard label="Total Expense" amount={expense} currency={currency} variant="red" />
+          </div>
+          <ProportionBar rows={rows} total={expense} currency={currency} variant="expense" />
+          <ReportRowTable
+            rows={rows}
+            currency={currency}
+            nameToId={nameToId}
+            period={{ startUnix: period.startUnix, endUnix: period.endUnix }}
+          />
+          <CurrencyFooter
+            defaultCurrency={currency}
+            entries={[{ label: 'Expense', byCurrency: result.total_expense }]}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/spa/src/routes/reports.income-breakdown.tsx
+++ b/spa/src/routes/reports.income-breakdown.tsx
@@ -1,0 +1,94 @@
+import { CurrencyFooter } from '@/components/reports/CurrencyFooter';
+import { KpiCard } from '@/components/reports/KpiCard';
+import { PeriodPicker } from '@/components/reports/PeriodPicker';
+import { ProportionBar } from '@/components/reports/ProportionBar';
+import { ReportRowTable } from '@/components/reports/ReportRowTable';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getBalances } from '@/lib/api';
+import { useIncomeBreakdown } from '@/lib/hooks/useReport';
+import { resolvePeriod } from '@/lib/period';
+import { type PeriodSearchParams, parsePeriodSearch } from '@/lib/reports-search-params';
+import { useServerConfig } from '@/lib/server-config';
+import { useQuery } from '@tanstack/react-query';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useMemo } from 'react';
+
+export const Route = createFileRoute('/reports/income-breakdown')({
+  validateSearch: (s): PeriodSearchParams => parsePeriodSearch(s),
+  component: IncomeBreakdownPage,
+});
+
+function IncomeBreakdownPage() {
+  const { defaults } = useServerConfig();
+  const currency = defaults.currency;
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: '/reports/income-breakdown' });
+  const period = useMemo(() => resolvePeriod(search), [search]);
+  const query = useIncomeBreakdown(period.apiParams);
+
+  const balancesQuery = useQuery({ queryKey: ['balances'], queryFn: getBalances });
+  const nameToId = useMemo(() => {
+    const m = new Map<string, number>();
+    if (balancesQuery.data) for (const row of balancesQuery.data.items) m.set(row.name, row.account_id);
+    return m;
+  }, [balancesQuery.data]);
+
+  const setSearch = (next: Partial<PeriodSearchParams>) =>
+    navigate({ search: () => ({ ...search, ...next }) });
+
+  if (query.isPending) {
+    return (
+      <div className="space-y-4">
+        <PeriodPicker value={search} onChange={setSearch} label={period.label} />
+        <Skeleton className="h-20" />
+        <Skeleton className="h-48" />
+      </div>
+    );
+  }
+  if (query.isError) {
+    return (
+      <div className="space-y-3">
+        <PeriodPicker value={search} onChange={setSearch} label={period.label} />
+        <Alert variant="destructive">
+          <AlertTitle>Failed to load income breakdown</AlertTitle>
+          <AlertDescription className="mt-2 space-y-3">
+            <div>{query.error instanceof Error ? query.error.message : 'Unknown error'}</div>
+            <Button onClick={() => query.refetch()} size="sm">Retry</Button>
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const result = query.data;
+  const income = result.total_income[currency] ?? 0;
+  const rows = result.income_rows.filter((r) => r.currency === currency);
+
+  return (
+    <div className="space-y-6">
+      <PeriodPicker value={search} onChange={setSearch} label={period.label} />
+      {rows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No income in {period.label}.</p>
+      ) : (
+        <>
+          <div className="max-w-xs">
+            <KpiCard label="Total Income" amount={income} currency={currency} variant="green" />
+          </div>
+          <ProportionBar rows={rows} total={income} currency={currency} variant="income" />
+          <ReportRowTable
+            rows={rows}
+            currency={currency}
+            nameToId={nameToId}
+            period={{ startUnix: period.startUnix, endUnix: period.endUnix }}
+          />
+          <CurrencyFooter
+            defaultCurrency={currency}
+            entries={[{ label: 'Income', byCurrency: result.total_income }]}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/spa/src/routes/reports.income-breakdown.tsx
+++ b/spa/src/routes/reports.income-breakdown.tsx
@@ -31,7 +31,8 @@ function IncomeBreakdownPage() {
   const balancesQuery = useQuery({ queryKey: ['balances'], queryFn: getBalances });
   const nameToId = useMemo(() => {
     const m = new Map<string, number>();
-    if (balancesQuery.data) for (const row of balancesQuery.data.items) m.set(row.name, row.account_id);
+    if (balancesQuery.data)
+      for (const row of balancesQuery.data.items) m.set(row.name, row.account_id);
     return m;
   }, [balancesQuery.data]);
 
@@ -55,7 +56,9 @@ function IncomeBreakdownPage() {
           <AlertTitle>Failed to load income breakdown</AlertTitle>
           <AlertDescription className="mt-2 space-y-3">
             <div>{query.error instanceof Error ? query.error.message : 'Unknown error'}</div>
-            <Button onClick={() => query.refetch()} size="sm">Retry</Button>
+            <Button onClick={() => query.refetch()} size="sm">
+              Retry
+            </Button>
           </AlertDescription>
         </Alert>
       </div>

--- a/spa/src/routes/reports.income-statement.tsx
+++ b/spa/src/routes/reports.income-statement.tsx
@@ -1,0 +1,141 @@
+import { CurrencyFooter } from '@/components/reports/CurrencyFooter';
+import { KpiCard } from '@/components/reports/KpiCard';
+import { PeriodPicker } from '@/components/reports/PeriodPicker';
+import { ReportRowTable } from '@/components/reports/ReportRowTable';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getBalances } from '@/lib/api';
+import { useIncomeStatement } from '@/lib/hooks/useReport';
+import { resolvePeriod } from '@/lib/period';
+import { type PeriodSearchParams, parsePeriodSearch } from '@/lib/reports-search-params';
+import { useServerConfig } from '@/lib/server-config';
+import { useQuery } from '@tanstack/react-query';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useMemo } from 'react';
+
+export const Route = createFileRoute('/reports/income-statement')({
+  validateSearch: (s): PeriodSearchParams => parsePeriodSearch(s),
+  component: IncomeStatementPage,
+});
+
+function IncomeStatementPage() {
+  const { defaults } = useServerConfig();
+  const currency = defaults.currency;
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: '/reports/income-statement' });
+  const period = useMemo(() => resolvePeriod(search), [search]);
+  const query = useIncomeStatement(period.apiParams);
+
+  const balancesQuery = useQuery({ queryKey: ['balances'], queryFn: getBalances });
+  const nameToId = useMemo(() => {
+    const m = new Map<string, number>();
+    if (balancesQuery.data) {
+      for (const row of balancesQuery.data.items) m.set(row.name, row.account_id);
+    }
+    return m;
+  }, [balancesQuery.data]);
+
+  const setSearch = (next: Partial<PeriodSearchParams>) => {
+    navigate({ search: () => ({ ...search, ...next }) });
+  };
+
+  if (query.isPending) {
+    return (
+      <div className="space-y-4">
+        <PeriodPicker value={search} onChange={setSearch} label={period.label} />
+        <div className="grid grid-cols-3 gap-3">
+          <Skeleton className="h-20" />
+          <Skeleton className="h-20" />
+          <Skeleton className="h-20" />
+        </div>
+        <Skeleton className="h-48" />
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div className="space-y-3">
+        <PeriodPicker value={search} onChange={setSearch} label={period.label} />
+        <Alert variant="destructive">
+          <AlertTitle>Failed to load income statement</AlertTitle>
+          <AlertDescription className="mt-2 space-y-3">
+            <div>{query.error instanceof Error ? query.error.message : 'Unknown error'}</div>
+            <Button onClick={() => query.refetch()} size="sm">Retry</Button>
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const result = query.data;
+  const isEmpty =
+    result.income_rows.length === 0 && result.expense_rows.length === 0;
+
+  const income = result.total_income[currency] ?? 0;
+  const expense = result.total_expense[currency] ?? 0;
+  const net = result.net_amount[currency] ?? 0;
+  const growth = result.net_worth_growth_pct[currency];
+
+  const netSubLine =
+    growth === undefined || Number.isNaN(growth)
+      ? undefined
+      : `${growth >= 0 ? '▲' : '▼'} ${Math.abs(growth).toFixed(1)}% net worth`;
+
+  return (
+    <div className="space-y-6">
+      <PeriodPicker value={search} onChange={setSearch} label={period.label} />
+
+      {isEmpty ? (
+        <p className="text-sm text-muted-foreground">
+          No income or expenses in {period.label}. Try a wider range.
+        </p>
+      ) : (
+        <>
+          <div className="grid grid-cols-3 gap-3">
+            <KpiCard label="Income" amount={income} currency={currency} variant="green" />
+            <KpiCard label="Expense" amount={expense} currency={currency} variant="red" />
+            <KpiCard
+              label="Net"
+              amount={net}
+              currency={currency}
+              variant="neutral"
+              subLine={netSubLine}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-6">
+            <section>
+              <h2 className="mb-2 text-sm font-semibold">Income detail</h2>
+              <ReportRowTable
+                rows={result.income_rows.filter((r) => r.currency === currency)}
+                currency={currency}
+                nameToId={nameToId}
+                period={{ startUnix: period.startUnix, endUnix: period.endUnix }}
+              />
+            </section>
+            <section>
+              <h2 className="mb-2 text-sm font-semibold">Expense detail</h2>
+              <ReportRowTable
+                rows={result.expense_rows.filter((r) => r.currency === currency)}
+                currency={currency}
+                nameToId={nameToId}
+                period={{ startUnix: period.startUnix, endUnix: period.endUnix }}
+              />
+            </section>
+          </div>
+
+          <CurrencyFooter
+            defaultCurrency={currency}
+            entries={[
+              { label: 'Income', byCurrency: result.total_income },
+              { label: 'Expense', byCurrency: result.total_expense },
+              { label: 'Net', byCurrency: result.net_amount },
+            ]}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/spa/src/routes/reports.income-statement.tsx
+++ b/spa/src/routes/reports.income-statement.tsx
@@ -63,7 +63,9 @@ function IncomeStatementPage() {
           <AlertTitle>Failed to load income statement</AlertTitle>
           <AlertDescription className="mt-2 space-y-3">
             <div>{query.error instanceof Error ? query.error.message : 'Unknown error'}</div>
-            <Button onClick={() => query.refetch()} size="sm">Retry</Button>
+            <Button onClick={() => query.refetch()} size="sm">
+              Retry
+            </Button>
           </AlertDescription>
         </Alert>
       </div>
@@ -71,8 +73,7 @@ function IncomeStatementPage() {
   }
 
   const result = query.data;
-  const isEmpty =
-    result.income_rows.length === 0 && result.expense_rows.length === 0;
+  const isEmpty = result.income_rows.length === 0 && result.expense_rows.length === 0;
 
   const income = result.total_income[currency] ?? 0;
   const expense = result.total_expense[currency] ?? 0;

--- a/spa/src/routes/reports.income-statement.tsx
+++ b/spa/src/routes/reports.income-statement.tsx
@@ -1,6 +1,7 @@
 import { CurrencyFooter } from '@/components/reports/CurrencyFooter';
 import { KpiCard } from '@/components/reports/KpiCard';
 import { PeriodPicker } from '@/components/reports/PeriodPicker';
+import { ProportionBar } from '@/components/reports/ProportionBar';
 import { ReportRowTable } from '@/components/reports/ReportRowTable';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -103,6 +104,29 @@ function IncomeStatementPage() {
               variant="neutral"
               subLine={netSubLine}
             />
+          </div>
+
+          <div className="grid grid-cols-2 gap-6">
+            <section>
+              <h2 className="mb-2 text-sm font-semibold">Income mix</h2>
+              <ProportionBar
+                rows={result.income_rows.filter((r) => r.currency === currency)}
+                total={income}
+                currency={currency}
+                limit={8}
+                variant="income"
+              />
+            </section>
+            <section>
+              <h2 className="mb-2 text-sm font-semibold">Expense mix</h2>
+              <ProportionBar
+                rows={result.expense_rows.filter((r) => r.currency === currency)}
+                total={expense}
+                currency={currency}
+                limit={8}
+                variant="expense"
+              />
+            </section>
           </div>
 
           <div className="grid grid-cols-2 gap-6">

--- a/spa/src/routes/reports.income-statement.tsx
+++ b/spa/src/routes/reports.income-statement.tsx
@@ -73,7 +73,9 @@ function IncomeStatementPage() {
   }
 
   const result = query.data;
-  const isEmpty = result.income_rows.length === 0 && result.expense_rows.length === 0;
+  const incomeRows = result.income_rows.filter((r) => r.currency === currency);
+  const expenseRows = result.expense_rows.filter((r) => r.currency === currency);
+  const isEmpty = incomeRows.length === 0 && expenseRows.length === 0;
 
   const income = result.total_income[currency] ?? 0;
   const expense = result.total_expense[currency] ?? 0;
@@ -111,7 +113,7 @@ function IncomeStatementPage() {
             <section>
               <h2 className="mb-2 text-sm font-semibold">Income mix</h2>
               <ProportionBar
-                rows={result.income_rows.filter((r) => r.currency === currency)}
+                rows={incomeRows}
                 total={income}
                 currency={currency}
                 limit={8}
@@ -121,7 +123,7 @@ function IncomeStatementPage() {
             <section>
               <h2 className="mb-2 text-sm font-semibold">Expense mix</h2>
               <ProportionBar
-                rows={result.expense_rows.filter((r) => r.currency === currency)}
+                rows={expenseRows}
                 total={expense}
                 currency={currency}
                 limit={8}
@@ -134,7 +136,7 @@ function IncomeStatementPage() {
             <section>
               <h2 className="mb-2 text-sm font-semibold">Income detail</h2>
               <ReportRowTable
-                rows={result.income_rows.filter((r) => r.currency === currency)}
+                rows={incomeRows}
                 currency={currency}
                 nameToId={nameToId}
                 period={{ startUnix: period.startUnix, endUnix: period.endUnix }}
@@ -143,7 +145,7 @@ function IncomeStatementPage() {
             <section>
               <h2 className="mb-2 text-sm font-semibold">Expense detail</h2>
               <ReportRowTable
-                rows={result.expense_rows.filter((r) => r.currency === currency)}
+                rows={expenseRows}
                 currency={currency}
                 nameToId={nameToId}
                 period={{ startUnix: period.startUnix, endUnix: period.endUnix }}

--- a/spa/src/routes/reports.index.tsx
+++ b/spa/src/routes/reports.index.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/reports/')({
+  beforeLoad: () => {
+    // TODO: remove cast when T14 adds /reports/income-statement
+    throw redirect({ to: '/reports/income-statement' as string });
+  },
+});

--- a/spa/src/routes/reports.index.tsx
+++ b/spa/src/routes/reports.index.tsx
@@ -2,7 +2,6 @@ import { createFileRoute, redirect } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/reports/')({
   beforeLoad: () => {
-    // TODO: remove cast when T14 adds /reports/income-statement
-    throw redirect({ to: '/reports/income-statement' as string });
+    throw redirect({ to: '/reports/income-statement' });
   },
 });

--- a/spa/src/routes/reports.index.tsx
+++ b/spa/src/routes/reports.index.tsx
@@ -2,6 +2,6 @@ import { createFileRoute, redirect } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/reports/')({
   beforeLoad: () => {
-    throw redirect({ to: '/reports/income-statement' });
+    throw redirect({ to: '/reports/income-statement', search: { range: 'this-month' } });
   },
 });

--- a/spa/src/routes/reports.net-worth.tsx
+++ b/spa/src/routes/reports.net-worth.tsx
@@ -3,8 +3,8 @@ import { CurrencyFooter } from '@/components/reports/CurrencyFooter';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useNetWorth } from '@/lib/hooks/useReport';
 import { formatCents } from '@/lib/format';
+import { useNetWorth } from '@/lib/hooks/useReport';
 import { type AtSearchParams, parseAtSearch } from '@/lib/reports-search-params';
 import { useServerConfig } from '@/lib/server-config';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
@@ -40,7 +40,9 @@ function NetWorthPage() {
           <AlertTitle>Failed to load net worth</AlertTitle>
           <AlertDescription className="mt-2 space-y-3">
             <div>{query.error instanceof Error ? query.error.message : 'Unknown error'}</div>
-            <Button onClick={() => query.refetch()} size="sm">Retry</Button>
+            <Button onClick={() => query.refetch()} size="sm">
+              Retry
+            </Button>
           </AlertDescription>
         </Alert>
       </div>

--- a/spa/src/routes/reports.net-worth.tsx
+++ b/spa/src/routes/reports.net-worth.tsx
@@ -7,7 +7,7 @@ import { formatCents } from '@/lib/format';
 import { useNetWorth } from '@/lib/hooks/useReport';
 import { type AtSearchParams, parseAtSearch } from '@/lib/reports-search-params';
 import { useServerConfig } from '@/lib/server-config';
-import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/reports/net-worth')({
   validateSearch: (s): AtSearchParams => parseAtSearch(s),
@@ -59,7 +59,17 @@ function NetWorthPage() {
         <div className="text-xs uppercase tracking-wide text-muted-foreground">Net Worth</div>
         <div className="mt-1 text-4xl font-semibold">{formatCents(nw, currency)}</div>
         {Object.keys(query.data.net_worth).length === 0 && (
-          <p className="mt-3 text-sm text-muted-foreground">No accounts yet.</p>
+          <p className="mt-3 text-sm text-muted-foreground">
+            No accounts yet —{' '}
+            <Link
+              to="/accounts/new"
+              className="underline hover:text-foreground"
+              search={{ include_hidden: false, show_parents: false, limit: 10, offset: 0 }}
+            >
+              create one
+            </Link>
+            .
+          </p>
         )}
       </section>
       {otherCurrencies.length > 0 && (

--- a/spa/src/routes/reports.net-worth.tsx
+++ b/spa/src/routes/reports.net-worth.tsx
@@ -1,0 +1,71 @@
+import { AsOfPicker } from '@/components/reports/AsOfPicker';
+import { CurrencyFooter } from '@/components/reports/CurrencyFooter';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useNetWorth } from '@/lib/hooks/useReport';
+import { formatCents } from '@/lib/format';
+import { type AtSearchParams, parseAtSearch } from '@/lib/reports-search-params';
+import { useServerConfig } from '@/lib/server-config';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/reports/net-worth')({
+  validateSearch: (s): AtSearchParams => parseAtSearch(s),
+  component: NetWorthPage,
+});
+
+function NetWorthPage() {
+  const { defaults } = useServerConfig();
+  const currency = defaults.currency;
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: '/reports/net-worth' });
+  const query = useNetWorth(search);
+
+  const setAt = (v: number | undefined) =>
+    navigate({ search: () => (v === undefined ? {} : { at: v }) });
+
+  if (query.isPending) {
+    return (
+      <div className="space-y-4">
+        <AsOfPicker label="At" value={search.at} onChange={setAt} />
+        <Skeleton className="h-24" />
+      </div>
+    );
+  }
+  if (query.isError) {
+    return (
+      <div className="space-y-3">
+        <AsOfPicker label="At" value={search.at} onChange={setAt} />
+        <Alert variant="destructive">
+          <AlertTitle>Failed to load net worth</AlertTitle>
+          <AlertDescription className="mt-2 space-y-3">
+            <div>{query.error instanceof Error ? query.error.message : 'Unknown error'}</div>
+            <Button onClick={() => query.refetch()} size="sm">Retry</Button>
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const nw = query.data.net_worth[currency] ?? 0;
+  const otherCurrencies = Object.keys(query.data.net_worth).filter((c) => c !== currency);
+
+  return (
+    <div className="space-y-6">
+      <AsOfPicker label="At" value={search.at} onChange={setAt} />
+      <section>
+        <div className="text-xs uppercase tracking-wide text-muted-foreground">Net Worth</div>
+        <div className="mt-1 text-4xl font-semibold">{formatCents(nw, currency)}</div>
+        {Object.keys(query.data.net_worth).length === 0 && (
+          <p className="mt-3 text-sm text-muted-foreground">No accounts yet.</p>
+        )}
+      </section>
+      {otherCurrencies.length > 0 && (
+        <CurrencyFooter
+          defaultCurrency={currency}
+          entries={[{ label: 'Net worth', byCurrency: query.data.net_worth }]}
+        />
+      )}
+    </div>
+  );
+}

--- a/spa/src/routes/reports.tsx
+++ b/spa/src/routes/reports.tsx
@@ -1,0 +1,16 @@
+import { TabNav } from '@/components/reports/TabNav';
+import { Outlet, createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/reports')({
+  component: ReportsLayout,
+});
+
+function ReportsLayout() {
+  return (
+    <div>
+      <h1 className="mb-3 text-xl font-semibold">Reports</h1>
+      <TabNav />
+      <Outlet />
+    </div>
+  );
+}

--- a/spa/src/routes/transactions.index.tsx
+++ b/spa/src/routes/transactions.index.tsx
@@ -1,31 +1,31 @@
-import { FilterBar } from "@/components/transactions/FilterBar";
-import { Pagination } from "@/components/transactions/Pagination";
-import { TransactionsTable } from "@/components/transactions/TransactionsTable";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
-import { listTransactions } from "@/lib/transactions";
+import { FilterBar } from '@/components/transactions/FilterBar';
+import { Pagination } from '@/components/transactions/Pagination';
+import { TransactionsTable } from '@/components/transactions/TransactionsTable';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { listTransactions } from '@/lib/transactions';
 import {
   type TransactionsSearch,
   searchToFilter,
   searchToListOptions,
-} from "@/lib/transactions-search-params";
-import { useQuery } from "@tanstack/react-query";
-import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
+} from '@/lib/transactions-search-params';
+import { useQuery } from '@tanstack/react-query';
+import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
 
-export const Route = createFileRoute("/transactions/")({
+export const Route = createFileRoute('/transactions/')({
   component: TransactionsListPage,
 });
 
 function TransactionsListPage() {
   const search = Route.useSearch();
-  const navigate = useNavigate({ from: "/transactions" });
+  const navigate = useNavigate({ from: '/transactions' });
 
   const filter = searchToFilter(search);
   const opts = searchToListOptions(search);
 
   const query = useQuery({
-    queryKey: ["transactions", { ...filter, ...opts }],
+    queryKey: ['transactions', { ...filter, ...opts }],
     queryFn: () => listTransactions(filter, opts),
   });
 
@@ -66,11 +66,7 @@ function TransactionsListPage() {
         <Alert variant="destructive">
           <AlertTitle>Failed to load transactions</AlertTitle>
           <AlertDescription className="mt-2 space-y-3">
-            <div>
-              {query.error instanceof Error
-                ? query.error.message
-                : "Unknown error"}
-            </div>
+            <div>{query.error instanceof Error ? query.error.message : 'Unknown error'}</div>
             <Button onClick={() => query.refetch()} size="sm">
               Retry
             </Button>

--- a/spa/src/test/reports.as-of-picker.test.tsx
+++ b/spa/src/test/reports.as-of-picker.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, test } from 'vitest';
+import { AsOfPicker } from '../components/reports/AsOfPicker';
+
+test('renders "Now" when value is undefined', () => {
+  const noop = (_: number | undefined) => {};
+  render(<AsOfPicker label="As of" value={undefined} onChange={noop} />);
+  expect(screen.getByText(/now/i)).toBeInTheDocument();
+});
+
+test('selecting a date emits Unix seconds', async () => {
+  const calls: (number | undefined)[] = [];
+  render(<AsOfPicker label="As of" value={undefined} onChange={(v) => calls.push(v)} />);
+  const input = screen.getByLabelText(/as of/i) as HTMLInputElement;
+  await userEvent.type(input, '2026-06-15');
+  // The input change emits at least once with a positive Unix number
+  expect(calls.some((c) => typeof c === 'number' && c > 0)).toBe(true);
+});
+
+test('clicking "Now" emits undefined', async () => {
+  const calls: (number | undefined)[] = [];
+  // Start with a specific time so "Now" is a transition.
+  const t = Math.floor(new Date('2026-06-01T00:00:00Z').getTime() / 1000);
+  render(<AsOfPicker label="As of" value={t} onChange={(v) => calls.push(v)} />);
+  await userEvent.click(screen.getByRole('button', { name: /now/i }));
+  expect(calls).toEqual([undefined]);
+});

--- a/spa/src/test/reports.balance-sheet.test.tsx
+++ b/spa/src/test/reports.balance-sheet.test.tsx
@@ -12,7 +12,8 @@ beforeEach(() => {
   vi.stubGlobal(
     'fetch',
     vi.fn((url: string) => {
-      if (url === '/api/config') return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+      if (url === '/api/config')
+        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
       if (url === '/api/ledgers')
         return Promise.resolve(
           okResponse({ active: 'p', items: [{ name: 'p', path: '/p.db', active: true }] }),
@@ -21,20 +22,41 @@ beforeEach(() => {
         return Promise.resolve(
           okResponse({
             items: [
-              { account_id: 1, name: 'Assets:Bank', type: 'A', currency: 'USD', amount: 125000, is_hidden: false },
+              {
+                account_id: 1,
+                name: 'Assets:Bank',
+                type: 'A',
+                currency: 'USD',
+                amount: 125000,
+                is_hidden: false,
+              },
             ],
-            total_count: 1, limit: 0, offset: 0,
+            total_count: 1,
+            limit: 0,
+            offset: 0,
           }),
         );
       if (url.startsWith('/api/reports/balance-sheet'))
         return Promise.resolve(
           okResponse({
             assets: [
-              { account_name: 'Assets:Bank', offset_account: '', amount: 125000, currency: 'USD', tx_count: 4 },
+              {
+                account_name: 'Assets:Bank',
+                offset_account: '',
+                amount: 125000,
+                currency: 'USD',
+                tx_count: 4,
+              },
             ],
             liabilities: [],
             equity: [
-              { account_name: 'Equity:OpeningBalances_USD', offset_account: '', amount: 125000, currency: 'USD', tx_count: 1 },
+              {
+                account_name: 'Equity:OpeningBalances_USD',
+                offset_account: '',
+                amount: 125000,
+                currency: 'USD',
+                tx_count: 1,
+              },
             ],
             total_assets: { USD: 125000 },
             total_liabilities: {},

--- a/spa/src/test/reports.balance-sheet.test.tsx
+++ b/spa/src/test/reports.balance-sheet.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { makeTestApp } from './test-app';
+
+const okResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string) => {
+      if (url === '/api/config') return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+      if (url === '/api/ledgers')
+        return Promise.resolve(
+          okResponse({ active: 'p', items: [{ name: 'p', path: '/p.db', active: true }] }),
+        );
+      if (url === '/api/balances')
+        return Promise.resolve(
+          okResponse({
+            items: [
+              { account_id: 1, name: 'Assets:Bank', type: 'A', currency: 'USD', amount: 125000, is_hidden: false },
+            ],
+            total_count: 1, limit: 0, offset: 0,
+          }),
+        );
+      if (url.startsWith('/api/reports/balance-sheet'))
+        return Promise.resolve(
+          okResponse({
+            assets: [
+              { account_name: 'Assets:Bank', offset_account: '', amount: 125000, currency: 'USD', tx_count: 4 },
+            ],
+            liabilities: [],
+            equity: [
+              { account_name: 'Equity:OpeningBalances_USD', offset_account: '', amount: 125000, currency: 'USD', tx_count: 1 },
+            ],
+            total_assets: { USD: 125000 },
+            total_liabilities: {},
+            total_equity: { USD: 125000 },
+            net_worth: { USD: 125000 },
+            as_of: 1781697600,
+          }),
+        );
+      throw new Error(`unexpected fetch: ${url}`);
+    }),
+  );
+});
+afterEach(() => vi.unstubAllGlobals());
+
+test('renders Assets and Equity sections; hides empty Liabilities', async () => {
+  render(makeTestApp('/reports/balance-sheet'));
+  await waitFor(() => {
+    expect(screen.getByText('Total Assets')).toBeInTheDocument();
+  });
+  expect(screen.getByText('Total Equity')).toBeInTheDocument();
+  expect(screen.queryByText('Total Liabilities')).not.toBeInTheDocument();
+  expect(screen.getAllByText('Assets:Bank').length).toBeGreaterThan(0);
+});
+
+test('asset rows link to /accounts/{id}', async () => {
+  render(makeTestApp('/reports/balance-sheet'));
+  await waitFor(() => {
+    expect(screen.getAllByText('Assets:Bank').length).toBeGreaterThan(0);
+  });
+  const link = screen.getByRole('link', { name: /Assets:Bank/ });
+  expect(link.getAttribute('href')).toMatch(/\/accounts\/1/);
+});

--- a/spa/src/test/reports.currency-footer.test.tsx
+++ b/spa/src/test/reports.currency-footer.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { CurrencyFooter } from '../components/reports/CurrencyFooter';
+
+test('renders nothing when only the default currency is present', () => {
+  const { container } = render(
+    <CurrencyFooter
+      defaultCurrency="USD"
+      entries={[{ label: 'Income', byCurrency: { USD: 524800 } }]}
+    />,
+  );
+  expect(container.firstChild).toBeNull();
+});
+
+test('renders non-default currency lines', () => {
+  render(
+    <CurrencyFooter
+      defaultCurrency="USD"
+      entries={[
+        { label: 'Income', byCurrency: { USD: 524800, JPY: 12000000 } },
+        { label: 'Expense', byCurrency: { USD: 253000, JPY: 4000000 } },
+      ]}
+    />,
+  );
+  expect(screen.getByText(/Income/)).toBeInTheDocument();
+  expect(screen.getByText(/Expense/)).toBeInTheDocument();
+  // JPY values appear, USD does not duplicate
+  expect(screen.queryAllByText(/JPY|¥/).length).toBeGreaterThan(0);
+});
+
+test('skips entries whose only currency is the default', () => {
+  const { container } = render(
+    <CurrencyFooter
+      defaultCurrency="USD"
+      entries={[
+        { label: 'Income', byCurrency: { USD: 1 } },
+        { label: 'Expense', byCurrency: { USD: 1, JPY: 1 } },
+      ]}
+    />,
+  );
+  // Only one line: Expense (Income's only currency is the default)
+  expect(container.querySelectorAll('[data-testid="cur-footer-line"]').length).toBe(1);
+});

--- a/spa/src/test/reports.expense-breakdown.test.tsx
+++ b/spa/src/test/reports.expense-breakdown.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { makeTestApp } from './test-app';
+
+const okResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string) => {
+      if (url === '/api/config') return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+      if (url === '/api/ledgers')
+        return Promise.resolve(
+          okResponse({ active: 'p', items: [{ name: 'p', path: '/p.db', active: true }] }),
+        );
+      if (url === '/api/balances')
+        return Promise.resolve(okResponse({ items: [], total_count: 0, limit: 0, offset: 0 }));
+      if (url.startsWith('/api/reports/expense-breakdown'))
+        return Promise.resolve(
+          okResponse({
+            period: 'June 2026',
+            total_income: {},
+            total_expense: { USD: 253000 },
+            net_amount: {},
+            net_worth: {},
+            previous_net_worth: {},
+            net_worth_growth_pct: {},
+            income_rows: [],
+            expense_rows: [
+              { account_name: 'Expenses:Rent', offset_account: '', amount: 180000, currency: 'USD', tx_count: 1 },
+              { account_name: 'Expenses:Food', offset_account: '', amount: 73000, currency: 'USD', tx_count: 5 },
+            ],
+          }),
+        );
+      throw new Error(`unexpected fetch: ${url}`);
+    }),
+  );
+});
+afterEach(() => vi.unstubAllGlobals());
+
+test('renders total expense KPI and rows', async () => {
+  render(makeTestApp('/reports/expense-breakdown'));
+  await waitFor(() => {
+    expect(screen.getByText('Total Expense')).toBeInTheDocument();
+  });
+  expect(screen.getByText('$2,530.00')).toBeInTheDocument();
+  expect(screen.getAllByText('Expenses:Rent').length).toBeGreaterThan(0);
+});

--- a/spa/src/test/reports.expense-breakdown.test.tsx
+++ b/spa/src/test/reports.expense-breakdown.test.tsx
@@ -12,7 +12,8 @@ beforeEach(() => {
   vi.stubGlobal(
     'fetch',
     vi.fn((url: string) => {
-      if (url === '/api/config') return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+      if (url === '/api/config')
+        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
       if (url === '/api/ledgers')
         return Promise.resolve(
           okResponse({ active: 'p', items: [{ name: 'p', path: '/p.db', active: true }] }),
@@ -31,8 +32,20 @@ beforeEach(() => {
             net_worth_growth_pct: {},
             income_rows: [],
             expense_rows: [
-              { account_name: 'Expenses:Rent', offset_account: '', amount: 180000, currency: 'USD', tx_count: 1 },
-              { account_name: 'Expenses:Food', offset_account: '', amount: 73000, currency: 'USD', tx_count: 5 },
+              {
+                account_name: 'Expenses:Rent',
+                offset_account: '',
+                amount: 180000,
+                currency: 'USD',
+                tx_count: 1,
+              },
+              {
+                account_name: 'Expenses:Food',
+                offset_account: '',
+                amount: 73000,
+                currency: 'USD',
+                tx_count: 5,
+              },
             ],
           }),
         );

--- a/spa/src/test/reports.income-breakdown.test.tsx
+++ b/spa/src/test/reports.income-breakdown.test.tsx
@@ -24,9 +24,18 @@ beforeEach(() => {
         return Promise.resolve(
           okResponse({
             items: [
-              { account_id: 13, name: 'Income:Salary', type: 'R', currency: 'USD', amount: -520000, is_hidden: false },
+              {
+                account_id: 13,
+                name: 'Income:Salary',
+                type: 'R',
+                currency: 'USD',
+                amount: -520000,
+                is_hidden: false,
+              },
             ],
-            total_count: 1, limit: 0, offset: 0,
+            total_count: 1,
+            limit: 0,
+            offset: 0,
           }),
         );
       }
@@ -41,8 +50,20 @@ beforeEach(() => {
             previous_net_worth: {},
             net_worth_growth_pct: {},
             income_rows: [
-              { account_name: 'Income:Salary', offset_account: 'Assets:Bank', amount: 520000, currency: 'USD', tx_count: 1 },
-              { account_name: 'Income:Interest', offset_account: 'Assets:Bank', amount: 4800, currency: 'USD', tx_count: 1 },
+              {
+                account_name: 'Income:Salary',
+                offset_account: 'Assets:Bank',
+                amount: 520000,
+                currency: 'USD',
+                tx_count: 1,
+              },
+              {
+                account_name: 'Income:Interest',
+                offset_account: 'Assets:Bank',
+                amount: 4800,
+                currency: 'USD',
+                tx_count: 1,
+              },
             ],
             expense_rows: [],
           }),

--- a/spa/src/test/reports.income-breakdown.test.tsx
+++ b/spa/src/test/reports.income-breakdown.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { makeTestApp } from './test-app';
+
+const okResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string) => {
+      if (url === '/api/config') {
+        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+      }
+      if (url === '/api/ledgers') {
+        return Promise.resolve(
+          okResponse({ active: 'p', items: [{ name: 'p', path: '/p.db', active: true }] }),
+        );
+      }
+      if (url === '/api/balances') {
+        return Promise.resolve(
+          okResponse({
+            items: [
+              { account_id: 13, name: 'Income:Salary', type: 'R', currency: 'USD', amount: -520000, is_hidden: false },
+            ],
+            total_count: 1, limit: 0, offset: 0,
+          }),
+        );
+      }
+      if (url.startsWith('/api/reports/income-breakdown')) {
+        return Promise.resolve(
+          okResponse({
+            period: 'June 2026',
+            total_income: { USD: 524800 },
+            total_expense: {},
+            net_amount: {},
+            net_worth: {},
+            previous_net_worth: {},
+            net_worth_growth_pct: {},
+            income_rows: [
+              { account_name: 'Income:Salary', offset_account: 'Assets:Bank', amount: 520000, currency: 'USD', tx_count: 1 },
+              { account_name: 'Income:Interest', offset_account: 'Assets:Bank', amount: 4800, currency: 'USD', tx_count: 1 },
+            ],
+            expense_rows: [],
+          }),
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }),
+  );
+});
+afterEach(() => vi.unstubAllGlobals());
+
+test('renders total income KPI and rows', async () => {
+  render(makeTestApp('/reports/income-breakdown'));
+  await waitFor(() => {
+    expect(screen.getByText('Total Income')).toBeInTheDocument();
+  });
+  expect(screen.getByText('$5,248.00')).toBeInTheDocument();
+  expect(screen.getAllByText('Income:Salary').length).toBeGreaterThan(0);
+  expect(screen.getAllByText('Income:Interest').length).toBeGreaterThan(0);
+});

--- a/spa/src/test/reports.income-statement.test.tsx
+++ b/spa/src/test/reports.income-statement.test.tsx
@@ -74,14 +74,14 @@ test('renders KPI cards, charts, and tables for income statement', async () => {
   expect(screen.getByText('$2,530.00')).toBeInTheDocument();
   expect(screen.getByText('$2,718.00')).toBeInTheDocument();
   expect(screen.getByText(/6\.2% net worth/)).toBeInTheDocument();
-  expect(screen.getByText('Expenses:Rent')).toBeInTheDocument();
-  expect(screen.getByText('Income:Salary')).toBeInTheDocument();
+  expect(screen.getAllByText('Expenses:Rent').length).toBeGreaterThan(0);
+  expect(screen.getAllByText('Income:Salary').length).toBeGreaterThan(0);
 });
 
 test('drill-down row links to /transactions with account_id and time bounds', async () => {
   render(makeTestApp('/reports/income-statement'));
   await waitFor(() => {
-    expect(screen.getByText('Expenses:Rent')).toBeInTheDocument();
+    expect(screen.getAllByText('Expenses:Rent').length).toBeGreaterThan(0);
   });
   const link = screen.getByRole('link', { name: /Expenses:Rent/ });
   const href = link.getAttribute('href') ?? '';

--- a/spa/src/test/reports.income-statement.test.tsx
+++ b/spa/src/test/reports.income-statement.test.tsx
@@ -17,11 +17,29 @@ const REPORT_PAYLOAD = {
   previous_net_worth: { USD: 4700000 },
   net_worth_growth_pct: { USD: 6.2 },
   income_rows: [
-    { account_name: 'Income:Salary', offset_account: 'Assets:Bank', amount: 520000, currency: 'USD', tx_count: 1 },
+    {
+      account_name: 'Income:Salary',
+      offset_account: 'Assets:Bank',
+      amount: 520000,
+      currency: 'USD',
+      tx_count: 1,
+    },
   ],
   expense_rows: [
-    { account_name: 'Expenses:Rent', offset_account: 'Assets:Bank', amount: 180000, currency: 'USD', tx_count: 1 },
-    { account_name: 'Expenses:Food', offset_account: 'Assets:Bank', amount: 73000, currency: 'USD', tx_count: 4 },
+    {
+      account_name: 'Expenses:Rent',
+      offset_account: 'Assets:Bank',
+      amount: 180000,
+      currency: 'USD',
+      tx_count: 1,
+    },
+    {
+      account_name: 'Expenses:Food',
+      offset_account: 'Assets:Bank',
+      amount: 73000,
+      currency: 'USD',
+      tx_count: 4,
+    },
   ],
 };
 
@@ -41,9 +59,30 @@ beforeEach(() => {
         return Promise.resolve(
           okResponse({
             items: [
-              { account_id: 11, name: 'Expenses:Rent', type: 'E', currency: 'USD', amount: 180000, is_hidden: false },
-              { account_id: 12, name: 'Expenses:Food', type: 'E', currency: 'USD', amount: 73000, is_hidden: false },
-              { account_id: 13, name: 'Income:Salary', type: 'R', currency: 'USD', amount: -520000, is_hidden: false },
+              {
+                account_id: 11,
+                name: 'Expenses:Rent',
+                type: 'E',
+                currency: 'USD',
+                amount: 180000,
+                is_hidden: false,
+              },
+              {
+                account_id: 12,
+                name: 'Expenses:Food',
+                type: 'E',
+                currency: 'USD',
+                amount: 73000,
+                is_hidden: false,
+              },
+              {
+                account_id: 13,
+                name: 'Income:Salary',
+                type: 'R',
+                currency: 'USD',
+                amount: -520000,
+                is_hidden: false,
+              },
             ],
             total_count: 3,
             limit: 0,

--- a/spa/src/test/reports.income-statement.test.tsx
+++ b/spa/src/test/reports.income-statement.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { makeTestApp } from './test-app';
+
+const okResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const REPORT_PAYLOAD = {
+  period: 'June 2026',
+  total_income: { USD: 524800 },
+  total_expense: { USD: 253000 },
+  net_amount: { USD: 271800 },
+  net_worth: { USD: 5000000 },
+  previous_net_worth: { USD: 4700000 },
+  net_worth_growth_pct: { USD: 6.2 },
+  income_rows: [
+    { account_name: 'Income:Salary', offset_account: 'Assets:Bank', amount: 520000, currency: 'USD', tx_count: 1 },
+  ],
+  expense_rows: [
+    { account_name: 'Expenses:Rent', offset_account: 'Assets:Bank', amount: 180000, currency: 'USD', tx_count: 1 },
+    { account_name: 'Expenses:Food', offset_account: 'Assets:Bank', amount: 73000, currency: 'USD', tx_count: 4 },
+  ],
+};
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string) => {
+      if (url === '/api/config') {
+        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+      }
+      if (url === '/api/ledgers') {
+        return Promise.resolve(
+          okResponse({ active: 'p', items: [{ name: 'p', path: '/p.db', active: true }] }),
+        );
+      }
+      if (url === '/api/balances') {
+        return Promise.resolve(
+          okResponse({
+            items: [
+              { account_id: 11, name: 'Expenses:Rent', type: 'E', currency: 'USD', amount: 180000, is_hidden: false },
+              { account_id: 12, name: 'Expenses:Food', type: 'E', currency: 'USD', amount: 73000, is_hidden: false },
+              { account_id: 13, name: 'Income:Salary', type: 'R', currency: 'USD', amount: -520000, is_hidden: false },
+            ],
+            total_count: 3,
+            limit: 0,
+            offset: 0,
+          }),
+        );
+      }
+      if (url.startsWith('/api/reports/income-statement')) {
+        return Promise.resolve(okResponse(REPORT_PAYLOAD));
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test('renders KPI cards, charts, and tables for income statement', async () => {
+  render(makeTestApp('/reports/income-statement'));
+  await waitFor(() => {
+    expect(screen.getByText('Income')).toBeInTheDocument();
+  });
+  expect(screen.getByText('Expense')).toBeInTheDocument();
+  expect(screen.getByText('Net')).toBeInTheDocument();
+  expect(screen.getByText('$5,248.00')).toBeInTheDocument();
+  expect(screen.getByText('$2,530.00')).toBeInTheDocument();
+  expect(screen.getByText('$2,718.00')).toBeInTheDocument();
+  expect(screen.getByText(/6\.2% net worth/)).toBeInTheDocument();
+  expect(screen.getByText('Expenses:Rent')).toBeInTheDocument();
+  expect(screen.getByText('Income:Salary')).toBeInTheDocument();
+});
+
+test('drill-down row links to /transactions with account_id and time bounds', async () => {
+  render(makeTestApp('/reports/income-statement'));
+  await waitFor(() => {
+    expect(screen.getByText('Expenses:Rent')).toBeInTheDocument();
+  });
+  const link = screen.getByRole('link', { name: /Expenses:Rent/ });
+  const href = link.getAttribute('href') ?? '';
+  expect(href).toContain('/transactions');
+  expect(href).toContain('account_id=11');
+});
+
+test('renders empty state when there are no rows', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string) => {
+      if (url === '/api/config') {
+        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+      }
+      if (url === '/api/ledgers') {
+        return Promise.resolve(
+          okResponse({ active: 'p', items: [{ name: 'p', path: '/p.db', active: true }] }),
+        );
+      }
+      if (url === '/api/balances') {
+        return Promise.resolve(okResponse({ items: [], total_count: 0, limit: 0, offset: 0 }));
+      }
+      if (url.startsWith('/api/reports/income-statement')) {
+        return Promise.resolve(
+          okResponse({
+            ...REPORT_PAYLOAD,
+            total_income: {},
+            total_expense: {},
+            net_amount: {},
+            income_rows: [],
+            expense_rows: [],
+          }),
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }),
+  );
+  render(makeTestApp('/reports/income-statement'));
+  await waitFor(() => {
+    expect(screen.getByText(/no income or expenses/i)).toBeInTheDocument();
+  });
+});

--- a/spa/src/test/reports.kpi-card.test.tsx
+++ b/spa/src/test/reports.kpi-card.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { KpiCard } from '../components/reports/KpiCard';
+
+test('renders label, formatted amount, and currency', () => {
+  render(<KpiCard label="Income" amount={524800} currency="USD" variant="green" />);
+  expect(screen.getByText('Income')).toBeInTheDocument();
+  expect(screen.getByText('$5,248.00')).toBeInTheDocument();
+});
+
+test('applies the green variant class', () => {
+  const { container } = render(
+    <KpiCard label="Income" amount={524800} currency="USD" variant="green" />,
+  );
+  const amountEl = container.querySelector('[data-testid="kpi-amount"]');
+  expect(amountEl?.className).toContain('text-green');
+});
+
+test('applies the red variant class', () => {
+  const { container } = render(
+    <KpiCard label="Expense" amount={253000} currency="USD" variant="red" />,
+  );
+  const amountEl = container.querySelector('[data-testid="kpi-amount"]');
+  expect(amountEl?.className).toContain('text-red');
+});
+
+test('renders sub-line when provided', () => {
+  render(
+    <KpiCard
+      label="Net"
+      amount={271800}
+      currency="USD"
+      variant="neutral"
+      subLine="▲ 6.2% net worth"
+    />,
+  );
+  expect(screen.getByText('▲ 6.2% net worth')).toBeInTheDocument();
+});
+
+test('omits sub-line when not provided', () => {
+  const { container } = render(
+    <KpiCard label="Net" amount={271800} currency="USD" variant="neutral" />,
+  );
+  expect(container.querySelector('[data-testid="kpi-subline"]')).toBeNull();
+});

--- a/spa/src/test/reports.net-worth.test.tsx
+++ b/spa/src/test/reports.net-worth.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { makeTestApp } from './test-app';
+
+const okResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string) => {
+      if (url === '/api/config') return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+      if (url === '/api/ledgers')
+        return Promise.resolve(
+          okResponse({ active: 'p', items: [{ name: 'p', path: '/p.db', active: true }] }),
+        );
+      if (url.startsWith('/api/reports/net-worth'))
+        return Promise.resolve(okResponse({ at: 1781697600, net_worth: { USD: 5000000, JPY: 12000000 } }));
+      throw new Error(`unexpected fetch: ${url}`);
+    }),
+  );
+});
+afterEach(() => vi.unstubAllGlobals());
+
+test('renders the default-currency net worth and currency footer', async () => {
+  render(makeTestApp('/reports/net-worth'));
+  await waitFor(() => {
+    expect(screen.getByText('$50,000.00')).toBeInTheDocument();
+  });
+  // heading label rendered by the component
+  expect(screen.getAllByText('Net Worth').length).toBeGreaterThan(0);
+  // CurrencyFooter row for JPY
+  expect(screen.getByText(/Also in this report:/i)).toBeInTheDocument();
+});

--- a/spa/src/test/reports.net-worth.test.tsx
+++ b/spa/src/test/reports.net-worth.test.tsx
@@ -12,13 +12,16 @@ beforeEach(() => {
   vi.stubGlobal(
     'fetch',
     vi.fn((url: string) => {
-      if (url === '/api/config') return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+      if (url === '/api/config')
+        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
       if (url === '/api/ledgers')
         return Promise.resolve(
           okResponse({ active: 'p', items: [{ name: 'p', path: '/p.db', active: true }] }),
         );
       if (url.startsWith('/api/reports/net-worth'))
-        return Promise.resolve(okResponse({ at: 1781697600, net_worth: { USD: 5000000, JPY: 12000000 } }));
+        return Promise.resolve(
+          okResponse({ at: 1781697600, net_worth: { USD: 5000000, JPY: 12000000 } }),
+        );
       throw new Error(`unexpected fetch: ${url}`);
     }),
   );

--- a/spa/src/test/reports.period-picker.test.tsx
+++ b/spa/src/test/reports.period-picker.test.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { expect, test } from 'vitest';
-import type { PeriodSearchParams } from '../lib/reports-search-params';
 import { PeriodPicker } from '../components/reports/PeriodPicker';
+import type { PeriodSearchParams } from '../lib/reports-search-params';
 
 test('renders all preset chips', () => {
   const noop = (_: Partial<PeriodSearchParams>) => {};

--- a/spa/src/test/reports.period-picker.test.tsx
+++ b/spa/src/test/reports.period-picker.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, test } from 'vitest';
+import type { PeriodSearchParams } from '../lib/reports-search-params';
+import { PeriodPicker } from '../components/reports/PeriodPicker';
+
+test('renders all preset chips', () => {
+  const noop = (_: Partial<PeriodSearchParams>) => {};
+  render(<PeriodPicker value={{ range: 'this-month' }} onChange={noop} label="June 2026" />);
+  expect(screen.getByRole('button', { name: /this month/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /last month/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /ytd/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /last 12 months/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /custom/i })).toBeInTheDocument();
+});
+
+test('clicking a chip calls onChange with new range', async () => {
+  const calls: Partial<PeriodSearchParams>[] = [];
+  render(
+    <PeriodPicker
+      value={{ range: 'this-month' }}
+      onChange={(v) => calls.push(v)}
+      label="June 2026"
+    />,
+  );
+  await userEvent.click(screen.getByRole('button', { name: /ytd/i }));
+  expect(calls).toEqual([{ range: 'ytd' }]);
+});
+
+test('active chip has aria-pressed=true', () => {
+  const noop = (_: Partial<PeriodSearchParams>) => {};
+  render(<PeriodPicker value={{ range: 'ytd' }} onChange={noop} label="YTD 2026" />);
+  expect(screen.getByRole('button', { name: /ytd/i }).getAttribute('aria-pressed')).toBe('true');
+  expect(screen.getByRole('button', { name: /this month/i }).getAttribute('aria-pressed')).toBe(
+    'false',
+  );
+});
+
+test('custom mode shows from/to inputs and emits change', async () => {
+  const calls: Partial<PeriodSearchParams>[] = [];
+  render(
+    <PeriodPicker
+      value={{ range: 'custom', from: '2026-01-01', to: '2026-01-31' }}
+      onChange={(v) => calls.push(v)}
+      label="Jan 1 – Jan 31, 2026"
+    />,
+  );
+  const fromInput = screen.getByLabelText(/from/i) as HTMLInputElement;
+  const toInput = screen.getByLabelText(/to/i) as HTMLInputElement;
+  expect(fromInput.value).toBe('2026-01-01');
+  expect(toInput.value).toBe('2026-01-31');
+  fireEvent.change(fromInput, { target: { value: '2026-02-01' } });
+  // Assert at least one custom call carries the new from
+  expect(calls.some((c) => c.range === 'custom' && c.from === '2026-02-01')).toBe(true);
+});
+
+test('renders human-readable label', () => {
+  const noop = (_: Partial<PeriodSearchParams>) => {};
+  render(<PeriodPicker value={{ range: 'this-month' }} onChange={noop} label="June 2026" />);
+  expect(screen.getByText('June 2026')).toBeInTheDocument();
+});

--- a/spa/src/test/reports.proportion-bar.test.tsx
+++ b/spa/src/test/reports.proportion-bar.test.tsx
@@ -41,9 +41,7 @@ test('clicking expand renders all rows', async () => {
     currency: 'USD',
     tx_count: 1,
   }));
-  const { container } = render(
-    <ProportionBar rows={many} total={1000} currency="USD" limit={5} />,
-  );
+  const { container } = render(<ProportionBar rows={many} total={1000} currency="USD" limit={5} />);
   await userEvent.click(screen.getByRole('button', { name: /5 more/i }));
   expect(container.querySelectorAll('[data-testid="prop-bar"]').length).toBe(10);
 });

--- a/spa/src/test/reports.proportion-bar.test.tsx
+++ b/spa/src/test/reports.proportion-bar.test.tsx
@@ -49,10 +49,10 @@ test('clicking expand renders all rows', async () => {
 });
 
 test('bar width is proportional to amount/total', () => {
-  const { container } = render(<ProportionBar rows={rows} total={524800} currency="USD" />);
+  const { container } = render(<ProportionBar rows={rows} total={520000} currency="USD" />);
   const bars = container.querySelectorAll('[data-testid="prop-bar"] [data-testid="bar-fill"]');
   expect(bars[0].getAttribute('style')).toContain('width: 100%');
-  // 4800/524800 ≈ 0.91%
+  // 4800/520000 ≈ 0.92%
   expect(bars[1].getAttribute('style')).toMatch(/width: 0\.\d+%|width: 1%/);
 });
 

--- a/spa/src/test/reports.proportion-bar.test.tsx
+++ b/spa/src/test/reports.proportion-bar.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, test } from 'vitest';
+import { ProportionBar } from '../components/reports/ProportionBar';
+import type { ReportRow } from '../lib/types';
+
+const rows: ReportRow[] = [
+  { account_name: 'Salary', offset_account: '', amount: 520000, currency: 'USD', tx_count: 1 },
+  { account_name: 'Interest', offset_account: '', amount: 4800, currency: 'USD', tx_count: 2 },
+];
+
+test('renders one bar per row up to limit', () => {
+  const many: ReportRow[] = Array.from({ length: 10 }, (_, i) => ({
+    account_name: `Row${i}`,
+    offset_account: '',
+    amount: 100 * (10 - i),
+    currency: 'USD',
+    tx_count: 1,
+  }));
+  const { container } = render(<ProportionBar rows={many} total={5500} currency="USD" limit={5} />);
+  expect(container.querySelectorAll('[data-testid="prop-bar"]').length).toBe(5);
+});
+
+test('shows expand button when rows exceed limit', () => {
+  const many: ReportRow[] = Array.from({ length: 10 }, (_, i) => ({
+    account_name: `Row${i}`,
+    offset_account: '',
+    amount: 100,
+    currency: 'USD',
+    tx_count: 1,
+  }));
+  render(<ProportionBar rows={many} total={1000} currency="USD" limit={5} />);
+  expect(screen.getByRole('button', { name: /5 more/i })).toBeInTheDocument();
+});
+
+test('clicking expand renders all rows', async () => {
+  const many: ReportRow[] = Array.from({ length: 10 }, (_, i) => ({
+    account_name: `Row${i}`,
+    offset_account: '',
+    amount: 100,
+    currency: 'USD',
+    tx_count: 1,
+  }));
+  const { container } = render(
+    <ProportionBar rows={many} total={1000} currency="USD" limit={5} />,
+  );
+  await userEvent.click(screen.getByRole('button', { name: /5 more/i }));
+  expect(container.querySelectorAll('[data-testid="prop-bar"]').length).toBe(10);
+});
+
+test('bar width is proportional to amount/total', () => {
+  const { container } = render(<ProportionBar rows={rows} total={524800} currency="USD" />);
+  const bars = container.querySelectorAll('[data-testid="prop-bar"] [data-testid="bar-fill"]');
+  expect(bars[0].getAttribute('style')).toContain('width: 100%');
+  // 4800/524800 ≈ 0.91%
+  expect(bars[1].getAttribute('style')).toMatch(/width: 0\.\d+%|width: 1%/);
+});
+
+test('renders empty state when no rows', () => {
+  render(<ProportionBar rows={[]} total={0} currency="USD" />);
+  expect(screen.getByText(/no data/i)).toBeInTheDocument();
+});
+
+test('handles total=0 without dividing by zero', () => {
+  const r: ReportRow[] = [
+    { account_name: 'A', offset_account: '', amount: 0, currency: 'USD', tx_count: 1 },
+  ];
+  const { container } = render(<ProportionBar rows={r} total={0} currency="USD" />);
+  const fill = container.querySelector('[data-testid="bar-fill"]');
+  expect(fill?.getAttribute('style')).toContain('width: 0%');
+});
+
+test('uses absolute values for negative amounts', () => {
+  const r: ReportRow[] = [
+    { account_name: 'Refund', offset_account: '', amount: -10000, currency: 'USD', tx_count: 1 },
+    { account_name: 'Other', offset_account: '', amount: 10000, currency: 'USD', tx_count: 1 },
+  ];
+  const { container } = render(<ProportionBar rows={r} total={-20000} currency="USD" />);
+  const bars = container.querySelectorAll('[data-testid="bar-fill"]');
+  expect(bars[0].getAttribute('style')).toContain('width: 50%');
+  expect(bars[1].getAttribute('style')).toContain('width: 50%');
+});

--- a/spa/src/test/reports.report-row-table.test.tsx
+++ b/spa/src/test/reports.report-row-table.test.tsx
@@ -1,5 +1,3 @@
-import { ReportRowTable } from '../components/reports/ReportRowTable';
-import type { ReportRow } from '../lib/types';
 import {
   RootRoute,
   Route,
@@ -9,6 +7,8 @@ import {
 } from '@tanstack/react-router';
 import { render, screen } from '@testing-library/react';
 import { expect, test } from 'vitest';
+import { ReportRowTable } from '../components/reports/ReportRowTable';
+import type { ReportRow } from '../lib/types';
 
 function harness(node: React.ReactNode) {
   const rootRoute = new RootRoute({ component: () => <>{node}</> });
@@ -96,11 +96,7 @@ test('rows without a resolvable id omit account_id', async () => {
 });
 
 test('with period=null, rows link to /accounts/{id}', async () => {
-  render(
-    harness(
-      <ReportRowTable rows={rows} currency="USD" nameToId={nameToId} period={null} />,
-    ),
-  );
+  render(harness(<ReportRowTable rows={rows} currency="USD" nameToId={nameToId} period={null} />));
   const link = await screen.findByRole('link', { name: /Expenses:Food:Groceries/ });
   expect(link.getAttribute('href')).toMatch(/\/accounts\/11/);
 });

--- a/spa/src/test/reports.report-row-table.test.tsx
+++ b/spa/src/test/reports.report-row-table.test.tsx
@@ -1,0 +1,111 @@
+import { ReportRowTable } from '../components/reports/ReportRowTable';
+import type { ReportRow } from '../lib/types';
+import {
+  RootRoute,
+  Route,
+  Router,
+  RouterProvider,
+  createMemoryHistory,
+} from '@tanstack/react-router';
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+
+function harness(node: React.ReactNode) {
+  const rootRoute = new RootRoute({ component: () => <>{node}</> });
+  const dummy = new Route({ getParentRoute: () => rootRoute, path: '/', component: () => null });
+  const router = new Router({
+    routeTree: rootRoute.addChildren([dummy]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  });
+  return <RouterProvider router={router} />;
+}
+
+const rows: ReportRow[] = [
+  {
+    account_name: 'Expenses:Food:Groceries',
+    offset_account: 'Assets:Bank',
+    amount: 52000,
+    currency: 'USD',
+    tx_count: 3,
+  },
+  {
+    account_name: 'Expenses:Rent',
+    offset_account: 'Assets:Bank',
+    amount: 180000,
+    currency: 'USD',
+    tx_count: 1,
+  },
+];
+
+const nameToId = new Map<string, number>([
+  ['Expenses:Food:Groceries', 11],
+  ['Expenses:Rent', 12],
+]);
+
+test('renders rows with account name, amount, tx count', async () => {
+  render(
+    harness(
+      <ReportRowTable
+        rows={rows}
+        currency="USD"
+        nameToId={nameToId}
+        period={{ startUnix: 100, endUnix: 200 }}
+      />,
+    ),
+  );
+  expect(await screen.findByText('Expenses:Food:Groceries')).toBeInTheDocument();
+  expect(screen.getByText('Expenses:Rent')).toBeInTheDocument();
+  expect(screen.getByText('$520.00')).toBeInTheDocument();
+  expect(screen.getByText('$1,800.00')).toBeInTheDocument();
+});
+
+test('rows link to /transactions with account_id and bounds', async () => {
+  render(
+    harness(
+      <ReportRowTable
+        rows={rows}
+        currency="USD"
+        nameToId={nameToId}
+        period={{ startUnix: 100, endUnix: 200 }}
+      />,
+    ),
+  );
+  const link = await screen.findByRole('link', { name: /Expenses:Food:Groceries/ });
+  const href = link.getAttribute('href') ?? '';
+  expect(href).toContain('/transactions');
+  expect(href).toContain('account_id=11');
+  expect(href).toContain('start_time=100');
+  expect(href).toContain('end_time=200');
+});
+
+test('rows without a resolvable id omit account_id', async () => {
+  render(
+    harness(
+      <ReportRowTable
+        rows={rows}
+        currency="USD"
+        nameToId={new Map()}
+        period={{ startUnix: 100, endUnix: 200 }}
+      />,
+    ),
+  );
+  const link = await screen.findByRole('link', { name: /Expenses:Food:Groceries/ });
+  const href = link.getAttribute('href') ?? '';
+  expect(href).not.toContain('account_id=');
+  expect(href).toContain('start_time=100');
+});
+
+test('with period=null, rows link to /accounts/{id}', async () => {
+  render(
+    harness(
+      <ReportRowTable rows={rows} currency="USD" nameToId={nameToId} period={null} />,
+    ),
+  );
+  const link = await screen.findByRole('link', { name: /Expenses:Food:Groceries/ });
+  expect(link.getAttribute('href')).toMatch(/\/accounts\/11/);
+});
+
+test('renders empty-state message when rows is empty', async () => {
+  render(harness(<ReportRowTable rows={[]} currency="USD" nameToId={nameToId} period={null} />));
+  expect(await screen.findByText(/no rows/i)).toBeInTheDocument();
+});

--- a/spa/src/test/reports.tab-nav.test.tsx
+++ b/spa/src/test/reports.tab-nav.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { makeTestApp } from './test-app';
+
+test('renders all 5 report tabs', () => {
+  render(makeTestApp('/reports/income-statement'));
+  expect(screen.getByRole('link', { name: /Income Statement/i })).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /Income Breakdown/i })).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /Expense Breakdown/i })).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /Balance Sheet/i })).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /Net Worth/i })).toBeInTheDocument();
+});
+
+test('marks the active tab', () => {
+  render(makeTestApp('/reports/balance-sheet'));
+  const active = screen.getByRole('link', { name: /Balance Sheet/i });
+  expect(active.getAttribute('aria-current')).toBe('page');
+});

--- a/spa/src/test/reports.tab-nav.test.tsx
+++ b/spa/src/test/reports.tab-nav.test.tsx
@@ -1,18 +1,77 @@
-import { render, screen } from '@testing-library/react';
-import { expect, test } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { makeTestApp } from './test-app';
 
-test('renders all 5 report tabs', () => {
+const okResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string) => {
+      if (url === '/api/config') {
+        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+      }
+      if (url === '/api/ledgers') {
+        return Promise.resolve(
+          okResponse({ active: 'p', items: [{ name: 'p', path: '/p.db', active: true }] }),
+        );
+      }
+      // Tab-nav tests don't care about report data; return empty payloads.
+      if (url === '/api/balances') {
+        return Promise.resolve(okResponse({ items: [], total_count: 0, limit: 0, offset: 0 }));
+      }
+      if (url.startsWith('/api/reports/')) {
+        return Promise.resolve(
+          okResponse({
+            period: '',
+            total_income: {},
+            total_expense: {},
+            net_amount: {},
+            net_worth: {},
+            previous_net_worth: {},
+            net_worth_growth_pct: {},
+            income_rows: [],
+            expense_rows: [],
+            assets: [],
+            liabilities: [],
+            equity: [],
+            total_assets: {},
+            total_liabilities: {},
+            total_equity: {},
+            as_of: 0,
+            at: 0,
+          }),
+        );
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test('renders all 5 report tabs', async () => {
   render(makeTestApp('/reports/income-statement'));
-  expect(screen.getByRole('link', { name: /Income Statement/i })).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.getByRole('link', { name: /Income Statement/i })).toBeInTheDocument();
+  });
   expect(screen.getByRole('link', { name: /Income Breakdown/i })).toBeInTheDocument();
   expect(screen.getByRole('link', { name: /Expense Breakdown/i })).toBeInTheDocument();
   expect(screen.getByRole('link', { name: /Balance Sheet/i })).toBeInTheDocument();
   expect(screen.getByRole('link', { name: /Net Worth/i })).toBeInTheDocument();
 });
 
-test('marks the active tab', () => {
+test('marks the active tab', async () => {
   render(makeTestApp('/reports/balance-sheet'));
+  await waitFor(() => {
+    expect(screen.getByRole('link', { name: /Balance Sheet/i })).toBeInTheDocument();
+  });
   const active = screen.getByRole('link', { name: /Balance Sheet/i });
   expect(active.getAttribute('aria-current')).toBe('page');
 });


### PR DESCRIPTION
## Summary
- Adds `/reports` parent + 5 sub-routes (Income Statement, Income Breakdown, Expense Breakdown, Balance Sheet, Net Worth) consuming the existing `/api/reports/*` endpoints — no backend changes.
- 7 shared components under `components/reports/`: KpiCard, ProportionBar (hand-rolled SVG, no chart library), CurrencyFooter, ReportRowTable (drill-down to `/transactions` or `/accounts/{id}`), TabNav, PeriodPicker (chip presets + custom range), AsOfPicker.
- `period.ts` resolves chip presets into both API params and Unix bounds (10 unit tests).
- Zod search-param schemas per route shape (period / as-of / at).
- Sidebar `Reports` entry enabled with prefix-matching for sub-route active state.

## Spec & plan
- Spec: `docs/superpowers/specs/2026-06-16-spa-reports-design.md`
- Plan: `docs/superpowers/plans/2026-06-16-spa-reports.md`

## Test plan
- [x] `cd spa && npm test` — 199 passed, 6 pre-existing balance-page failures unchanged (verified against master via worktree)
- [x] `cd spa && npm run check` — biome clean
- [x] `cd spa && npx tsc --noEmit` — clean
- [x] `cd spa && npm run build` — production build clean
- [ ] Manual: `make run -- serve` + `make spa-dev`, walk all five tabs; verify chip presets update the URL, custom range reveals from/to inputs, row click drills into `/transactions` with `account_id` / `start_time` / `end_time`, Balance Sheet rows drill to `/accounts/{id}`, Net Worth empty state links to `/accounts/new`.

## Known issues out of scope
- 6 pre-existing test failures in `balances.test.tsx` / `balances.link.test.tsx` on master.
- Minor polish flagged in final review but non-blocking: Balance Sheet loading skeleton density, `ProportionBar` has no collapse, leap-day edge in `last-12mo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)