### PR TITLE
feat(spa): strip account-type prefix from report row labels

### DIFF
--- a/spa/src/components/reports/ProportionBar.tsx
+++ b/spa/src/components/reports/ProportionBar.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button';
+import { stripAccountTypePrefix } from '@/lib/accounts';
 import { formatCents } from '@/lib/format';
 import type { ReportRow } from '@/lib/types';
 import { useState } from 'react';
@@ -41,7 +42,7 @@ export function ProportionBar({ rows, total, currency, limit, variant = 'income'
           >
             <div className="flex items-baseline justify-between gap-2">
               <span className="truncate" title={row.account_name}>
-                {row.account_name}
+                {stripAccountTypePrefix(row.account_name)}
               </span>
               <span className="font-mono text-xs tabular-nums">
                 {formatCents(row.amount, currency)}

--- a/spa/src/components/reports/ReportRowTable.tsx
+++ b/spa/src/components/reports/ReportRowTable.tsx
@@ -1,3 +1,4 @@
+import { stripAccountTypePrefix } from '@/lib/accounts';
 import { formatCents } from '@/lib/format';
 import { DEFAULT_TRANSACTIONS_LIMIT } from '@/lib/transactions-search-params';
 import type { ReportRow } from '@/lib/types';
@@ -30,7 +31,7 @@ export function ReportRowTable({ rows, currency, nameToId, period }: Props) {
           const id = nameToId.get(row.account_name);
           const linkContent = (
             <span className="truncate" title={row.account_name}>
-              {row.account_name}
+              {stripAccountTypePrefix(row.account_name)}
             </span>
           );
           return (
@@ -65,7 +66,12 @@ export function ReportRowTable({ rows, currency, nameToId, period }: Props) {
                   </Link>
                 )}
               </td>
-              <td className="py-1.5 text-muted-foreground">{row.offset_account}</td>
+              <td
+                className="py-1.5 text-muted-foreground"
+                title={row.offset_account}
+              >
+                {stripAccountTypePrefix(row.offset_account)}
+              </td>
               <td className="py-1.5 text-right font-mono tabular-nums">
                 {formatCents(row.amount, currency)}
               </td>

--- a/spa/src/lib/accounts.test.ts
+++ b/spa/src/lib/accounts.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+import { stripAccountTypePrefix } from './accounts';
+
+describe('stripAccountTypePrefix', () => {
+  test('strips each recognized type prefix and keeps the rest of the path', () => {
+    expect(stripAccountTypePrefix('Assets:Bank:Checking')).toBe('Bank:Checking');
+    expect(stripAccountTypePrefix('Liabilities:CreditCard')).toBe('CreditCard');
+    expect(stripAccountTypePrefix('Equity:OpeningBalances_USD')).toBe('OpeningBalances_USD');
+    expect(stripAccountTypePrefix('Revenue:Salary')).toBe('Salary');
+    expect(stripAccountTypePrefix('Expenses:Food:Dinner')).toBe('Food:Dinner');
+  });
+
+  test('only strips the first segment when it matches a known type', () => {
+    expect(stripAccountTypePrefix('Expenses')).toBe('Expenses');
+    expect(stripAccountTypePrefix('Investments:Stocks')).toBe('Investments:Stocks');
+    expect(stripAccountTypePrefix('')).toBe('');
+  });
+
+  test('does not strip later segments named like a type', () => {
+    expect(stripAccountTypePrefix('Assets:Expenses:Foo')).toBe('Expenses:Foo');
+  });
+});

--- a/spa/src/lib/accounts.ts
+++ b/spa/src/lib/accounts.ts
@@ -97,6 +97,15 @@ export function isOpeningBalancesAccount(name: string): boolean {
   return /^Equity:OpeningBalances_[A-Z]{3}$/.test(name);
 }
 
+// "Assets:Bank:Checking" → "Bank:Checking". The account-type prefix is
+// redundant in views that already convey type via surrounding context
+// (e.g. a report titled "Top 5 Expense"). Returns the input unchanged when
+// no recognized prefix is present, so unusual or non-prefixed names pass
+// through safely.
+export function stripAccountTypePrefix(name: string): string {
+  return name.replace(/^(Assets|Liabilities|Equity|Revenue|Expenses):/, '');
+}
+
 // Returns the balance in the account's "natural direction" — what the
 // user means by "the size of this account" regardless of the stored sign
 // convention. Used for sorting so descending = biggest of this thing.

--- a/spa/src/test/reports.balance-sheet.test.tsx
+++ b/spa/src/test/reports.balance-sheet.test.tsx
@@ -78,14 +78,16 @@ test('renders Assets and Equity sections; hides empty Liabilities', async () => 
   });
   expect(screen.getByText('Total Equity')).toBeInTheDocument();
   expect(screen.queryByText('Total Liabilities')).not.toBeInTheDocument();
-  expect(screen.getAllByText('Assets:Bank').length).toBeGreaterThan(0);
+  // Account-type prefix stripped in rendered text on report pages.
+  expect(screen.getAllByText('Bank').length).toBeGreaterThan(0);
+  expect(screen.queryByText('Assets:Bank')).toBeNull();
 });
 
 test('asset rows link to /accounts/{id}', async () => {
   render(makeTestApp('/reports/balance-sheet'));
   await waitFor(() => {
-    expect(screen.getAllByText('Assets:Bank').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Bank').length).toBeGreaterThan(0);
   });
-  const link = screen.getByRole('link', { name: /Assets:Bank/ });
+  const link = screen.getByRole('link', { name: /Bank/ });
   expect(link.getAttribute('href')).toMatch(/\/accounts\/1/);
 });

--- a/spa/src/test/reports.expense-breakdown.test.tsx
+++ b/spa/src/test/reports.expense-breakdown.test.tsx
@@ -61,5 +61,7 @@ test('renders total expense KPI and rows', async () => {
     expect(screen.getByText('Total Expense')).toBeInTheDocument();
   });
   expect(screen.getByText('$2,530.00')).toBeInTheDocument();
-  expect(screen.getAllByText('Expenses:Rent').length).toBeGreaterThan(0);
+  // Account-type prefix stripped in rendered text on report pages.
+  expect(screen.getAllByText('Rent').length).toBeGreaterThan(0);
+  expect(screen.queryByText('Expenses:Rent')).toBeNull();
 });

