### PR TITLE
fix(reports): emit empty arrays instead of null for empty ledgers

### DIFF
--- a/internal/service/report_service.go
+++ b/internal/service/report_service.go
@@ -257,6 +257,7 @@ func (ts *TransactionService) GenerateIncomeBreakdown(ctx context.Context, start
 
 	return &model.ReportResult{
 		IncomeRows:  rows,
+		ExpenseRows: []model.ReportRow{},
 		TotalIncome: total,
 	}, nil
 }
@@ -277,6 +278,7 @@ func (ts *TransactionService) GenerateExpenseBreakdown(ctx context.Context, star
 	}
 
 	return &model.ReportResult{
+		IncomeRows:   []model.ReportRow{},
 		ExpenseRows:  rows,
 		TotalExpense: total,
 	}, nil
@@ -297,6 +299,9 @@ func (ts *TransactionService) GenerateBalanceSheet(ctx context.Context, asOf int
 
 	result := &model.BalanceSheetResult{
 		AsOf:             asOf,
+		Assets:           []model.ReportRow{},
+		Liabilities:      []model.ReportRow{},
+		Equity:           []model.ReportRow{},
 		TotalAssets:      map[string]int64{},
 		TotalLiabilities: map[string]int64{},
 		TotalEquity:      map[string]int64{},

--- a/internal/service/report_service_test.go
+++ b/internal/service/report_service_test.go
@@ -591,6 +591,15 @@ func TestGenerateIncomeBreakdown(t *testing.T) {
 		require.Len(t, result.IncomeRows, 2)
 		assert.GreaterOrEqual(t, result.IncomeRows[0].Amount, result.IncomeRows[1].Amount)
 	})
+
+	t.Run("unused expense rows slice is non-nil so it serializes as []", func(t *testing.T) {
+		// Reason: JSON marshals a nil slice as `null`, which crashes the SPA's
+		// `result.expense_rows.filter(...)`. The handler must emit `[]`.
+		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
+		result, err := svc.GenerateIncomeBreakdown(context.Background(), 0, 0)
+		require.NoError(t, err)
+		require.NotNil(t, result.ExpenseRows)
+	})
 }
 
 // ──────────────────────────────────────────────
@@ -617,6 +626,14 @@ func TestGenerateExpenseBreakdown(t *testing.T) {
 		assert.Equal(t, int64(500), result.TotalExpense["USD"])
 		assert.NotEmpty(t, result.ExpenseRows)
 		assert.Empty(t, result.IncomeRows)
+	})
+
+	t.Run("unused income rows slice is non-nil so it serializes as []", func(t *testing.T) {
+		// Reason: a nil slice JSON-marshals to `null` and crashes the SPA.
+		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
+		result, err := svc.GenerateExpenseBreakdown(context.Background(), 0, 0)
+		require.NoError(t, err)
+		require.NotNil(t, result.IncomeRows)
 	})
 }
 
@@ -817,5 +834,17 @@ func TestGenerateBalanceSheet(t *testing.T) {
 		assert.Equal(t, int64(8000), result.NetWorth["USD"]) // 7000 - (-1000)
 		require.Len(t, result.Liabilities, 1)
 		assert.Equal(t, int64(-1000), result.Liabilities[0].Amount)
+	})
+
+	t.Run("empty ledger returns non-nil slices that serialize as []", func(t *testing.T) {
+		// Reason: a nil slice JSON-marshals to `null` and crashes the SPA's
+		// `result.liabilities.filter(...)` on databases with no liabilities (or
+		// no assets, or no equity accounts).
+		svc := newTestTransactionService(newMockAccountRepo(), newMockTransactionRepo())
+		result, err := svc.GenerateBalanceSheet(context.Background(), 9999999999)
+		require.NoError(t, err)
+		require.NotNil(t, result.Assets)
+		require.NotNil(t, result.Liabilities)
+		require.NotNil(t, result.Equity)
 	})
 }

