### PR TITLE
feat(spa): income statement layout tweaks (Top 5, prior-period diff)

### DIFF
--- a/docs/2026-06-17-income-statement-layout-tweaks-design.md
+++ b/docs/2026-06-17-income-statement-layout-tweaks-design.md
@@ -1,0 +1,163 @@
+# Income Statement Layout Tweaks
+
+## Goal
+
+Tighten the `/reports/income-statement` page:
+
+1. Show only the top 5 rows in the Income mix and Expense mix bars (down from 8).
+2. Remove the Income detail and Expense detail row tables from this page (the standalone `/reports/income-breakdown` and `/reports/expense-breakdown` routes are unaffected).
+3. Show a prior-period diff on the Income, Expense, and Net KPI cards.
+
+## Files affected
+
+- `spa/src/routes/reports.income-statement.tsx` — main page wiring
+- `spa/src/lib/period.ts` — new `previousPeriod` helper
+- `spa/src/lib/hooks/useReport.ts` — already exposes `useIncomeStatement`; no new hook needed (callsite passes a different `params` object)
+- `spa/src/components/reports/KpiCard.tsx` — new optional `diff` prop
+- `spa/src/test/period.test.ts` — new file, `previousPeriod` cases
+- `spa/src/test/reports.kpi-card.test.tsx` — diff prop cases
+- `spa/src/test/reports.income-statement.test.tsx` — assert layout changes
+- Existing `ReportRowTable` component and its test stay (still used by breakdown routes)
+
+## 1. Mix bar limit
+
+Change `limit={8}` → `limit={5}` on both `ProportionBar` calls in [reports.income-statement.tsx](spa/src/routes/reports.income-statement.tsx). The existing "+ N more" expand button is unchanged.
+
+## 2. Remove detail tables
+
+Delete the second `grid grid-cols-2 gap-6` block containing the two Income/Expense detail `ReportRowTable` sections.
+
+Resulting dead code to also remove from `reports.income-statement.tsx`:
+
+- `balancesQuery` (line 31)
+- `nameToId` memo (lines 32–38)
+- Imports: `ReportRowTable`, `getBalances`
+
+(`useQuery` import stays — section 3.2 reuses it for the previous-period fetch.)
+
+The Currency footer stays.
+
+## 3. Prior-period diff on KPI cards
+
+### 3.1 `previousPeriod` helper
+
+Add to `spa/src/lib/period.ts`:
+
+```ts
+export function previousPeriod(
+  search: PeriodSearch,
+  resolved: ResolvedPeriod,
+  nowUnix: number = Date.now() / 1000,
+): { apiParams: PeriodApiParams } | null
+```
+
+Returns `null` when no sensible prior window exists (shouldn't happen for the four canonical ranges, but guards custom edge cases). Otherwise returns API params suitable for `fetchIncomeStatement`.
+
+Rules per range:
+
+| Current range | Previous range |
+|---|---|
+| `this-month` (Y-M) | previous calendar month (handles Jan → Dec of prior year) |
+| `last-month` | the month before that |
+| `ytd` (Jan 1 → today of year Y) | `from=(Y-1)-01-01, to=(Y-1)-MM-DD` (same MM-DD as today) |
+| `last-12mo` (12 months ending today) | the 12 months ending one day before current `startUnix` |
+| `custom from..to` | same-length window ending one day before `from`. Length = `to - from` in days. |
+
+For `this-month` / `last-month` / previous-of-`ytd`, return `{ month }` or `{ from, to }` matching the existing API shape.
+
+### 3.2 Data fetch
+
+In `reports.income-statement.tsx`:
+
+```ts
+const previous = useMemo(() => previousPeriod(search, period), [search, period]);
+const previousQuery = useQuery({
+  queryKey: ['reports', 'income-statement', previous?.apiParams],
+  queryFn: () => fetchIncomeStatement(previous!.apiParams),
+  enabled: previous !== null,
+});
+```
+
+The previous query is **supplementary**: if it's loading or errored, KPI cards render without a diff. No spinner, no error UI. The main page's existing pending/error states only key off the primary `query`.
+
+### 3.3 `KpiCard` `diff` prop
+
+```ts
+interface DiffInfo {
+  delta: number;            // current - previous, in cents
+  prevAmount: number;       // for percent calc; if 0, percent is omitted
+  goodWhen: 'up' | 'down';  // semantic direction
+}
+
+interface Props {
+  // ...existing...
+  diff?: DiffInfo;
+}
+```
+
+Render as an additional sub-line below `subLine` (so the Net card shows both net-worth growth AND the period-over-period diff):
+
+- Arrow: `▲` when `delta > 0`, `▼` when `delta < 0`, `—` when `delta === 0`
+- Format: `{arrow} {±formatCents(delta, currency)}{ (±X.X%) if prevAmount !== 0} vs last period`
+- Color:
+  - `delta === 0` → muted
+  - sign matches `goodWhen` → green (`text-green-700 dark:text-green-400`)
+  - sign opposes `goodWhen` → red (`text-red-700 dark:text-red-400`)
+- Test id: `data-testid="kpi-diff"`
+
+Sign convention: "good" means `delta > 0 && goodWhen === 'up'` OR `delta < 0 && goodWhen === 'down'`.
+
+Percent is computed as `(delta / Math.abs(prevAmount)) * 100`, displayed with one decimal, sign included. Skipped entirely when `prevAmount === 0`.
+
+### 3.4 Wiring per card
+
+```ts
+const prevIncome  = previousQuery.data?.total_income[currency]  ?? 0;
+const prevExpense = previousQuery.data?.total_expense[currency] ?? 0;
+const prevNet     = previousQuery.data?.net_amount[currency]    ?? 0;
+const hasPrev     = previousQuery.isSuccess;
+
+<KpiCard ... diff={hasPrev ? { delta: income - prevIncome, prevAmount: prevIncome, goodWhen: 'up' }   : undefined} />
+<KpiCard ... diff={hasPrev ? { delta: expense - prevExpense, prevAmount: prevExpense, goodWhen: 'down' } : undefined} />
+<KpiCard ... subLine={netSubLine} diff={hasPrev ? { delta: net - prevNet, prevAmount: prevNet, goodWhen: 'up' } : undefined} />
+```
+
+Note `expense` and `prevExpense` are positive cents (totals are reported as positive magnitudes in this codebase — verified against existing usage at [reports.income-statement.tsx:81](spa/src/routes/reports.income-statement.tsx:81)). `delta > 0` for expense means expense grew, which `goodWhen: 'down'` correctly colors red.
+
+## Testing
+
+### `period.test.ts` (new)
+
+Cases for `previousPeriod`:
+
+- `this-month` 2026-06 → `{ month: '2026-05' }`
+- `this-month` 2026-01 → `{ month: '2025-12' }` (year rollover)
+- `last-month` (`nowUnix` in 2026-06) → previous calendar month two back, i.e. `{ month: '2026-04' }`
+- `ytd` with `nowUnix=2026-06-17` → `{ from: '2025-01-01', to: '2025-06-17' }`
+- `last-12mo` with `nowUnix=2026-06-17` → 12 months ending one day before current window's start
+- `custom from=2026-03-01,to=2026-03-31` → `{ from: '2026-01-29', to: '2026-02-28' }` (same length, ending one day before `from`)
+
+### `reports.kpi-card.test.tsx` (updated)
+
+- Renders diff line with `▲` arrow and green text when `delta > 0` and `goodWhen='up'`
+- Renders diff line with `▲` arrow and red text when `delta > 0` and `goodWhen='down'`
+- Renders diff line with `▼` arrow and red text when `delta < 0` and `goodWhen='up'`
+- Renders diff line with `—` and muted text when `delta === 0`
+- Omits percent when `prevAmount === 0`
+- Coexists with `subLine` — both render
+- No `data-testid="kpi-diff"` element when `diff` prop omitted
+
+### `reports.income-statement.test.tsx` (updated)
+
+- "Income detail" and "Expense detail" headings no longer present
+- `ReportRowTable` not rendered on this page (assert absence by test-id or heading)
+- ProportionBar shows at most 5 rows initially
+- When mock fixture has previous-period data, KPI cards render `data-testid="kpi-diff"`
+- When previous-period query is pending or errored, KPI cards render without `data-testid="kpi-diff"`
+
+## Out of scope
+
+- The standalone `/reports/income-breakdown` and `/reports/expense-breakdown` routes
+- Changing the `CurrencyFooter`
+- Any backend / API changes
+- Persisting "expanded" state across navigation

--- a/docs/2026-06-17-income-statement-layout-tweaks-plan.md
+++ b/docs/2026-06-17-income-statement-layout-tweaks-plan.md
@@ -1,0 +1,903 @@
+# Income Statement Layout Tweaks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Trim the `/reports/income-statement` page — top-5 mix bars, remove detail tables, and add prior-period diff lines on the Income / Expense / Net KPI cards.
+
+**Architecture:** Pure SPA-side change. The diff is computed in the page by issuing a second `useQuery` against the existing `/api/reports/income-statement` endpoint with previous-period params; the prior-window is computed by a new `previousPeriod` helper in `lib/period.ts`. `KpiCard` gains an optional `diff` prop; the previous-period fetch is supplementary (no spinner / error UI). No backend changes.
+
+**Tech Stack:** React, TypeScript, TanStack Query, TanStack Router, Tailwind, Vitest, Testing Library.
+
+**Reference spec:** [docs/2026-06-17-income-statement-layout-tweaks-design.md](docs/2026-06-17-income-statement-layout-tweaks-design.md)
+
+**Commands:**
+- All SPA tests: `cd spa && npm test`
+- Single SPA test file: `cd spa && npx vitest run src/test/<name>.test.tsx`
+- Watch mode: `cd spa && npm run test:watch`
+- Build (type-check): `cd spa && npm run build`
+
+---
+
+## File Structure
+
+**Modified:**
+- `spa/src/lib/period.ts` — add `previousPeriod` helper
+- `spa/src/components/reports/KpiCard.tsx` — add optional `diff` prop and rendering
+- `spa/src/routes/reports.income-statement.tsx` — limit→5, remove detail tables, add previous-period query, wire diffs
+- `spa/src/test/reports.kpi-card.test.tsx` — new test cases for `diff`
+- `spa/src/test/reports.income-statement.test.tsx` — assert detail tables removed; assert diff lines render; drop drill-down test (links lived in detail table)
+
+**Created:**
+- `spa/src/test/period.test.ts` — covers `previousPeriod` (new file; no existing `period` test)
+
+**Not touched (deliberately):**
+- `spa/src/components/reports/ProportionBar.tsx` — already accepts `limit` and has tests
+- `spa/src/components/reports/ReportRowTable.tsx` — still used by `/reports/income-breakdown` and `/reports/expense-breakdown`
+- API client `spa/src/lib/api/reports.ts` and hooks in `spa/src/lib/hooks/useReport.ts` — reused as-is
+- All non-SPA Go code
+
+---
+
+### Task 1: Mix bar `limit` 8 → 5
+
+**Files:**
+- Modify: `spa/src/routes/reports.income-statement.tsx` (the two `<ProportionBar>` calls)
+
+- [ ] **Step 1: Change `limit` on both `ProportionBar` calls**
+
+In `spa/src/routes/reports.income-statement.tsx`, find the income/expense mix block (currently around lines 112–133):
+
+```tsx
+<ProportionBar
+  rows={incomeRows}
+  total={income}
+  currency={currency}
+  limit={8}
+  variant="income"
+/>
+```
+
+```tsx
+<ProportionBar
+  rows={expenseRows}
+  total={expense}
+  currency={currency}
+  limit={8}
+  variant="expense"
+/>
+```
+
+Change both `limit={8}` to `limit={5}`.
+
+- [ ] **Step 2: Run the existing income-statement integration test**
+
+```bash
+cd spa && npx vitest run src/test/reports.income-statement.test.tsx
+```
+
+Expected: PASS (current fixture has only 1 income row and 2 expense rows, so the limit change is invisible to it).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add spa/src/routes/reports.income-statement.tsx
+git commit -m "feat(spa): cap income statement mix bars at top 5"
+```
+
+---
+
+### Task 2: Remove "Income detail" / "Expense detail" tables
+
+**Files:**
+- Modify: `spa/src/routes/reports.income-statement.tsx`
+- Modify: `spa/src/test/reports.income-statement.test.tsx`
+
+The detail tables and their drill-down links are going away. The standalone `/reports/income-breakdown` and `/reports/expense-breakdown` routes are unaffected.
+
+- [ ] **Step 1: Update integration test to expect detail tables gone**
+
+In `spa/src/test/reports.income-statement.test.tsx`:
+
+1. **Drop the drill-down test** (it asserts a `link` for `Expenses:Rent`, which only existed inside the detail table). Delete the entire test starting at:
+   ```tsx
+   test('drill-down row links to /transactions with account_id and time bounds', async () => {
+   ```
+   and ending at the closing `});` of that test.
+
+2. **Tighten the first test** — replace the `expect(screen.getAllByText('Expenses:Rent').length).toBeGreaterThan(0);` and `expect(screen.getAllByText('Income:Salary').length).toBeGreaterThan(0);` assertions with:
+   ```tsx
+   // Row labels appear in the mix bars (not in any detail table).
+   expect(screen.getByText('Expenses:Rent')).toBeInTheDocument();
+   expect(screen.getByText('Income:Salary')).toBeInTheDocument();
+   // No detail-table headings.
+   expect(screen.queryByRole('heading', { name: /Income detail/i })).toBeNull();
+   expect(screen.queryByRole('heading', { name: /Expense detail/i })).toBeNull();
+   // No drill-down links to /transactions.
+   expect(screen.queryByRole('link', { name: /Expenses:Rent/ })).toBeNull();
+   ```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd spa && npx vitest run src/test/reports.income-statement.test.tsx
+```
+
+Expected: FAIL — the headings "Income detail" / "Expense detail" still render and the `/transactions` link is still present.
+
+- [ ] **Step 3: Delete the detail-table block from the page**
+
+In `spa/src/routes/reports.income-statement.tsx`:
+
+Delete the entire JSX block (currently lines 135–154):
+```tsx
+<div className="grid grid-cols-2 gap-6">
+  <section>
+    <h2 className="mb-2 text-sm font-semibold">Income detail</h2>
+    <ReportRowTable
+      rows={incomeRows}
+      currency={currency}
+      nameToId={nameToId}
+      period={{ startUnix: period.startUnix, endUnix: period.endUnix }}
+    />
+  </section>
+  <section>
+    <h2 className="mb-2 text-sm font-semibold">Expense detail</h2>
+    <ReportRowTable
+      rows={expenseRows}
+      currency={currency}
+      nameToId={nameToId}
+      period={{ startUnix: period.startUnix, endUnix: period.endUnix }}
+    />
+  </section>
+</div>
+```
+
+Also delete the now-dead bindings:
+
+- The `balancesQuery` declaration:
+  ```tsx
+  const balancesQuery = useQuery({ queryKey: ['balances'], queryFn: getBalances });
+  ```
+- The `nameToId` memo (lines 32–38):
+  ```tsx
+  const nameToId = useMemo(() => {
+    const m = new Map<string, number>();
+    if (balancesQuery.data) {
+      for (const row of balancesQuery.data.items) m.set(row.name, row.account_id);
+    }
+    return m;
+  }, [balancesQuery.data]);
+  ```
+
+Update imports — remove only:
+- `ReportRowTable` (from `@/components/reports/ReportRowTable`)
+- `getBalances` (from `@/lib/api`)
+
+Keep `useQuery` and `useMemo` — they will be re-used in Task 5 and by the still-present `period` memo.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd spa && npx vitest run src/test/reports.income-statement.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Full SPA test + build**
+
+```bash
+cd spa && npm test
+cd spa && npm run build
+```
+
+Expected: PASS (and no TypeScript errors from unused imports).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add spa/src/routes/reports.income-statement.tsx spa/src/test/reports.income-statement.test.tsx
+git commit -m "feat(spa): drop detail tables from income statement page"
+```
+
+---
+
+### Task 3: `previousPeriod` helper in `lib/period.ts`
+
+**Files:**
+- Modify: `spa/src/lib/period.ts`
+- Create: `spa/src/test/period.test.ts`
+
+Compute the API params for the same-length window immediately preceding the current period.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `spa/src/test/period.test.ts`:
+
+```ts
+import { describe, expect, test } from 'vitest';
+import { previousPeriod, resolvePeriod } from '../lib/period';
+
+// Helper: build a `nowUnix` for a given UTC date.
+function utc(year: number, month1to12: number, day: number): number {
+  return Date.UTC(year, month1to12 - 1, day) / 1000;
+}
+
+describe('previousPeriod', () => {
+  test('this-month: previous calendar month', () => {
+    const now = utc(2026, 6, 17);
+    const search = { range: 'this-month' as const };
+    const resolved = resolvePeriod(search, now);
+    expect(previousPeriod(search, resolved, now)).toEqual({
+      apiParams: { month: '2026-05' },
+    });
+  });
+
+  test('this-month: January rolls back into prior December', () => {
+    const now = utc(2026, 1, 15);
+    const search = { range: 'this-month' as const };
+    const resolved = resolvePeriod(search, now);
+    expect(previousPeriod(search, resolved, now)).toEqual({
+      apiParams: { month: '2025-12' },
+    });
+  });
+
+  test('this-month with explicit month string', () => {
+    const now = utc(2026, 6, 17);
+    const search = { range: 'this-month' as const, month: '2026-03' };
+    const resolved = resolvePeriod(search, now);
+    expect(previousPeriod(search, resolved, now)).toEqual({
+      apiParams: { month: '2026-02' },
+    });
+  });
+
+  test('last-month: the month before last', () => {
+    const now = utc(2026, 6, 17);
+    const search = { range: 'last-month' as const };
+    const resolved = resolvePeriod(search, now);
+    expect(previousPeriod(search, resolved, now)).toEqual({
+      apiParams: { month: '2026-04' },
+    });
+  });
+
+  test('ytd: same MM-DD window in the previous year', () => {
+    const now = utc(2026, 6, 17);
+    const search = { range: 'ytd' as const };
+    const resolved = resolvePeriod(search, now);
+    expect(previousPeriod(search, resolved, now)).toEqual({
+      apiParams: { from: '2025-01-01', to: '2025-06-17' },
+    });
+  });
+
+  test('last-12mo: 12 months ending one day before current start', () => {
+    const now = utc(2026, 6, 17);
+    const search = { range: 'last-12mo' as const };
+    const resolved = resolvePeriod(search, now);
+    // current window starts at 2025-06-17; previous ends 2025-06-16, starts 2024-06-16.
+    expect(previousPeriod(search, resolved, now)).toEqual({
+      apiParams: { from: '2024-06-16', to: '2025-06-16' },
+    });
+  });
+
+  test('custom: same-length window ending one day before from', () => {
+    const now = utc(2026, 6, 17);
+    const search = {
+      range: 'custom' as const,
+      from: '2026-03-01',
+      to: '2026-03-31',
+    };
+    const resolved = resolvePeriod(search, now);
+    // March has 31 days; previous window is 31 days ending 2026-02-28 → starts 2026-01-29.
+    expect(previousPeriod(search, resolved, now)).toEqual({
+      apiParams: { from: '2026-01-29', to: '2026-02-28' },
+    });
+  });
+
+  test('custom with missing from/to returns null', () => {
+    const now = utc(2026, 6, 17);
+    const search = { range: 'custom' as const };
+    const resolved = resolvePeriod(search, now);
+    expect(previousPeriod(search, resolved, now)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cd spa && npx vitest run src/test/period.test.ts
+```
+
+Expected: FAIL — `previousPeriod` is not exported from `../lib/period`.
+
+- [ ] **Step 3: Implement `previousPeriod`**
+
+In `spa/src/lib/period.ts`, append below the existing `resolvePeriod` function:
+
+```ts
+import type { PeriodApiParams } from './api/reports';
+
+export function previousPeriod(
+  search: PeriodSearch,
+  resolved: ResolvedPeriod,
+  nowUnix: number = Date.now() / 1000,
+): { apiParams: PeriodApiParams } | null {
+  // this-month and last-month → step back exactly one calendar month
+  // from the resolved month string ("YYYY-MM" via apiParams.month).
+  if (search.range === 'this-month' || search.range === 'last-month') {
+    const monthStr = resolved.apiParams.month;
+    if (!monthStr) return null;
+    const parsed = /^(\d{4})-(\d{2})$/.exec(monthStr);
+    if (!parsed) return null;
+    let y = Number(parsed[1]);
+    let m = Number(parsed[2]) - 1;
+    if (m === 0) {
+      m = 12;
+      y -= 1;
+    }
+    return { apiParams: { month: `${y}-${pad2(m)}` } };
+  }
+
+  if (search.range === 'ytd') {
+    const now = new Date(nowUnix * 1000);
+    const y = now.getUTCFullYear() - 1;
+    const mm = pad2(now.getUTCMonth() + 1);
+    const dd = pad2(now.getUTCDate());
+    return { apiParams: { from: `${y}-01-01`, to: `${y}-${mm}-${dd}` } };
+  }
+
+  if (search.range === 'last-12mo' || search.range === 'custom') {
+    if (!resolved.apiParams.from || !resolved.apiParams.to) return null;
+    // Length includes both endpoints when measured in days.
+    const lengthSec = resolved.endUnix - resolved.startUnix;
+    // Previous window ends one second before current start; subtract length to get its start.
+    const prevEnd = resolved.startUnix - 1;
+    const prevStart = prevEnd - lengthSec;
+    return {
+      apiParams: {
+        from: isoDate(prevStart),
+        to: isoDate(prevEnd),
+      },
+    };
+  }
+
+  return null;
+}
+```
+
+If `pad2` and `isoDate` are not exported at module scope (they are defined above as module-local in the existing file), no change is needed — the new function is in the same module.
+
+Also add the import line at the top of the file (just below the existing imports/exports — keep adjacent):
+
+```ts
+import type { PeriodApiParams } from './api/reports';
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd spa && npx vitest run src/test/period.test.ts
+```
+
+Expected: PASS (all 8 cases).
+
+If any of the `last-12mo` or `custom` boundary tests are off by a day or a second, double-check the rule:
+- Resolved windows in `period.ts` represent the period as `[startUnix, endUnix]` where `endUnix` is 23:59:59 of the last day.
+- `lengthSec = endUnix - startUnix` therefore measures one second short of `n * 86400` for an n-day window. The previous window is computed with the same convention so the helper returns matching ISO dates.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/lib/period.ts spa/src/test/period.test.ts
+git commit -m "feat(spa): add previousPeriod helper for period.ts"
+```
+
+---
+
+### Task 4: `KpiCard` `diff` prop
+
+**Files:**
+- Modify: `spa/src/components/reports/KpiCard.tsx`
+- Modify: `spa/src/test/reports.kpi-card.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `spa/src/test/reports.kpi-card.test.tsx`:
+
+```tsx
+test('diff: positive delta with goodWhen=up renders ▲, green color, amount, and percent', () => {
+  const { container } = render(
+    <KpiCard
+      label="Income"
+      amount={524800}
+      currency="USD"
+      variant="green"
+      diff={{ delta: 120000, prevAmount: 404800, goodWhen: 'up' }}
+    />,
+  );
+  const diff = container.querySelector('[data-testid="kpi-diff"]');
+  expect(diff).not.toBeNull();
+  expect(diff?.textContent).toContain('▲');
+  expect(diff?.textContent).toContain('+$1,200.00');
+  expect(diff?.textContent).toContain('+29.6%');
+  expect(diff?.textContent).toContain('vs last period');
+  expect(diff?.className).toContain('text-green');
+});
+
+test('diff: positive delta with goodWhen=down renders red (e.g. expense grew)', () => {
+  const { container } = render(
+    <KpiCard
+      label="Expense"
+      amount={253000}
+      currency="USD"
+      variant="red"
+      diff={{ delta: 30000, prevAmount: 223000, goodWhen: 'down' }}
+    />,
+  );
+  const diff = container.querySelector('[data-testid="kpi-diff"]');
+  expect(diff?.className).toContain('text-red');
+  expect(diff?.textContent).toContain('▲');
+  expect(diff?.textContent).toContain('+$300.00');
+});
+
+test('diff: negative delta with goodWhen=up renders ▼ and red', () => {
+  const { container } = render(
+    <KpiCard
+      label="Income"
+      amount={400000}
+      currency="USD"
+      variant="green"
+      diff={{ delta: -50000, prevAmount: 450000, goodWhen: 'up' }}
+    />,
+  );
+  const diff = container.querySelector('[data-testid="kpi-diff"]');
+  expect(diff?.className).toContain('text-red');
+  expect(diff?.textContent).toContain('▼');
+  expect(diff?.textContent).toContain('-$500.00');
+  expect(diff?.textContent).toContain('-11.1%');
+});
+
+test('diff: zero delta renders em-dash and muted color, no percent', () => {
+  const { container } = render(
+    <KpiCard
+      label="Income"
+      amount={100000}
+      currency="USD"
+      variant="green"
+      diff={{ delta: 0, prevAmount: 100000, goodWhen: 'up' }}
+    />,
+  );
+  const diff = container.querySelector('[data-testid="kpi-diff"]');
+  expect(diff?.textContent).toContain('—');
+  expect(diff?.className).toContain('text-muted-foreground');
+  expect(diff?.textContent).not.toMatch(/%/);
+});
+
+test('diff: omits percent when prevAmount is 0', () => {
+  const { container } = render(
+    <KpiCard
+      label="Income"
+      amount={500}
+      currency="USD"
+      variant="green"
+      diff={{ delta: 500, prevAmount: 0, goodWhen: 'up' }}
+    />,
+  );
+  const diff = container.querySelector('[data-testid="kpi-diff"]');
+  expect(diff?.textContent).toContain('+$5.00');
+  expect(diff?.textContent).not.toMatch(/%/);
+});
+
+test('diff: coexists with subLine — both render', () => {
+  const { container } = render(
+    <KpiCard
+      label="Net"
+      amount={271800}
+      currency="USD"
+      variant="neutral"
+      subLine="▲ 6.2% net worth"
+      diff={{ delta: 10000, prevAmount: 261800, goodWhen: 'up' }}
+    />,
+  );
+  expect(container.querySelector('[data-testid="kpi-subline"]')).not.toBeNull();
+  expect(container.querySelector('[data-testid="kpi-diff"]')).not.toBeNull();
+});
+
+test('diff: no kpi-diff element when diff prop omitted', () => {
+  const { container } = render(
+    <KpiCard label="Income" amount={524800} currency="USD" variant="green" />,
+  );
+  expect(container.querySelector('[data-testid="kpi-diff"]')).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cd spa && npx vitest run src/test/reports.kpi-card.test.tsx
+```
+
+Expected: FAIL — `diff` prop does not exist.
+
+- [ ] **Step 3: Implement `diff` on `KpiCard`**
+
+Replace `spa/src/components/reports/KpiCard.tsx` with:
+
+```tsx
+import { cn } from '@/lib/cn';
+import { formatCents } from '@/lib/format';
+
+export type KpiVariant = 'green' | 'red' | 'neutral';
+
+export interface KpiDiff {
+  delta: number;
+  prevAmount: number;
+  goodWhen: 'up' | 'down';
+}
+
+interface Props {
+  label: string;
+  amount: number;
+  currency: string;
+  variant: KpiVariant;
+  subLine?: string;
+  diff?: KpiDiff;
+}
+
+const VARIANT_CLASS: Record<KpiVariant, string> = {
+  green: 'text-green-700 dark:text-green-400',
+  red: 'text-red-700 dark:text-red-400',
+  neutral: 'text-foreground',
+};
+
+const GOOD_CLASS = 'text-green-700 dark:text-green-400';
+const BAD_CLASS = 'text-red-700 dark:text-red-400';
+const NEUTRAL_DIFF_CLASS = 'text-muted-foreground';
+
+function formatDiff(diff: KpiDiff, currency: string): { text: string; className: string } {
+  if (diff.delta === 0) {
+    return { text: '— no change vs last period', className: NEUTRAL_DIFF_CLASS };
+  }
+  const arrow = diff.delta > 0 ? '▲' : '▼';
+  const sign = diff.delta > 0 ? '+' : '-';
+  const absAmount = formatCents(Math.abs(diff.delta), currency);
+  let pctPart = '';
+  if (diff.prevAmount !== 0) {
+    const pct = (diff.delta / Math.abs(diff.prevAmount)) * 100;
+    const pctSign = pct > 0 ? '+' : pct < 0 ? '-' : '';
+    pctPart = ` (${pctSign}${Math.abs(pct).toFixed(1)}%)`;
+  }
+  const isGood =
+    (diff.delta > 0 && diff.goodWhen === 'up') ||
+    (diff.delta < 0 && diff.goodWhen === 'down');
+  return {
+    text: `${arrow} ${sign}${absAmount}${pctPart} vs last period`,
+    className: isGood ? GOOD_CLASS : BAD_CLASS,
+  };
+}
+
+export function KpiCard({ label, amount, currency, variant, subLine, diff }: Props) {
+  const diffRendered = diff ? formatDiff(diff, currency) : null;
+  return (
+    <div className="rounded-md border bg-card p-4">
+      <div className="text-xs uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div
+        data-testid="kpi-amount"
+        className={cn('mt-1 text-2xl font-semibold', VARIANT_CLASS[variant])}
+      >
+        {formatCents(amount, currency)}
+      </div>
+      {subLine && (
+        <div data-testid="kpi-subline" className="mt-1 text-xs text-muted-foreground">
+          {subLine}
+        </div>
+      )}
+      {diffRendered && (
+        <div data-testid="kpi-diff" className={cn('mt-1 text-xs', diffRendered.className)}>
+          {diffRendered.text}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+Notes for the implementer:
+- `formatCents` is at `@/lib/format`. It uses `Intl.NumberFormat` with `style: 'currency'`, so passing a positive cent value (e.g. `120000`) yields `$1,200.00`. Always pass `Math.abs(diff.delta)` and prepend the sign manually so the output is `+$1,200.00` / `-$500.00` rather than the locale's accounting `($500.00)` form.
+- Percent calculation uses `Math.abs(prevAmount)` so the sign comes from `delta` alone — important when the previous expense total is positive but conceptually a "cost".
+- The em-dash variant's full text is `"— no change vs last period"` (matches the test which only checks for `—`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd spa && npx vitest run src/test/reports.kpi-card.test.tsx
+```
+
+Expected: PASS (all original 5 + new 7 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/components/reports/KpiCard.tsx spa/src/test/reports.kpi-card.test.tsx
+git commit -m "feat(spa): add diff prop to KpiCard"
+```
+
+---
+
+### Task 5: Wire previous-period fetch and diffs into the page
+
+**Files:**
+- Modify: `spa/src/routes/reports.income-statement.tsx`
+- Modify: `spa/src/test/reports.income-statement.test.tsx`
+
+- [ ] **Step 1: Extend the integration test fixture and add diff assertions**
+
+In `spa/src/test/reports.income-statement.test.tsx`, modify the `beforeEach` fetch mock so the `/api/reports/income-statement` branch differentiates by query string:
+
+```tsx
+const PREV_REPORT_PAYLOAD = {
+  ...REPORT_PAYLOAD,
+  period: 'May 2026',
+  total_income: { USD: 400000 },   // prev income = $4,000.00; current = $5,248.00 → +$1,248.00 (+31.2%)
+  total_expense: { USD: 300000 },  // prev expense = $3,000.00; current = $2,530.00 → -$470.00 (-15.7%)
+  net_amount: { USD: 100000 },     // prev net = $1,000.00; current = $2,718.00 → +$1,718.00 (+171.8%)
+};
+```
+
+Add it just below the existing `REPORT_PAYLOAD` constant.
+
+Replace the `/api/reports/income-statement` branch in the default `beforeEach` fetch mock:
+
+```tsx
+if (url.startsWith('/api/reports/income-statement')) {
+  // Default search for /reports/income-statement resolves to `month=YYYY-MM`
+  // for the current month. The previous-period request uses the previous month.
+  // Use the URL to distinguish: any URL whose month query is the test "now" month
+  // returns current; everything else returns previous.
+  if (url.includes('month=') && !url.includes('month=2026-05')) {
+    return Promise.resolve(okResponse(REPORT_PAYLOAD));
+  }
+  return Promise.resolve(okResponse(PREV_REPORT_PAYLOAD));
+}
+```
+
+> **Note for the implementer:** the tests don't currently freeze "now". `resolvePeriod` defaults to `Date.now()`. To make the differentiation deterministic regardless of when the test runs, use a substring match that distinguishes "any month param vs. a specific previous month" — adjust by switching to `vi.useFakeTimers().setSystemTime(new Date('2026-06-17T00:00:00Z'))` in `beforeEach` and `vi.useRealTimers()` in `afterEach`. The simpler implementation: freeze time, then current uses `month=2026-06` and previous uses `month=2026-05`. Replace the branch with:
+
+```tsx
+if (url.startsWith('/api/reports/income-statement')) {
+  if (url.includes('month=2026-05')) {
+    return Promise.resolve(okResponse(PREV_REPORT_PAYLOAD));
+  }
+  return Promise.resolve(okResponse(REPORT_PAYLOAD));
+}
+```
+
+And at the top of `beforeEach`:
+```tsx
+vi.useFakeTimers({ shouldAdvanceTime: true });
+vi.setSystemTime(new Date('2026-06-17T00:00:00Z'));
+```
+
+And in `afterEach`:
+```tsx
+vi.useRealTimers();
+```
+
+(`shouldAdvanceTime: true` keeps queueMicrotask / Promises working.)
+
+Then add new assertions to the first test (the "renders KPI cards…" test):
+
+```tsx
+// Diff lines (current minus previous) appear on each KPI card.
+await waitFor(() => {
+  const diffs = document.querySelectorAll('[data-testid="kpi-diff"]');
+  expect(diffs.length).toBe(3);
+});
+const diffTexts = Array.from(
+  document.querySelectorAll('[data-testid="kpi-diff"]'),
+).map((el) => el.textContent ?? '');
+// Income: +$1,248.00 vs prev $4,000.00
+expect(diffTexts.some((t) => t.includes('+$1,248.00'))).toBe(true);
+// Expense: -$470.00 vs prev $3,000.00
+expect(diffTexts.some((t) => t.includes('-$470.00'))).toBe(true);
+// Net: +$1,718.00 vs prev $1,000.00
+expect(diffTexts.some((t) => t.includes('+$1,718.00'))).toBe(true);
+```
+
+Add a new test for the no-previous-data path:
+
+```tsx
+test('omits diff lines when previous-period query is errored', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string) => {
+      if (url === '/api/config') {
+        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+      }
+      if (url === '/api/ledgers') {
+        return Promise.resolve(
+          okResponse({ active: 'p', items: [{ name: 'p', path: '/p.db', active: true }] }),
+        );
+      }
+      if (url === '/api/balances') {
+        return Promise.resolve(okResponse({ items: [], total_count: 0, limit: 0, offset: 0 }));
+      }
+      if (url.startsWith('/api/reports/income-statement')) {
+        if (url.includes('month=2026-05')) {
+          return Promise.resolve(new Response('boom', { status: 500 }));
+        }
+        return Promise.resolve(okResponse(REPORT_PAYLOAD));
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }),
+  );
+  render(makeTestApp('/reports/income-statement'));
+  await waitFor(() => {
+    expect(screen.getByText('Income')).toBeInTheDocument();
+  });
+  // Give the previous-period query time to settle.
+  await waitFor(() => {
+    expect(document.querySelectorAll('[data-testid="kpi-diff"]').length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+cd spa && npx vitest run src/test/reports.income-statement.test.tsx
+```
+
+Expected: FAIL — no `kpi-diff` elements render yet because the page does not fetch the previous period.
+
+- [ ] **Step 3: Wire the previous-period query and pass `diff` to KPI cards**
+
+In `spa/src/routes/reports.income-statement.tsx`:
+
+1. Update imports at the top:
+   ```tsx
+   import { CurrencyFooter } from '@/components/reports/CurrencyFooter';
+   import { KpiCard } from '@/components/reports/KpiCard';
+   import { PeriodPicker } from '@/components/reports/PeriodPicker';
+   import { ProportionBar } from '@/components/reports/ProportionBar';
+   import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+   import { Button } from '@/components/ui/button';
+   import { Skeleton } from '@/components/ui/skeleton';
+   import { fetchIncomeStatement } from '@/lib/api/reports';
+   import { useIncomeStatement } from '@/lib/hooks/useReport';
+   import { previousPeriod, resolvePeriod } from '@/lib/period';
+   import { type PeriodSearchParams, parsePeriodSearch } from '@/lib/reports-search-params';
+   import { useServerConfig } from '@/lib/server-config';
+   import { useQuery } from '@tanstack/react-query';
+   import { createFileRoute, useNavigate } from '@tanstack/react-router';
+   import { useMemo } from 'react';
+   ```
+
+2. After the existing `const query = useIncomeStatement(period.apiParams);` line, add:
+
+   ```tsx
+   const previous = useMemo(() => previousPeriod(search, period), [search, period]);
+   const previousQuery = useQuery({
+     queryKey: ['reports', 'income-statement', 'previous', previous?.apiParams],
+     queryFn: () => fetchIncomeStatement(previous!.apiParams),
+     enabled: previous !== null,
+   });
+   ```
+
+3. Replace the KPI card grid block with:
+
+   ```tsx
+   <div className="grid grid-cols-3 gap-3">
+     <KpiCard
+       label="Income"
+       amount={income}
+       currency={currency}
+       variant="green"
+       diff={
+         previousQuery.isSuccess
+           ? {
+               delta: income - (previousQuery.data.total_income[currency] ?? 0),
+               prevAmount: previousQuery.data.total_income[currency] ?? 0,
+               goodWhen: 'up',
+             }
+           : undefined
+       }
+     />
+     <KpiCard
+       label="Expense"
+       amount={expense}
+       currency={currency}
+       variant="red"
+       diff={
+         previousQuery.isSuccess
+           ? {
+               delta: expense - (previousQuery.data.total_expense[currency] ?? 0),
+               prevAmount: previousQuery.data.total_expense[currency] ?? 0,
+               goodWhen: 'down',
+             }
+           : undefined
+       }
+     />
+     <KpiCard
+       label="Net"
+       amount={net}
+       currency={currency}
+       variant="neutral"
+       subLine={netSubLine}
+       diff={
+         previousQuery.isSuccess
+           ? {
+               delta: net - (previousQuery.data.net_amount[currency] ?? 0),
+               prevAmount: previousQuery.data.net_amount[currency] ?? 0,
+               goodWhen: 'up',
+             }
+           : undefined
+       }
+     />
+   </div>
+   ```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd spa && npx vitest run src/test/reports.income-statement.test.tsx
+```
+
+Expected: PASS — three `kpi-diff` elements with the expected amounts; the "errored previous" test sees zero `kpi-diff` elements.
+
+- [ ] **Step 5: Full SPA test + build**
+
+```bash
+cd spa && npm test
+cd spa && npm run build
+```
+
+Expected: PASS, no TypeScript errors.
+
+- [ ] **Step 6: Manual smoke (optional but recommended for UI work)**
+
+```bash
+cd spa && npm run dev
+```
+
+Open the dev URL, navigate to `/reports/income-statement`, and confirm:
+- Three KPI cards show a `▲`/`▼`/`—` diff line below them.
+- Income card diff is green when income grew; red when it shrank.
+- Expense card diff is red when expense grew; green when it shrank.
+- Mix bars show at most 5 rows initially with "+ N more" if there are more accounts.
+- The old "Income detail" / "Expense detail" tables are gone.
+- The currency footer is still visible.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add spa/src/routes/reports.income-statement.tsx spa/src/test/reports.income-statement.test.tsx
+git commit -m "feat(spa): show prior-period diff on income statement KPI cards"
+```
+
+---
+
+### Task 6: Final pass
+
+- [ ] **Step 1: Full test + build from repo root**
+
+```bash
+cd spa && npm test && npm run build
+cd .. && go test ./...
+```
+
+Expected: all green. Go tests are unrelated to this change but worth confirming nothing accidentally moved.
+
+- [ ] **Step 2: `git log` review**
+
+```bash
+git log --oneline origin/master..HEAD
+```
+
+Expected (5 commits):
+1. cap mix bars at top 5
+2. drop detail tables
+3. add `previousPeriod` helper
+4. add `diff` prop to `KpiCard`
+5. show prior-period diff on KPI cards
+
+If commits look right, this plan is done.

--- a/spa/src/components/reports/KpiCard.tsx
+++ b/spa/src/components/reports/KpiCard.tsx
@@ -3,12 +3,19 @@ import { formatCents } from '@/lib/format';
 
 export type KpiVariant = 'green' | 'red' | 'neutral';
 
+export interface KpiDiff {
+  delta: number;
+  prevAmount: number;
+  goodWhen: 'up' | 'down';
+}
+
 interface Props {
   label: string;
   amount: number;
   currency: string;
   variant: KpiVariant;
   subLine?: string;
+  diff?: KpiDiff;
 }
 
 const VARIANT_CLASS: Record<KpiVariant, string> = {
@@ -17,7 +24,34 @@ const VARIANT_CLASS: Record<KpiVariant, string> = {
   neutral: 'text-foreground',
 };
 
-export function KpiCard({ label, amount, currency, variant, subLine }: Props) {
+const GOOD_CLASS = 'text-green-700 dark:text-green-400';
+const BAD_CLASS = 'text-red-700 dark:text-red-400';
+const NEUTRAL_DIFF_CLASS = 'text-muted-foreground';
+
+function formatDiff(diff: KpiDiff, currency: string): { text: string; className: string } {
+  if (diff.delta === 0) {
+    return { text: '— no change vs last period', className: NEUTRAL_DIFF_CLASS };
+  }
+  const arrow = diff.delta > 0 ? '▲' : '▼';
+  const sign = diff.delta > 0 ? '+' : '-';
+  const absAmount = formatCents(Math.abs(diff.delta), currency);
+  let pctPart = '';
+  if (diff.prevAmount !== 0) {
+    const pct = (diff.delta / Math.abs(diff.prevAmount)) * 100;
+    const pctSign = pct > 0 ? '+' : pct < 0 ? '-' : '';
+    pctPart = ` (${pctSign}${Math.abs(pct).toFixed(1)}%)`;
+  }
+  const isGood =
+    (diff.delta > 0 && diff.goodWhen === 'up') ||
+    (diff.delta < 0 && diff.goodWhen === 'down');
+  return {
+    text: `${arrow} ${sign}${absAmount}${pctPart} vs last period`,
+    className: isGood ? GOOD_CLASS : BAD_CLASS,
+  };
+}
+
+export function KpiCard({ label, amount, currency, variant, subLine, diff }: Props) {
+  const diffRendered = diff ? formatDiff(diff, currency) : null;
   return (
     <div className="rounded-md border bg-card p-4">
       <div className="text-xs uppercase tracking-wide text-muted-foreground">{label}</div>
@@ -30,6 +64,11 @@ export function KpiCard({ label, amount, currency, variant, subLine }: Props) {
       {subLine && (
         <div data-testid="kpi-subline" className="mt-1 text-xs text-muted-foreground">
           {subLine}
+        </div>
+      )}
+      {diffRendered && (
+        <div data-testid="kpi-diff" className={cn('mt-1 text-xs', diffRendered.className)}>
+          {diffRendered.text}
         </div>
       )}
     </div>

--- a/spa/src/components/reports/ProportionBar.tsx
+++ b/spa/src/components/reports/ProportionBar.tsx
@@ -34,7 +34,11 @@ export function ProportionBar({ rows, total, currency, limit, variant = 'income'
       {shown.map((row) => {
         const pct = denom === 0 ? 0 : (Math.abs(row.amount) / denom) * 100;
         return (
-          <div key={row.account_name} data-testid="prop-bar" className="text-sm">
+          <div
+            key={`${row.account_name}|${row.offset_account}`}
+            data-testid="prop-bar"
+            className="text-sm"
+          >
             <div className="flex items-baseline justify-between gap-2">
               <span className="truncate" title={row.account_name}>
                 {row.account_name}

--- a/spa/src/lib/period.ts
+++ b/spa/src/lib/period.ts
@@ -203,9 +203,11 @@ export function previousPeriod(
   if (search.range === 'ytd') {
     const now = new Date(nowUnix * 1000);
     const y = now.getUTCFullYear() - 1;
-    const mm = pad2(now.getUTCMonth() + 1);
-    const dd = pad2(now.getUTCDate());
-    return { apiParams: { from: `${y}-01-01`, to: `${y}-${mm}-${dd}` } };
+    const month = now.getUTCMonth() + 1;
+    const day = Math.min(now.getUTCDate(), daysInMonth(y, month));
+    return {
+      apiParams: { from: `${y}-01-01`, to: `${y}-${pad2(month)}-${pad2(day)}` },
+    };
   }
 
   if (search.range === 'last-12mo' || search.range === 'custom') {

--- a/spa/src/lib/period.ts
+++ b/spa/src/lib/period.ts
@@ -1,3 +1,5 @@
+import type { PeriodApiParams } from './api/reports';
+
 export type PeriodRange = 'this-month' | 'last-month' | 'ytd' | 'last-12mo' | 'custom';
 
 export interface PeriodSearch {
@@ -175,4 +177,50 @@ export function resolvePeriod(
 
   // fallback: this-month
   return resolvePeriod({ range: 'this-month' }, nowUnix);
+}
+
+export function previousPeriod(
+  search: PeriodSearch,
+  resolved: ResolvedPeriod,
+  nowUnix: number = Date.now() / 1000,
+): { apiParams: PeriodApiParams } | null {
+  // this-month and last-month → step back exactly one calendar month
+  // from the resolved month string ("YYYY-MM" via apiParams.month).
+  if (search.range === 'this-month' || search.range === 'last-month') {
+    const monthStr = resolved.apiParams.month;
+    if (!monthStr) return null;
+    const parsed = /^(\d{4})-(\d{2})$/.exec(monthStr);
+    if (!parsed) return null;
+    let y = Number(parsed[1]);
+    let m = Number(parsed[2]) - 1;
+    if (m === 0) {
+      m = 12;
+      y -= 1;
+    }
+    return { apiParams: { month: `${y}-${pad2(m)}` } };
+  }
+
+  if (search.range === 'ytd') {
+    const now = new Date(nowUnix * 1000);
+    const y = now.getUTCFullYear() - 1;
+    const mm = pad2(now.getUTCMonth() + 1);
+    const dd = pad2(now.getUTCDate());
+    return { apiParams: { from: `${y}-01-01`, to: `${y}-${mm}-${dd}` } };
+  }
+
+  if (search.range === 'last-12mo' || search.range === 'custom') {
+    if (!resolved.apiParams.from || !resolved.apiParams.to) return null;
+    const lengthSec = resolved.endUnix - resolved.startUnix;
+    // Previous window ends one second before current start; subtract length to get its start.
+    const prevEnd = resolved.startUnix - 1;
+    const prevStart = prevEnd - lengthSec;
+    return {
+      apiParams: {
+        from: isoDate(prevStart),
+        to: isoDate(prevEnd),
+      },
+    };
+  }
+
+  return null;
 }

--- a/spa/src/routes/reports.income-statement.tsx
+++ b/spa/src/routes/reports.income-statement.tsx
@@ -144,22 +144,20 @@ function IncomeStatementPage() {
 
           <div className="grid grid-cols-2 gap-6">
             <section>
-              <h2 className="mb-2 text-sm font-semibold">Income mix</h2>
+              <h2 className="mb-2 text-sm font-semibold">Top 5 Income</h2>
               <ProportionBar
-                rows={incomeRows}
+                rows={incomeRows.slice(0, 5)}
                 total={income}
                 currency={currency}
-                limit={5}
                 variant="income"
               />
             </section>
             <section>
-              <h2 className="mb-2 text-sm font-semibold">Expense mix</h2>
+              <h2 className="mb-2 text-sm font-semibold">Top 5 Expense</h2>
               <ProportionBar
-                rows={expenseRows}
+                rows={expenseRows.slice(0, 5)}
                 total={expense}
                 currency={currency}
-                limit={5}
                 variant="expense"
               />
             </section>

--- a/spa/src/routes/reports.income-statement.tsx
+++ b/spa/src/routes/reports.income-statement.tsx
@@ -2,16 +2,13 @@ import { CurrencyFooter } from '@/components/reports/CurrencyFooter';
 import { KpiCard } from '@/components/reports/KpiCard';
 import { PeriodPicker } from '@/components/reports/PeriodPicker';
 import { ProportionBar } from '@/components/reports/ProportionBar';
-import { ReportRowTable } from '@/components/reports/ReportRowTable';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { getBalances } from '@/lib/api';
 import { useIncomeStatement } from '@/lib/hooks/useReport';
 import { resolvePeriod } from '@/lib/period';
 import { type PeriodSearchParams, parsePeriodSearch } from '@/lib/reports-search-params';
 import { useServerConfig } from '@/lib/server-config';
-import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useMemo } from 'react';
 
@@ -27,15 +24,6 @@ function IncomeStatementPage() {
   const navigate = useNavigate({ from: '/reports/income-statement' });
   const period = useMemo(() => resolvePeriod(search), [search]);
   const query = useIncomeStatement(period.apiParams);
-
-  const balancesQuery = useQuery({ queryKey: ['balances'], queryFn: getBalances });
-  const nameToId = useMemo(() => {
-    const m = new Map<string, number>();
-    if (balancesQuery.data) {
-      for (const row of balancesQuery.data.items) m.set(row.name, row.account_id);
-    }
-    return m;
-  }, [balancesQuery.data]);
 
   const setSearch = (next: Partial<PeriodSearchParams>) => {
     navigate({ search: () => ({ ...search, ...next }) });
@@ -128,27 +116,6 @@ function IncomeStatementPage() {
                 currency={currency}
                 limit={5}
                 variant="expense"
-              />
-            </section>
-          </div>
-
-          <div className="grid grid-cols-2 gap-6">
-            <section>
-              <h2 className="mb-2 text-sm font-semibold">Income detail</h2>
-              <ReportRowTable
-                rows={incomeRows}
-                currency={currency}
-                nameToId={nameToId}
-                period={{ startUnix: period.startUnix, endUnix: period.endUnix }}
-              />
-            </section>
-            <section>
-              <h2 className="mb-2 text-sm font-semibold">Expense detail</h2>
-              <ReportRowTable
-                rows={expenseRows}
-                currency={currency}
-                nameToId={nameToId}
-                period={{ startUnix: period.startUnix, endUnix: period.endUnix }}
               />
             </section>
           </div>

--- a/spa/src/routes/reports.income-statement.tsx
+++ b/spa/src/routes/reports.income-statement.tsx
@@ -5,10 +5,12 @@ import { ProportionBar } from '@/components/reports/ProportionBar';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { fetchIncomeStatement } from '@/lib/api/reports';
 import { useIncomeStatement } from '@/lib/hooks/useReport';
-import { resolvePeriod } from '@/lib/period';
+import { previousPeriod, resolvePeriod } from '@/lib/period';
 import { type PeriodSearchParams, parsePeriodSearch } from '@/lib/reports-search-params';
 import { useServerConfig } from '@/lib/server-config';
+import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useMemo } from 'react';
 
@@ -24,6 +26,12 @@ function IncomeStatementPage() {
   const navigate = useNavigate({ from: '/reports/income-statement' });
   const period = useMemo(() => resolvePeriod(search), [search]);
   const query = useIncomeStatement(period.apiParams);
+  const previous = useMemo(() => previousPeriod(search, period), [search, period]);
+  const previousQuery = useQuery({
+    queryKey: ['reports', 'income-statement', 'previous', previous?.apiParams],
+    queryFn: () => fetchIncomeStatement(previous!.apiParams),
+    enabled: previous !== null,
+  });
 
   const setSearch = (next: Partial<PeriodSearchParams>) => {
     navigate({ search: () => ({ ...search, ...next }) });
@@ -86,14 +94,51 @@ function IncomeStatementPage() {
       ) : (
         <>
           <div className="grid grid-cols-3 gap-3">
-            <KpiCard label="Income" amount={income} currency={currency} variant="green" />
-            <KpiCard label="Expense" amount={expense} currency={currency} variant="red" />
+            <KpiCard
+              label="Income"
+              amount={income}
+              currency={currency}
+              variant="green"
+              diff={
+                previousQuery.isSuccess
+                  ? {
+                      delta: income - (previousQuery.data.total_income[currency] ?? 0),
+                      prevAmount: previousQuery.data.total_income[currency] ?? 0,
+                      goodWhen: 'up',
+                    }
+                  : undefined
+              }
+            />
+            <KpiCard
+              label="Expense"
+              amount={expense}
+              currency={currency}
+              variant="red"
+              diff={
+                previousQuery.isSuccess
+                  ? {
+                      delta: expense - (previousQuery.data.total_expense[currency] ?? 0),
+                      prevAmount: previousQuery.data.total_expense[currency] ?? 0,
+                      goodWhen: 'down',
+                    }
+                  : undefined
+              }
+            />
             <KpiCard
               label="Net"
               amount={net}
               currency={currency}
               variant="neutral"
               subLine={netSubLine}
+              diff={
+                previousQuery.isSuccess
+                  ? {
+                      delta: net - (previousQuery.data.net_amount[currency] ?? 0),
+                      prevAmount: previousQuery.data.net_amount[currency] ?? 0,
+                      goodWhen: 'up',
+                    }
+                  : undefined
+              }
             />
           </div>
 

--- a/spa/src/routes/reports.income-statement.tsx
+++ b/spa/src/routes/reports.income-statement.tsx
@@ -116,7 +116,7 @@ function IncomeStatementPage() {
                 rows={incomeRows}
                 total={income}
                 currency={currency}
-                limit={8}
+                limit={5}
                 variant="income"
               />
             </section>
@@ -126,7 +126,7 @@ function IncomeStatementPage() {
                 rows={expenseRows}
                 total={expense}
                 currency={currency}
-                limit={8}
+                limit={5}
                 variant="expense"
               />
             </section>

--- a/spa/src/test/period.test.ts
+++ b/spa/src/test/period.test.ts
@@ -82,4 +82,22 @@ describe('previousPeriod', () => {
     const resolved = resolvePeriod(search, now);
     expect(previousPeriod(search, resolved, now)).toBeNull();
   });
+
+  test('ytd: Feb 29 of a leap year clamps to Feb 28 in previous (non-leap) year', () => {
+    const now = utc(2028, 2, 29);
+    const search = { range: 'ytd' as const };
+    const resolved = resolvePeriod(search, now);
+    expect(previousPeriod(search, resolved, now)).toEqual({
+      apiParams: { from: '2027-01-01', to: '2027-02-28' },
+    });
+  });
+
+  test('ytd: non-leap-day still preserves exact MM-DD', () => {
+    const now = utc(2028, 3, 1);
+    const search = { range: 'ytd' as const };
+    const resolved = resolvePeriod(search, now);
+    expect(previousPeriod(search, resolved, now)).toEqual({
+      apiParams: { from: '2027-01-01', to: '2027-03-01' },
+    });
+  });
 });

--- a/spa/src/test/period.test.ts
+++ b/spa/src/test/period.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'vitest';
+import { previousPeriod, resolvePeriod } from '../lib/period';
+
+// Helper: build a `nowUnix` for a given UTC date.
+function utc(year: number, month1to12: number, day: number): number {
+  return Date.UTC(year, month1to12 - 1, day) / 1000;
+}
+
+describe('previousPeriod', () => {
+  test('this-month: previous calendar month', () => {
+    const now = utc(2026, 6, 17);
+    const search = { range: 'this-month' as const };
+    const resolved = resolvePeriod(search, now);
+    expect(previousPeriod(search, resolved, now)).toEqual({
+      apiParams: { month: '2026-05' },
+    });
+  });
+
+  test('this-month: January rolls back into prior December', () => {
+    const now = utc(2026, 1, 15);
+    const search = { range: 'this-month' as const };
+    const resolved = resolvePeriod(search, now);
+    expect(previousPeriod(search, resolved, now)).toEqual({
+      apiParams: { month: '2025-12' },
+    });
+  });
+
+  test('this-month with explicit month string', () => {
+    const now = utc(2026, 6, 17);
+    const search = { range: 'this-month' as const, month: '2026-03' };
+    const resolved = resolvePeriod(search, now);
+    expect(previousPeriod(search, resolved, now)).toEqual({
+      apiParams: { month: '2026-02' },
+    });
+  });
+
+  test('last-month: the month before last', () => {
+    const now = utc(2026, 6, 17);
+    const search = { range: 'last-month' as const };
+    const resolved = resolvePeriod(search, now);
+    expect(previousPeriod(search, resolved, now)).toEqual({
+      apiParams: { month: '2026-04' },
+    });
+  });
+
+  test('ytd: same MM-DD window in the previous year', () => {
+    const now = utc(2026, 6, 17);
+    const search = { range: 'ytd' as const };
+    const resolved = resolvePeriod(search, now);
+    expect(previousPeriod(search, resolved, now)).toEqual({
+      apiParams: { from: '2025-01-01', to: '2025-06-17' },
+    });
+  });
+
+  test('last-12mo: 12 months ending one day before current start', () => {
+    const now = utc(2026, 6, 17);
+    const search = { range: 'last-12mo' as const };
+    const resolved = resolvePeriod(search, now);
+    // current window starts at 2025-06-17; previous ends 2025-06-16, starts 2024-06-16.
+    expect(previousPeriod(search, resolved, now)).toEqual({
+      apiParams: { from: '2024-06-16', to: '2025-06-16' },
+    });
+  });
+
+  test('custom: same-length window ending one day before from', () => {
+    const now = utc(2026, 6, 17);
+    const search = {
+      range: 'custom' as const,
+      from: '2026-03-01',
+      to: '2026-03-31',
+    };
+    const resolved = resolvePeriod(search, now);
+    // March has 31 days; previous window is 31 days ending 2026-02-28 → starts 2026-01-29.
+    expect(previousPeriod(search, resolved, now)).toEqual({
+      apiParams: { from: '2026-01-29', to: '2026-02-28' },
+    });
+  });
+
+  test('custom with missing from/to returns null', () => {
+    const now = utc(2026, 6, 17);
+    const search = { range: 'custom' as const };
+    const resolved = resolvePeriod(search, now);
+    expect(previousPeriod(search, resolved, now)).toBeNull();
+  });
+});

--- a/spa/src/test/reports.income-statement.test.tsx
+++ b/spa/src/test/reports.income-statement.test.tsx
@@ -113,19 +113,14 @@ test('renders KPI cards, charts, and tables for income statement', async () => {
   expect(screen.getByText('$2,530.00')).toBeInTheDocument();
   expect(screen.getByText('$2,718.00')).toBeInTheDocument();
   expect(screen.getByText(/6\.2% net worth/)).toBeInTheDocument();
-  expect(screen.getAllByText('Expenses:Rent').length).toBeGreaterThan(0);
-  expect(screen.getAllByText('Income:Salary').length).toBeGreaterThan(0);
-});
-
-test('drill-down row links to /transactions with account_id and time bounds', async () => {
-  render(makeTestApp('/reports/income-statement'));
-  await waitFor(() => {
-    expect(screen.getAllByText('Expenses:Rent').length).toBeGreaterThan(0);
-  });
-  const link = screen.getByRole('link', { name: /Expenses:Rent/ });
-  const href = link.getAttribute('href') ?? '';
-  expect(href).toContain('/transactions');
-  expect(href).toContain('account_id=11');
+  // Row labels appear in the mix bars (not in any detail table).
+  expect(screen.getByText('Expenses:Rent')).toBeInTheDocument();
+  expect(screen.getByText('Income:Salary')).toBeInTheDocument();
+  // No detail-table headings.
+  expect(screen.queryByRole('heading', { name: /Income detail/i })).toBeNull();
+  expect(screen.queryByRole('heading', { name: /Expense detail/i })).toBeNull();
+  // No drill-down links to /transactions.
+  expect(screen.queryByRole('link', { name: /Expenses:Rent/ })).toBeNull();
 });
 
 test('renders empty state when there are no rows', async () => {

--- a/spa/src/test/reports.income-statement.test.tsx
+++ b/spa/src/test/reports.income-statement.test.tsx
@@ -43,7 +43,17 @@ const REPORT_PAYLOAD = {
   ],
 };
 
+const PREV_REPORT_PAYLOAD = {
+  ...REPORT_PAYLOAD,
+  period: 'May 2026',
+  total_income: { USD: 400000 },   // prev income = $4,000.00; current = $5,248.00 → +$1,248.00 (+31.2%)
+  total_expense: { USD: 300000 },  // prev expense = $3,000.00; current = $2,530.00 → -$470.00 (-15.7%)
+  net_amount: { USD: 100000 },     // prev net = $1,000.00; current = $2,718.00 → +$1,718.00 (+171.8%)
+};
+
 beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.setSystemTime(new Date('2026-06-17T00:00:00Z'));
   vi.stubGlobal(
     'fetch',
     vi.fn((url: string) => {
@@ -91,6 +101,9 @@ beforeEach(() => {
         );
       }
       if (url.startsWith('/api/reports/income-statement')) {
+        if (url.includes('month=2026-05')) {
+          return Promise.resolve(okResponse(PREV_REPORT_PAYLOAD));
+        }
         return Promise.resolve(okResponse(REPORT_PAYLOAD));
       }
       throw new Error(`unexpected fetch: ${url}`);
@@ -100,6 +113,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
 
 test('renders KPI cards, charts, and tables for income statement', async () => {
@@ -121,6 +135,21 @@ test('renders KPI cards, charts, and tables for income statement', async () => {
   expect(screen.queryByRole('heading', { name: /Expense detail/i })).toBeNull();
   // No drill-down links to /transactions.
   expect(screen.queryByRole('link', { name: /Expenses:Rent/ })).toBeNull();
+
+  // Diff lines (current minus previous) appear on each KPI card.
+  await waitFor(() => {
+    const diffs = document.querySelectorAll('[data-testid="kpi-diff"]');
+    expect(diffs.length).toBe(3);
+  });
+  const diffTexts = Array.from(
+    document.querySelectorAll('[data-testid="kpi-diff"]'),
+  ).map((el) => el.textContent ?? '');
+  // Income: +$1,248.00 vs prev $4,000.00
+  expect(diffTexts.some((t) => t.includes('+$1,248.00'))).toBe(true);
+  // Expense: -$470.00 vs prev $3,000.00
+  expect(diffTexts.some((t) => t.includes('-$470.00'))).toBe(true);
+  // Net: +$1,718.00 vs prev $1,000.00
+  expect(diffTexts.some((t) => t.includes('+$1,718.00'))).toBe(true);
 });
 
 test('renders empty state when there are no rows', async () => {
@@ -156,5 +185,39 @@ test('renders empty state when there are no rows', async () => {
   render(makeTestApp('/reports/income-statement'));
   await waitFor(() => {
     expect(screen.getByText(/no income or expenses/i)).toBeInTheDocument();
+  });
+});
+
+test('omits diff lines when previous-period query is errored', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string) => {
+      if (url === '/api/config') {
+        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+      }
+      if (url === '/api/ledgers') {
+        return Promise.resolve(
+          okResponse({ active: 'p', items: [{ name: 'p', path: '/p.db', active: true }] }),
+        );
+      }
+      if (url === '/api/balances') {
+        return Promise.resolve(okResponse({ items: [], total_count: 0, limit: 0, offset: 0 }));
+      }
+      if (url.startsWith('/api/reports/income-statement')) {
+        if (url.includes('month=2026-05')) {
+          return Promise.resolve(new Response('boom', { status: 500 }));
+        }
+        return Promise.resolve(okResponse(REPORT_PAYLOAD));
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }),
+  );
+  render(makeTestApp('/reports/income-statement'));
+  await waitFor(() => {
+    expect(screen.getByText('Income')).toBeInTheDocument();
+  });
+  // Give the previous-period query time to settle.
+  await waitFor(() => {
+    expect(document.querySelectorAll('[data-testid="kpi-diff"]').length).toBe(0);
   });
 });

--- a/spa/src/test/reports.kpi-card.test.tsx
+++ b/spa/src/test/reports.kpi-card.test.tsx
@@ -43,3 +43,108 @@ test('omits sub-line when not provided', () => {
   );
   expect(container.querySelector('[data-testid="kpi-subline"]')).toBeNull();
 });
+
+test('diff: positive delta with goodWhen=up renders ▲, green color, amount, and percent', () => {
+  const { container } = render(
+    <KpiCard
+      label="Income"
+      amount={524800}
+      currency="USD"
+      variant="green"
+      diff={{ delta: 120000, prevAmount: 404800, goodWhen: 'up' }}
+    />,
+  );
+  const diff = container.querySelector('[data-testid="kpi-diff"]');
+  expect(diff).not.toBeNull();
+  expect(diff?.textContent).toContain('▲');
+  expect(diff?.textContent).toContain('+$1,200.00');
+  expect(diff?.textContent).toContain('+29.6%');
+  expect(diff?.textContent).toContain('vs last period');
+  expect(diff?.className).toContain('text-green');
+});
+
+test('diff: positive delta with goodWhen=down renders red (e.g. expense grew)', () => {
+  const { container } = render(
+    <KpiCard
+      label="Expense"
+      amount={253000}
+      currency="USD"
+      variant="red"
+      diff={{ delta: 30000, prevAmount: 223000, goodWhen: 'down' }}
+    />,
+  );
+  const diff = container.querySelector('[data-testid="kpi-diff"]');
+  expect(diff?.className).toContain('text-red');
+  expect(diff?.textContent).toContain('▲');
+  expect(diff?.textContent).toContain('+$300.00');
+});
+
+test('diff: negative delta with goodWhen=up renders ▼ and red', () => {
+  const { container } = render(
+    <KpiCard
+      label="Income"
+      amount={400000}
+      currency="USD"
+      variant="green"
+      diff={{ delta: -50000, prevAmount: 450000, goodWhen: 'up' }}
+    />,
+  );
+  const diff = container.querySelector('[data-testid="kpi-diff"]');
+  expect(diff?.className).toContain('text-red');
+  expect(diff?.textContent).toContain('▼');
+  expect(diff?.textContent).toContain('-$500.00');
+  expect(diff?.textContent).toContain('-11.1%');
+});
+
+test('diff: zero delta renders em-dash and muted color, no percent', () => {
+  const { container } = render(
+    <KpiCard
+      label="Income"
+      amount={100000}
+      currency="USD"
+      variant="green"
+      diff={{ delta: 0, prevAmount: 100000, goodWhen: 'up' }}
+    />,
+  );
+  const diff = container.querySelector('[data-testid="kpi-diff"]');
+  expect(diff?.textContent).toContain('—');
+  expect(diff?.className).toContain('text-muted-foreground');
+  expect(diff?.textContent).not.toMatch(/%/);
+});
+
+test('diff: omits percent when prevAmount is 0', () => {
+  const { container } = render(
+    <KpiCard
+      label="Income"
+      amount={500}
+      currency="USD"
+      variant="green"
+      diff={{ delta: 500, prevAmount: 0, goodWhen: 'up' }}
+    />,
+  );
+  const diff = container.querySelector('[data-testid="kpi-diff"]');
+  expect(diff?.textContent).toContain('+$5.00');
+  expect(diff?.textContent).not.toMatch(/%/);
+});
+
+test('diff: coexists with subLine — both render', () => {
+  const { container } = render(
+    <KpiCard
+      label="Net"
+      amount={271800}
+      currency="USD"
+      variant="neutral"
+      subLine="▲ 6.2% net worth"
+      diff={{ delta: 10000, prevAmount: 261800, goodWhen: 'up' }}
+    />,
+  );
+  expect(container.querySelector('[data-testid="kpi-subline"]')).not.toBeNull();
+  expect(container.querySelector('[data-testid="kpi-diff"]')).not.toBeNull();
+});
+
+test('diff: no kpi-diff element when diff prop omitted', () => {
+  const { container } = render(
+    <KpiCard label="Income" amount={524800} currency="USD" variant="green" />,
+  );
+  expect(container.querySelector('[data-testid="kpi-diff"]')).toBeNull();
+});

--- a/spa/src/test/reports.proportion-bar.test.tsx
+++ b/spa/src/test/reports.proportion-bar.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { ProportionBar } from '../components/reports/ProportionBar';
 import type { ReportRow } from '../lib/types';
 
@@ -66,6 +66,28 @@ test('handles total=0 without dividing by zero', () => {
   const { container } = render(<ProportionBar rows={r} total={0} currency="USD" />);
   const fill = container.querySelector('[data-testid="bar-fill"]');
   expect(fill?.getAttribute('style')).toContain('width: 0%');
+});
+
+test('row keys are unique when account_name repeats across offset accounts', () => {
+  // The report API returns one row per (account, offset) pair, so the same
+  // account_name commonly appears multiple times. React keys must reflect
+  // that uniqueness — otherwise reconciliation logs a warning and can mix
+  // DOM nodes across period switches.
+  const rows: ReportRow[] = [
+    { account_name: 'Food', offset_account: 'Bank', amount: 100000, currency: 'USD', tx_count: 1 },
+    { account_name: 'Food', offset_account: 'Card', amount: 50000, currency: 'USD', tx_count: 1 },
+    { account_name: 'Rent', offset_account: 'Bank', amount: 80000, currency: 'USD', tx_count: 1 },
+  ];
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  try {
+    render(<ProportionBar rows={rows} total={230000} currency="USD" />);
+    const dupKeyWarning = errorSpy.mock.calls.find((args) =>
+      String(args[0]).includes('two children with the same key'),
+    );
+    expect(dupKeyWarning).toBeUndefined();
+  } finally {
+    errorSpy.mockRestore();
+  }
 });
 
 test('uses absolute values for negative amounts', () => {


### PR DESCRIPTION
## Summary

Refresh the `/reports/income-statement` page:

- **KPI cards** now show a prior-period diff line (`▲ +$1,200 (+8.2%) vs last period`) with semantic green/red coloring (income up = good, expense up = bad). The previous period is the same-length window immediately preceding the current one, computed by a new `previousPeriod` helper in `lib/period.ts`.
- **Mix bars** are capped at top 5 per side, headings renamed **Top 5 Income** / **Top 5 Expense**, and the `+ N more` expand control is gone.
- **Detail tables** (`Income detail` / `Expense detail` `ReportRowTable`s) removed from this page. The standalone `/reports/income-breakdown` and `/reports/expense-breakdown` routes still use `ReportRowTable` and are unaffected.

Two fixes landed during testing:

- **Leap-day YTD bug:** the previous-period date for `ytd` could produce `YYYY-02-29` in a non-leap previous year (e.g. Feb 29 of a leap year → invalid `to=2027-02-29`). Now clamps the day to the last valid day of the previous-year month.
- **Stale Top 5 rows after switching periods:** the API returns one report row per `(account_name, offset_account)` pair, so the same `account_name` repeats. `ProportionBar` used `key={row.account_name}` — duplicate keys caused React to log a warning and fall back to position-based reconciliation, leaving stale DOM nodes after period switches until a hard refresh. Key is now `${account_name}|${offset_account}`.

## Test plan

- [x] Unit: `KpiCard` diff prop — 7 new cases (sign, percent, color, em-dash, prevAmount=0, coexists with subLine, omitted-when-absent)
- [x] Unit: `previousPeriod` — 10 cases across this-month / last-month / ytd / last-12mo / custom, plus leap-day clamp
- [x] Unit: `ProportionBar` — regression test asserting no React duplicate-key warning when `account_name` repeats
- [x] Integration: `reports.income-statement` — verifies detail tables are gone, three KPI cards show the right diff amounts, and diffs are absent when the previous-period fetch errors
- [x] Manually verified period switching via dev server console diagnostics + the user reproduced the original stale-rows bug, which the key fix resolves
- [x] `npm run build` clean, `go test ./...` green

Spec + plan committed to the branch under `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)