--- a/spa/src/test/reports.income-statement.test.tsx
+++ b/spa/src/test/reports.income-statement.test.tsx
@@ -127,14 +127,18 @@ test('renders KPI cards, charts, and tables for income statement', async () => {
   expect(screen.getByText('$2,530.00')).toBeInTheDocument();
   expect(screen.getByText('$2,718.00')).toBeInTheDocument();
   expect(screen.getByText(/6\.2% net worth/)).toBeInTheDocument();
-  // Row labels appear in the mix bars (not in any detail table).
-  expect(screen.getByText('Expenses:Rent')).toBeInTheDocument();
+  // Row labels appear in the mix bars; the account-type prefix is
+  // stripped in the visible text. `Income:Salary` is a non-canonical
+  // fixture name whose prefix isn't in the strip set, so it renders
+  // unchanged.
+  expect(screen.getByText('Rent')).toBeInTheDocument();
+  expect(screen.queryByText('Expenses:Rent')).toBeNull();
   expect(screen.getByText('Income:Salary')).toBeInTheDocument();
   // No detail-table headings.
   expect(screen.queryByRole('heading', { name: /Income detail/i })).toBeNull();
   expect(screen.queryByRole('heading', { name: /Expense detail/i })).toBeNull();
   // No drill-down links to /transactions.
-  expect(screen.queryByRole('link', { name: /Expenses:Rent/ })).toBeNull();
+  expect(screen.queryByRole('link', { name: /Rent/ })).toBeNull();
 
   // Diff lines (current minus previous) appear on each KPI card.
   await waitFor(() => {

--- a/spa/src/test/reports.report-row-table.test.tsx
+++ b/spa/src/test/reports.report-row-table.test.tsx
@@ -53,8 +53,12 @@ test('renders rows with account name, amount, tx count', async () => {
       />,
     ),
   );
-  expect(await screen.findByText('Expenses:Food:Groceries')).toBeInTheDocument();
-  expect(screen.getByText('Expenses:Rent')).toBeInTheDocument();
+  // Type prefix is stripped in the rendered cell; the original full name
+  // stays on the wrapping span's `title` for hover.
+  expect(await screen.findByText('Food:Groceries')).toBeInTheDocument();
+  expect(screen.getByText('Rent')).toBeInTheDocument();
+  expect(screen.queryByText('Expenses:Food:Groceries')).toBeNull();
+  expect(screen.queryByText('Expenses:Rent')).toBeNull();
   expect(screen.getByText('$520.00')).toBeInTheDocument();
   expect(screen.getByText('$1,800.00')).toBeInTheDocument();
 });
@@ -70,7 +74,7 @@ test('rows link to /transactions with account_id and bounds', async () => {
       />,
     ),
   );
-  const link = await screen.findByRole('link', { name: /Expenses:Food:Groceries/ });
+  const link = await screen.findByRole('link', { name: /Food:Groceries/ });
   const href = link.getAttribute('href') ?? '';
   expect(href).toContain('/transactions');
   expect(href).toContain('account_id=11');
@@ -89,7 +93,7 @@ test('rows without a resolvable id omit account_id', async () => {
       />,
     ),
   );
-  const link = await screen.findByRole('link', { name: /Expenses:Food:Groceries/ });
+  const link = await screen.findByRole('link', { name: /Food:Groceries/ });
   const href = link.getAttribute('href') ?? '';
   expect(href).not.toContain('account_id=');
   expect(href).toContain('start_time=100');
@@ -97,7 +101,7 @@ test('rows without a resolvable id omit account_id', async () => {
 
 test('with period=null, rows link to /accounts/{id}', async () => {
   render(harness(<ReportRowTable rows={rows} currency="USD" nameToId={nameToId} period={null} />));
-  const link = await screen.findByRole('link', { name: /Expenses:Food:Groceries/ });
+  const link = await screen.findByRole('link', { name: /Food:Groceries/ });
   expect(link.getAttribute('href')).toMatch(/\/accounts\/11/);
 });
 


### PR DESCRIPTION
## Summary

Account names on the reports pages render with the leading account-type segment removed:

- `Assets:Bank:Checking` → `Bank:Checking`
- `Expenses:Food:Dinner` → `Food:Dinner`
- `Revenue:Salary` → `Salary`

The type is already conveyed by the section heading or table column, so the prefix is visual noise. The full name is preserved on the wrapping span's `title` attribute, so hover still surfaces the canonical name. Five recognized roots are stripped: `Assets`, `Liabilities`, `Equity`, `Revenue`, `Expenses`.

Applies to:
- `ProportionBar` — used on income-statement, balance-sheet, income-breakdown, expense-breakdown
- `ReportRowTable` — used on income-breakdown, expense-breakdown (both the Account and Offset columns)

Implementation: a small `stripAccountTypePrefix` helper in `lib/accounts.ts`.

## Why the "Reapply" commit?

The original commit (`b887390`) landed directly on `master` by accident (the previous PR had just been merged and I forgot to start a new branch). To preserve the branch-and-PR workflow, master got a non-destructive revert (`36c06e3`), and this branch reapplies the change as `e66089f`. Net diff vs. master is the original change set.

## Test plan

- [x] Unit: `stripAccountTypePrefix` — three cases (strips each known root; leaves unknown/blank inputs alone; only strips the leading segment)
- [x] Updated existing report integration tests to assert the stripped form is rendered and the prefixed form is gone
- [x] Manually verified in the running dev server
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)