--- a/spa/src/routes/reports.balance-sheet.tsx
+++ b/spa/src/routes/reports.balance-sheet.tsx
@@ -69,9 +69,9 @@ function BalanceSheetPage() {
   const tl = result.total_liabilities[currency] ?? 0;
   const te = result.total_equity[currency] ?? 0;
   const nw = result.net_worth[currency] ?? 0;
-  const assets = result.assets.filter((r) => r.currency === currency);
-  const liabilities = result.liabilities.filter((r) => r.currency === currency);
-  const equity = result.equity.filter((r) => r.currency === currency);
+  const assets = (result.assets ?? []).filter((r) => r.currency === currency);
+  const liabilities = (result.liabilities ?? []).filter((r) => r.currency === currency);
+  const equity = (result.equity ?? []).filter((r) => r.currency === currency);
 
   if (assets.length === 0 && liabilities.length === 0 && equity.length === 0) {
     return (

--- a/spa/src/routes/reports.expense-breakdown.tsx
+++ b/spa/src/routes/reports.expense-breakdown.tsx
@@ -67,7 +67,7 @@ function ExpenseBreakdownPage() {
 
   const result = query.data;
   const expense = result.total_expense[currency] ?? 0;
-  const rows = result.expense_rows.filter((r) => r.currency === currency);
+  const rows = (result.expense_rows ?? []).filter((r) => r.currency === currency);
 
   return (
     <div className="space-y-6">

--- a/spa/src/routes/reports.income-breakdown.tsx
+++ b/spa/src/routes/reports.income-breakdown.tsx
@@ -67,7 +67,7 @@ function IncomeBreakdownPage() {
 
   const result = query.data;
   const income = result.total_income[currency] ?? 0;
-  const rows = result.income_rows.filter((r) => r.currency === currency);
+  const rows = (result.income_rows ?? []).filter((r) => r.currency === currency);
 
   return (
     <div className="space-y-6">

--- a/spa/src/routes/reports.income-statement.tsx
+++ b/spa/src/routes/reports.income-statement.tsx
@@ -73,8 +73,8 @@ function IncomeStatementPage() {
   }
 
   const result = query.data;
-  const incomeRows = result.income_rows.filter((r) => r.currency === currency);
-  const expenseRows = result.expense_rows.filter((r) => r.currency === currency);
+  const incomeRows = (result.income_rows ?? []).filter((r) => r.currency === currency);
+  const expenseRows = (result.expense_rows ?? []).filter((r) => r.currency === currency);
   const isEmpty = incomeRows.length === 0 && expenseRows.length === 0;
 
   const income = result.total_income[currency] ?? 0;


### PR DESCRIPTION
## Summary

The SPA's Balance Sheet page crashed with `can't access property "filter", l.liabilities is null` when opened against a database that had no liability accounts. Same null-slice JSON serialization bug applied to:

- `GenerateBalanceSheet` — `Assets` / `Liabilities` / `Equity` were `nil` if no account of that type existed.
- `GenerateIncomeBreakdown` — `ExpenseRows` was always `nil`.
- `GenerateExpenseBreakdown` — `IncomeRows` was always `nil`.

Root cause: Go marshals `nil` slices to JSON `null`, not `[]`.

## Fix

**Backend** (the contract fix): initialize the slices in the result struct to `[]model.ReportRow{}`. New tests lock this in by asserting `require.NotNil(t, result.X)` on the empty-ledger case for each function.

**Frontend** (defense-in-depth): add `(xs ?? []).filter(...)` on every `result.*_rows` / `result.assets|liabilities|equity` filter call across the four affected routes — so SPAs talking to an older binary keep working.

## Test plan
- [x] `go test ./...` — clean (3 new subtests added for empty-ledger non-nil slices)
- [x] `cd spa && npx tsc --noEmit` — clean
- [x] `cd spa && npx vitest run src/test/reports.*.test.tsx` — 7/7 pass
- [ ] Manual: open `/reports/balance-sheet` against a database with no liabilities (the original repro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)