### PR TITLE
feat: add display.hide_decimals option for whole-unit amounts in SPA

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -7,16 +7,21 @@ import "net/http"
 
 type configResponse struct {
 	Defaults configDefaults `json:"defaults"`
+	Display  configDisplay  `json:"display"`
 }
 
 type configDefaults struct {
 	Currency string `json:"currency"`
 }
 
+type configDisplay struct {
+	HideDecimals bool `json:"hide_decimals"`
+}
+
 func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) error {
+	cfg := s.svc.Config()
 	return writeJSON(w, http.StatusOK, configResponse{
-		Defaults: configDefaults{
-			Currency: s.svc.Config().Defaults.Currency,
-		},
+		Defaults: configDefaults{Currency: cfg.Defaults.Currency},
+		Display:  configDisplay{HideDecimals: cfg.Display.HideDecimals},
 	})
 }

--- a/internal/api/config_test.go
+++ b/internal/api/config_test.go
@@ -13,17 +13,19 @@ import (
 
 func TestGetConfig(t *testing.T) {
 	tests := []struct {
-		name     string
-		currency string
-		wantBody string
+		name         string
+		currency     string
+		hideDecimals bool
+		wantBody     string
 	}{
-		{"populated", "USD", `{"defaults":{"currency":"USD"}}`},
-		{"empty", "", `{"defaults":{"currency":""}}`},
-		{"non_default", "TWD", `{"defaults":{"currency":"TWD"}}`},
+		{"populated", "USD", false, `{"defaults":{"currency":"USD"},"display":{"hide_decimals":false}}`},
+		{"empty", "", false, `{"defaults":{"currency":""},"display":{"hide_decimals":false}}`},
+		{"non_default", "TWD", false, `{"defaults":{"currency":"TWD"},"display":{"hide_decimals":false}}`},
+		{"hide_decimals", "USD", true, `{"defaults":{"currency":"USD"},"display":{"hide_decimals":true}}`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts, _, _ := newServerForWriteWithCurrency(t, tt.currency)
+			ts, _, _ := newServerForWriteWithDisplay(t, tt.currency, tt.hideDecimals)
 
 			resp, err := http.Get(ts.URL + "/api/config")
 			if err != nil {
@@ -51,12 +53,18 @@ func TestGetConfig(t *testing.T) {
 				Defaults struct {
 					Currency string `json:"currency"`
 				} `json:"defaults"`
+				Display struct {
+					HideDecimals bool `json:"hide_decimals"`
+				} `json:"display"`
 			}
 			if err := json.Unmarshal(raw, &parsed); err != nil {
 				t.Fatalf("unmarshal: %v", err)
 			}
 			if parsed.Defaults.Currency != tt.currency {
 				t.Errorf("parsed currency: got %q, want %q", parsed.Defaults.Currency, tt.currency)
+			}
+			if parsed.Display.HideDecimals != tt.hideDecimals {
+				t.Errorf("parsed hide_decimals: got %v, want %v", parsed.Display.HideDecimals, tt.hideDecimals)
 			}
 		})
 	}

--- a/internal/api/testhelper_test.go
+++ b/internal/api/testhelper_test.go
@@ -89,6 +89,31 @@ func newServerForWriteWithCurrency(t *testing.T, currency string) (*httptest.Ser
 	return ts, svc, st
 }
 
+// newServerForWriteWithDisplay is a variant of newServerForWriteWithCurrency
+// that also lets the caller set cfg.Display.HideDecimals. Used by /api/config
+// tests that exercise the display option.
+func newServerForWriteWithDisplay(t *testing.T, currency string, hideDecimals bool) (*httptest.Server, *service.Service, *store.Store) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	st, err := store.NewStore(dbPath, migrations.FS)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	cfg := config.NewDefault()
+	cfg.Defaults.Currency = currency
+	cfg.Display.HideDecimals = hideDecimals
+
+	svc := service.NewService(st, st, st, cfg)
+	srv := NewServer(cfg, svc, nil, nil, "", nil, discardLogger())
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+
+	return ts, svc, st
+}
+
 // newServerForWrite is a variant of newServerWithStore that also returns the
 // underlying *store.Store, so write tests can manipulate reconcile state and
 // inject a parent cycle directly via the repo (bypassing the service layer

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ package config
 type Config struct {
 	Database   DatabaseConfig `mapstructure:"database"`
 	Defaults   DefaultsConfig `mapstructure:"defaults"`
+	Display    DisplayConfig  `mapstructure:"display"`
 	Server     ServerConfig   `mapstructure:"server"`
 	ConfigPath string         `mapstructure:"-"`
 }
@@ -24,10 +25,15 @@ type DefaultsConfig struct {
 	Currency string `mapstructure:"currency"`
 }
 
+type DisplayConfig struct {
+	HideDecimals bool `mapstructure:"hide_decimals"`
+}
+
 func NewDefault() *Config {
 	return &Config{
 		Database: DatabaseConfig{Path: ""},
 		Defaults: DefaultsConfig{},
+		Display:  DisplayConfig{HideDecimals: false},
 		Server: ServerConfig{
 			Host:        "localhost",
 			Port:        8080,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,3 +18,11 @@ func TestNewDefault_ServerConfig(t *testing.T) {
 		t.Errorf("expected default CORS origins [http://localhost:5173], got %v", cfg.Server.CORSOrigins)
 	}
 }
+
+func TestNewDefault_DisplayConfig(t *testing.T) {
+	cfg := NewDefault()
+
+	if cfg.Display.HideDecimals != false {
+		t.Errorf("expected default HideDecimals=false, got %v", cfg.Display.HideDecimals)
+	}
+}

--- a/spa/src/components/NetWorthCard.tsx
+++ b/spa/src/components/NetWorthCard.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent } from '@/components/ui/card';
-import { formatCents } from '@/lib/format';
+import { useAmountFormat } from '@/lib/server-config';
 
 interface Props {
   netWorth: number;
@@ -8,6 +8,7 @@ interface Props {
 }
 
 export function NetWorthCard({ netWorth, currency, excludedCount }: Props) {
+  const { formatCents } = useAmountFormat();
   return (
     <Card className="mb-4 bg-gradient-to-br from-blue-700 to-blue-500 text-white">
       <CardContent className="p-6">

--- a/spa/src/components/accounts/AccountDetailHeader.tsx
+++ b/spa/src/components/accounts/AccountDetailHeader.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/cn';
-import { formatCents } from '@/lib/format';
+import { useAmountFormat } from '@/lib/server-config';
 import type { Account, BalanceResponse } from '@/lib/types';
 import { Link } from '@tanstack/react-router';
 import type { ReactNode } from 'react';
@@ -20,6 +20,7 @@ const TYPE_LABEL: Record<Account['type'], string> = {
 };
 
 export function AccountDetailHeader({ account, balance, deleteSlot }: Props) {
+  const { formatCents } = useAmountFormat();
   return (
     <div className="mb-4 rounded-md border bg-card p-4">
       <div className="flex items-start justify-between gap-3">

--- a/spa/src/components/accounts/AccountSearchResults.tsx
+++ b/spa/src/components/accounts/AccountSearchResults.tsx
@@ -1,15 +1,8 @@
 import { AccountTypeBadge } from '@/components/accounts/AccountTypeBadge';
 import { balanceColor } from '@/lib/accounts';
+import { useAmountFormat } from '@/lib/server-config';
 import type { Account, AccountBalance } from '@/lib/types';
 import { Link } from '@tanstack/react-router';
-
-// Balance column shows just `$X,XXX.XX` (no currency code — that's in
-// its own column) and conveys sign via color: negative red, positive
-// green, zero unstyled. The `-` prefix is dropped from negatives.
-function formatBalance(cents: number): string {
-  const abs = Math.abs(cents / 100);
-  return `$${abs.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-}
 
 interface Props {
   accounts: Account[];
@@ -19,6 +12,7 @@ interface Props {
 }
 
 export function AccountSearchResults({ accounts, balances, sortDir, onToggleSort }: Props) {
+  const { formatBalanceAbs } = useAmountFormat();
   const balanceById = new Map<number, { amount: number; currency: string }>();
   if (balances) {
     for (const b of balances) {
@@ -78,7 +72,7 @@ export function AccountSearchResults({ accounts, balances, sortDir, onToggleSort
                   <td className="px-3 py-2 text-right tabular-nums">
                     {bal ? (
                       <span className={balanceColor(acc.type, bal.amount)}>
-                        {formatBalance(bal.amount)}
+                        {formatBalanceAbs(bal.amount)}
                       </span>
                     ) : (
                       '—'

--- a/spa/src/components/accounts/ChildAccountsCard.tsx
+++ b/spa/src/components/accounts/ChildAccountsCard.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/lib/cn';
-import { formatCents } from '@/lib/format';
+import { useAmountFormat } from '@/lib/server-config';
 import type { AccountBalance, AccountNode } from '@/lib/types';
 import { Link } from '@tanstack/react-router';
 
@@ -9,6 +9,7 @@ interface Props {
 }
 
 export function ChildAccountsCard({ accounts, balances }: Props) {
+  const { formatCents } = useAmountFormat();
   const balanceById = new Map<number, { amount: number; currency: string }>();
   if (balances) {
     for (const b of balances) {

--- a/spa/src/components/accounts/RecentTransactionsCard.tsx
+++ b/spa/src/components/accounts/RecentTransactionsCard.tsx
@@ -2,6 +2,7 @@ import { StatusText } from '@/components/transactions/StatusText';
 import { TypeBadge } from '@/components/transactions/TypeBadge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/cn';
+import { useAmountFormat } from '@/lib/server-config';
 import { displayAmount } from '@/lib/transactionDisplay';
 import { listTransactions } from '@/lib/transactions';
 import { DEFAULT_TRANSACTIONS_LIMIT } from '@/lib/transactions-search-params';
@@ -20,16 +21,8 @@ function formatDate(unix: number): string {
   return d.toISOString().slice(0, 10);
 }
 
-// Plain "$X,XXX.XX" — sign conveyed by color, transfer-coloring handled
-// at the call site.
-function formatDollars(cents: number): string {
-  return `$${(Math.abs(cents) / 100).toLocaleString('en-US', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
-}
-
 export function RecentTransactionsCard({ accountId }: Props) {
+  const { formatBalanceAbs } = useAmountFormat();
   const query = useQuery({
     queryKey: ['transactions', { account_id: accountId, limit: RECENT_LIMIT }],
     queryFn: () => listTransactions({ account_id: accountId }, { limit: RECENT_LIMIT }),
@@ -82,7 +75,7 @@ export function RecentTransactionsCard({ accountId }: Props) {
               <TypeBadge type={tx.type} />
               <span className="truncate">{tx.description}</span>
               <span className={cn('text-right tabular-nums', signClass)}>
-                {formatDollars(amount)}
+                {formatBalanceAbs(amount)}
               </span>
               <span className="text-right">
                 <StatusText status={tx.status} />

--- a/spa/src/components/balances/BalanceCard.tsx
+++ b/spa/src/components/balances/BalanceCard.tsx
@@ -1,7 +1,7 @@
 import { Sparkline } from '@/components/balances/Sparkline';
 import { balanceColor, balanceStrokeColor } from '@/lib/accounts';
 import { cn } from '@/lib/cn';
-import { formatBalanceAbs } from '@/lib/format';
+import { useAmountFormat } from '@/lib/server-config';
 import type { AccountBalance, BalanceHistoryPoint } from '@/lib/types';
 import { Link } from '@tanstack/react-router';
 
@@ -20,6 +20,7 @@ function stripColumnPrefix(name: string, columnLabel: 'Assets' | 'Liabilities'):
 }
 
 export function BalanceCard({ row, columnLabel, share, points }: Props) {
+  const { formatBalanceAbs } = useAmountFormat();
   const displayName = stripColumnPrefix(row.name, columnLabel);
   const shareWording = columnLabel.toLowerCase(); // 'assets' | 'liabilities'
 

--- a/spa/src/components/balances/BalanceColumn.tsx
+++ b/spa/src/components/balances/BalanceColumn.tsx
@@ -4,7 +4,7 @@ import { Pagination } from '@/components/transactions/Pagination';
 import { Card, CardContent } from '@/components/ui/card';
 import { balanceColor } from '@/lib/accounts';
 import { cn } from '@/lib/cn';
-import { formatBalanceAbs } from '@/lib/format';
+import { useAmountFormat } from '@/lib/server-config';
 import type { AccountBalance, BalanceHistoryPoint } from '@/lib/types';
 
 export const LIST_PAGE_SIZE = 8;
@@ -47,6 +47,7 @@ export function BalanceColumn({
   view,
   historyByAccount,
 }: Props) {
+  const { formatBalanceAbs } = useAmountFormat();
   const isEmpty = rows.length === 0;
   const totalType = label === 'Assets' ? 'A' : 'L';
   const totalText = formatBalanceAbs(total);

--- a/spa/src/components/balances/BalanceColumnRow.tsx
+++ b/spa/src/components/balances/BalanceColumnRow.tsx
@@ -1,6 +1,6 @@
 import { balanceColor } from '@/lib/accounts';
 import { cn } from '@/lib/cn';
-import { formatBalanceAbs } from '@/lib/format';
+import { useAmountFormat } from '@/lib/server-config';
 import type { AccountBalance } from '@/lib/types';
 import { Link } from '@tanstack/react-router';
 
@@ -9,6 +9,7 @@ interface Props {
 }
 
 export function BalanceColumnRow({ row }: Props) {
+  const { formatBalanceAbs } = useAmountFormat();
   return (
     <Link
       to="/accounts/$id"

--- a/spa/src/components/reports/CurrencyFooter.tsx
+++ b/spa/src/components/reports/CurrencyFooter.tsx
@@ -1,4 +1,4 @@
-import { formatCents } from '@/lib/format';
+import { useAmountFormat } from '@/lib/server-config';
 
 export interface CurrencyEntry {
   label: string;
@@ -11,6 +11,7 @@ interface Props {
 }
 
 export function CurrencyFooter({ defaultCurrency, entries }: Props) {
+  const { formatCents } = useAmountFormat();
   const lines = entries
     .map((entry) => {
       const others = Object.entries(entry.byCurrency).filter(([cur]) => cur !== defaultCurrency);

--- a/spa/src/components/reports/KpiCard.tsx
+++ b/spa/src/components/reports/KpiCard.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/lib/cn';
-import { formatCents } from '@/lib/format';
+import { useAmountFormat } from '@/lib/server-config';
 
 export type KpiVariant = 'green' | 'red' | 'neutral';
 
@@ -28,30 +28,30 @@ const GOOD_CLASS = 'text-green-700 dark:text-green-400';
 const BAD_CLASS = 'text-red-700 dark:text-red-400';
 const NEUTRAL_DIFF_CLASS = 'text-muted-foreground';
 
-function formatDiff(diff: KpiDiff, currency: string): { text: string; className: string } {
-  if (diff.delta === 0) {
-    return { text: '— no change vs last period', className: NEUTRAL_DIFF_CLASS };
-  }
-  const arrow = diff.delta > 0 ? '▲' : '▼';
-  const sign = diff.delta > 0 ? '+' : '-';
-  const absAmount = formatCents(Math.abs(diff.delta), currency);
-  let pctPart = '';
-  if (diff.prevAmount !== 0) {
-    const pct = (diff.delta / Math.abs(diff.prevAmount)) * 100;
-    const pctSign = pct > 0 ? '+' : pct < 0 ? '-' : '';
-    pctPart = ` (${pctSign}${Math.abs(pct).toFixed(1)}%)`;
-  }
-  const isGood =
-    (diff.delta > 0 && diff.goodWhen === 'up') ||
-    (diff.delta < 0 && diff.goodWhen === 'down');
-  return {
-    text: `${arrow} ${sign}${absAmount}${pctPart} vs last period`,
-    className: isGood ? GOOD_CLASS : BAD_CLASS,
-  };
-}
-
 export function KpiCard({ label, amount, currency, variant, subLine, diff }: Props) {
-  const diffRendered = diff ? formatDiff(diff, currency) : null;
+  const { formatCents } = useAmountFormat();
+
+  const formatDiff = (d: KpiDiff): { text: string; className: string } => {
+    if (d.delta === 0) {
+      return { text: '— no change vs last period', className: NEUTRAL_DIFF_CLASS };
+    }
+    const arrow = d.delta > 0 ? '▲' : '▼';
+    const sign = d.delta > 0 ? '+' : '-';
+    const absAmount = formatCents(Math.abs(d.delta), currency);
+    let pctPart = '';
+    if (d.prevAmount !== 0) {
+      const pct = (d.delta / Math.abs(d.prevAmount)) * 100;
+      const pctSign = pct > 0 ? '+' : pct < 0 ? '-' : '';
+      pctPart = ` (${pctSign}${Math.abs(pct).toFixed(1)}%)`;
+    }
+    const isGood = (d.delta > 0 && d.goodWhen === 'up') || (d.delta < 0 && d.goodWhen === 'down');
+    return {
+      text: `${arrow} ${sign}${absAmount}${pctPart} vs last period`,
+      className: isGood ? GOOD_CLASS : BAD_CLASS,
+    };
+  };
+
+  const diffRendered = diff ? formatDiff(diff) : null;
   return (
     <div className="rounded-md border bg-card p-4">
       <div className="text-xs uppercase tracking-wide text-muted-foreground">{label}</div>

--- a/spa/src/components/reports/ProportionBar.tsx
+++ b/spa/src/components/reports/ProportionBar.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { stripAccountTypePrefix } from '@/lib/accounts';
-import { formatCents } from '@/lib/format';
+import { useAmountFormat } from '@/lib/server-config';
 import type { ReportRow } from '@/lib/types';
 import { useState } from 'react';
 
@@ -20,6 +20,7 @@ const COLOR: Record<NonNullable<Props['variant']>, string> = {
 };
 
 export function ProportionBar({ rows, total, currency, limit, variant = 'income' }: Props) {
+  const { formatCents } = useAmountFormat();
   const [expanded, setExpanded] = useState(false);
 
   if (rows.length === 0) {

--- a/spa/src/components/reports/ReportRowTable.tsx
+++ b/spa/src/components/reports/ReportRowTable.tsx
@@ -1,5 +1,5 @@
 import { stripAccountTypePrefix } from '@/lib/accounts';
-import { formatCents } from '@/lib/format';
+import { useAmountFormat } from '@/lib/server-config';
 import { DEFAULT_TRANSACTIONS_LIMIT } from '@/lib/transactions-search-params';
 import type { ReportRow } from '@/lib/types';
 import { Link } from '@tanstack/react-router';
@@ -13,6 +13,7 @@ interface Props {
 }
 
 export function ReportRowTable({ rows, currency, nameToId, period }: Props) {
+  const { formatCents } = useAmountFormat();
   if (rows.length === 0) {
     return <p className="text-sm text-muted-foreground">No rows.</p>;
   }
@@ -66,10 +67,7 @@ export function ReportRowTable({ rows, currency, nameToId, period }: Props) {
                   </Link>
                 )}
               </td>
-              <td
-                className="py-1.5 text-muted-foreground"
-                title={row.offset_account}
-              >
+              <td className="py-1.5 text-muted-foreground" title={row.offset_account}>
                 {stripAccountTypePrefix(row.offset_account)}
               </td>
               <td className="py-1.5 text-right font-mono tabular-nums">

--- a/spa/src/components/transactions/TransactionRow.tsx
+++ b/spa/src/components/transactions/TransactionRow.tsx
@@ -52,7 +52,9 @@ export function TransactionRow({ tx, search }: Props) {
       <span className="truncate text-left text-muted-foreground" title={offset}>
         {offset}
       </span>
-      <span className={cn('text-right tabular-nums', signClass)}>{formatBalanceAbs(absAmount)}</span>
+      <span className={cn('text-right tabular-nums', signClass)}>
+        {formatBalanceAbs(absAmount)}
+      </span>
       <span className="text-right">
         <StatusText status={tx.status} />
       </span>

--- a/spa/src/components/transactions/TransactionRow.tsx
+++ b/spa/src/components/transactions/TransactionRow.tsx
@@ -2,6 +2,7 @@ import { StatusText } from '@/components/transactions/StatusText';
 import { TRANSACTIONS_GRID_COLS } from '@/components/transactions/TransactionsTable';
 import { TypeBadge } from '@/components/transactions/TypeBadge';
 import { cn } from '@/lib/cn';
+import { useAmountFormat } from '@/lib/server-config';
 import { displayAccount, displayAmount, displayOffsetAccount } from '@/lib/transactionDisplay';
 import type { TransactionsSearch } from '@/lib/transactions-search-params';
 import type { TransactionDetail } from '@/lib/types';
@@ -20,14 +21,8 @@ function fmtDate(unix: number): string {
   return `${y}-${m}-${day}`;
 }
 
-function formatDollars(cents: number): string {
-  return `$${(cents / 100).toLocaleString('en-US', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
-}
-
 export function TransactionRow({ tx, search }: Props) {
+  const { formatBalanceAbs } = useAmountFormat();
   const acc = displayAccount(tx.splits, tx.type);
   const offset = displayOffsetAccount(tx.splits, tx.type, acc);
   const { amount } = displayAmount(tx.splits, tx.type);
@@ -57,7 +52,7 @@ export function TransactionRow({ tx, search }: Props) {
       <span className="truncate text-left text-muted-foreground" title={offset}>
         {offset}
       </span>
-      <span className={cn('text-right tabular-nums', signClass)}>{formatDollars(absAmount)}</span>
+      <span className={cn('text-right tabular-nums', signClass)}>{formatBalanceAbs(absAmount)}</span>
       <span className="text-right">
         <StatusText status={tx.status} />
       </span>

--- a/spa/src/lib/format.test.ts
+++ b/spa/src/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { formatCents } from './format';
+import { formatBalanceAbs, formatCents } from './format';
 
 describe('formatCents', () => {
   test('formats positive cents as USD', () => {
@@ -24,5 +24,42 @@ describe('formatCents', () => {
   test('falls back gracefully on unknown currency code', () => {
     // Intl will throw on bogus codes; helper must handle.
     expect(() => formatCents(100, 'ZZZ')).not.toThrow();
+  });
+});
+
+describe('formatCents with hideDecimals: true', () => {
+  test('drops decimals for whole values', () => {
+    expect(formatCents(260000, 'USD', { hideDecimals: true })).toBe('$2,600');
+  });
+
+  test('rounds half away from zero (positive)', () => {
+    expect(formatCents(260050, 'USD', { hideDecimals: true })).toBe('$2,601');
+  });
+
+  test('rounds half away from zero (negative)', () => {
+    expect(formatCents(-260050, 'USD', { hideDecimals: true })).toBe('-$2,601');
+  });
+
+  test('does not round below half', () => {
+    expect(formatCents(260049, 'USD', { hideDecimals: true })).toBe('$2,600');
+  });
+
+  test('falls back gracefully on unknown currency', () => {
+    expect(() => formatCents(260050, 'ZZZ', { hideDecimals: true })).not.toThrow();
+  });
+});
+
+describe('formatBalanceAbs', () => {
+  test('renders two decimals by default', () => {
+    expect(formatBalanceAbs(260000)).toBe('$2,600.00');
+    expect(formatBalanceAbs(-42050)).toBe('$420.50');
+  });
+
+  test('drops decimals when hideDecimals is true', () => {
+    expect(formatBalanceAbs(260000, { hideDecimals: true })).toBe('$2,600');
+  });
+
+  test('rounds and strips sign when hideDecimals is true', () => {
+    expect(formatBalanceAbs(-260050, { hideDecimals: true })).toBe('$2,601');
   });
 });

--- a/spa/src/lib/format.ts
+++ b/spa/src/lib/format.ts
@@ -1,19 +1,34 @@
-export function formatCents(cents: number, currency: string): string {
+export interface AmountFormatOptions {
+  hideDecimals?: boolean;
+}
+
+export function formatCents(
+  cents: number,
+  currency: string,
+  options: AmountFormatOptions = {},
+): string {
   const value = cents / 100;
+  const digits = options.hideDecimals ? 0 : 2;
   try {
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency,
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
     }).format(value);
   } catch {
     // Unknown currency code — fall back to plain number with the code.
-    return `${value.toFixed(2)} ${currency}`;
+    return `${value.toFixed(digits)} ${currency}`;
   }
 }
 
 // `$X,XXX.XX` with no currency code and no minus sign. Used where the row's
 // type/column already conveys account and the surrounding color conveys sign.
-export function formatBalanceAbs(cents: number): string {
+export function formatBalanceAbs(cents: number, options: AmountFormatOptions = {}): string {
   const abs = Math.abs(cents / 100);
-  return `$${abs.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  const digits = options.hideDecimals ? 0 : 2;
+  return `$${abs.toLocaleString('en-US', {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  })}`;
 }

--- a/spa/src/lib/server-config.tsx
+++ b/spa/src/lib/server-config.tsx
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { type ReactNode, createContext, useContext } from 'react';
 import { getConfig } from './api';
+import { formatBalanceAbs, formatCents } from './format';
 import type { ServerConfig } from './types';
 
-const ServerConfigContext = createContext<ServerConfig | null>(null);
+export const ServerConfigContext = createContext<ServerConfig | null>(null);
 
 interface ServerConfigProviderProps {
   fallback: ReactNode;
@@ -34,4 +35,13 @@ export function useServerConfig(): ServerConfig {
     throw new Error('useServerConfig must be used inside ServerConfigProvider');
   }
   return cfg;
+}
+
+export function useAmountFormat() {
+  const cfg = useServerConfig();
+  const opts = { hideDecimals: cfg.display.hide_decimals };
+  return {
+    formatCents: (cents: number, currency: string) => formatCents(cents, currency, opts),
+    formatBalanceAbs: (cents: number) => formatBalanceAbs(cents, opts),
+  };
 }

--- a/spa/src/lib/types.ts
+++ b/spa/src/lib/types.ts
@@ -21,6 +21,9 @@ export interface ServerConfig {
   defaults: {
     currency: string;
   };
+  display: {
+    hide_decimals: boolean;
+  };
 }
 
 export interface LedgerInfo {

--- a/spa/src/routes/reports.balance-sheet.tsx
+++ b/spa/src/routes/reports.balance-sheet.tsx
@@ -7,10 +7,9 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { getBalances } from '@/lib/api';
-import { formatCents } from '@/lib/format';
 import { useBalanceSheet } from '@/lib/hooks/useReport';
 import { type AsOfSearchParams, parseAsOfSearch } from '@/lib/reports-search-params';
-import { useServerConfig } from '@/lib/server-config';
+import { useAmountFormat, useServerConfig } from '@/lib/server-config';
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useMemo } from 'react';
@@ -22,6 +21,7 @@ export const Route = createFileRoute('/reports/balance-sheet')({
 
 function BalanceSheetPage() {
   const { defaults } = useServerConfig();
+  const { formatCents } = useAmountFormat();
   const currency = defaults.currency;
   const search = Route.useSearch();
   const navigate = useNavigate({ from: '/reports/balance-sheet' });

--- a/spa/src/routes/reports.net-worth.tsx
+++ b/spa/src/routes/reports.net-worth.tsx
@@ -3,10 +3,9 @@ import { CurrencyFooter } from '@/components/reports/CurrencyFooter';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { formatCents } from '@/lib/format';
 import { useNetWorth } from '@/lib/hooks/useReport';
 import { type AtSearchParams, parseAtSearch } from '@/lib/reports-search-params';
-import { useServerConfig } from '@/lib/server-config';
+import { useAmountFormat, useServerConfig } from '@/lib/server-config';
 import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/reports/net-worth')({
@@ -16,6 +15,7 @@ export const Route = createFileRoute('/reports/net-worth')({
 
 function NetWorthPage() {
   const { defaults } = useServerConfig();
+  const { formatCents } = useAmountFormat();
   const currency = defaults.currency;
   const search = Route.useSearch();
   const navigate = useNavigate({ from: '/reports/net-worth' });

--- a/spa/src/routes/transactions.$id.index.tsx
+++ b/spa/src/routes/transactions.$id.index.tsx
@@ -4,7 +4,7 @@ import { TypeBadge } from '@/components/transactions/TypeBadge';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { formatCents } from '@/lib/format';
+import { useAmountFormat } from '@/lib/server-config';
 import { deleteTransaction, getTransaction } from '@/lib/transactions';
 import { DEFAULT_TRANSACTIONS_LIMIT } from '@/lib/transactions-search-params';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -21,6 +21,7 @@ function TransactionDetailPage() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const { formatCents } = useAmountFormat();
 
   const query = useQuery({
     queryKey: ['transaction', txId],

--- a/spa/src/test/accounts.delete.test.tsx
+++ b/spa/src/test/accounts.delete.test.tsx
@@ -38,7 +38,9 @@ vi.mock('@/lib/transactions', async () => ({
 
 vi.mock('@/lib/api', async () => ({
   ...(await vi.importActual<object>('@/lib/api')),
-  getConfig: vi.fn().mockResolvedValue({ defaults: { currency: 'USD' } }),
+  getConfig: vi
+    .fn()
+    .mockResolvedValue({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
   getBalances: vi.fn().mockResolvedValue({
     items: [],
     total_count: 0,

--- a/spa/src/test/accounts.detail.test.tsx
+++ b/spa/src/test/accounts.detail.test.tsx
@@ -56,7 +56,9 @@ vi.mock('@/lib/transactions', async () => ({
 
 vi.mock('@/lib/api', async () => ({
   ...(await vi.importActual<object>('@/lib/api')),
-  getConfig: vi.fn().mockResolvedValue({ defaults: { currency: 'USD' } }),
+  getConfig: vi
+    .fn()
+    .mockResolvedValue({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
   getBalances: vi.fn().mockResolvedValue({
     items: [],
     total_count: 0,

--- a/spa/src/test/accounts.form.test.tsx
+++ b/spa/src/test/accounts.form.test.tsx
@@ -57,7 +57,9 @@ vi.mock('@/lib/accounts', async () => ({
 
 vi.mock('@/lib/api', async () => ({
   ...(await vi.importActual<object>('@/lib/api')),
-  getConfig: vi.fn().mockResolvedValue({ defaults: { currency: 'USD' } }),
+  getConfig: vi
+    .fn()
+    .mockResolvedValue({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
   getBalances: vi.fn().mockResolvedValue({
     items: [],
     total_count: 0,

--- a/spa/src/test/accounts.list.test.tsx
+++ b/spa/src/test/accounts.list.test.tsx
@@ -44,7 +44,9 @@ vi.mock('@/lib/accounts', async () => {
 
 vi.mock('@/lib/api', async () => ({
   ...(await vi.importActual<object>('@/lib/api')),
-  getConfig: vi.fn().mockResolvedValue({ defaults: { currency: 'USD' } }),
+  getConfig: vi
+    .fn()
+    .mockResolvedValue({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
   getBalances: vi.fn().mockResolvedValue({
     items: [
       { account_id: 1, name: 'Assets', type: 'A', currency: 'USD', amount: 0, is_hidden: false },

--- a/spa/src/test/accounts.search.test.tsx
+++ b/spa/src/test/accounts.search.test.tsx
@@ -44,7 +44,9 @@ vi.mock('@/lib/api', async () => ({
     limit: 0,
     offset: 0,
   }),
-  getConfig: vi.fn().mockResolvedValue({ defaults: { currency: 'USD' } }),
+  getConfig: vi
+    .fn()
+    .mockResolvedValue({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
 }));
 
 describe('accounts list — search mode', () => {

--- a/spa/src/test/balances.link.test.tsx
+++ b/spa/src/test/balances.link.test.tsx
@@ -4,7 +4,9 @@ import { makeTestApp } from './test-app';
 
 vi.mock('@/lib/api', async () => ({
   ...(await vi.importActual<object>('@/lib/api')),
-  getConfig: vi.fn().mockResolvedValue({ defaults: { currency: 'USD' } }),
+  getConfig: vi
+    .fn()
+    .mockResolvedValue({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
   getBalances: vi.fn().mockResolvedValue({
     items: [
       {

--- a/spa/src/test/balances.test.tsx
+++ b/spa/src/test/balances.test.tsx
@@ -14,7 +14,9 @@ beforeEach(() => {
     'fetch',
     vi.fn((url: string) => {
       if (url === '/api/config') {
-        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+        return Promise.resolve(
+          okResponse({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
+        );
       }
       if (url === '/api/balances') {
         return Promise.resolve(
@@ -159,7 +161,9 @@ test('sorts liabilities by natural amount so biggest debt comes first by default
     'fetch',
     vi.fn((url: string) => {
       if (url === '/api/config') {
-        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+        return Promise.resolve(
+          okResponse({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
+        );
       }
       if (url === '/api/ledgers') {
         return Promise.resolve(
@@ -233,7 +237,9 @@ test('Assets pagination advances a_offset without touching the Liabilities colum
     'fetch',
     vi.fn((url: string) => {
       if (url === '/api/config') {
-        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+        return Promise.resolve(
+          okResponse({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
+        );
       }
       if (url === '/api/ledgers') {
         return Promise.resolve(

--- a/spa/src/test/components/BalanceCard.test.tsx
+++ b/spa/src/test/components/BalanceCard.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '@tanstack/react-router';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
+import { withServerConfig } from '../test-app';
 
 function renderWithRouter(ui: React.ReactNode) {
   const rootRoute = new RootRoute({ component: () => <>{ui}</> });
@@ -20,9 +21,11 @@ function renderWithRouter(ui: React.ReactNode) {
   });
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
   return render(
-    <QueryClientProvider client={qc}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>,
+    withServerConfig(
+      <QueryClientProvider client={qc}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    ),
   );
 }
 

--- a/spa/src/test/components/BalanceColumn.test.tsx
+++ b/spa/src/test/components/BalanceColumn.test.tsx
@@ -11,6 +11,7 @@ import {
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
+import { withServerConfig } from '../test-app';
 
 // BalanceColumn renders <Link>, so it needs a router context. Build a
 // minimal one with a single dummy route so the link has somewhere to go.
@@ -23,9 +24,11 @@ function renderWithRouter(ui: React.ReactNode) {
   });
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
   return render(
-    <QueryClientProvider client={qc}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>,
+    withServerConfig(
+      <QueryClientProvider client={qc}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    ),
   );
 }
 

--- a/spa/src/test/reports.balance-sheet.test.tsx
+++ b/spa/src/test/reports.balance-sheet.test.tsx
@@ -13,7 +13,9 @@ beforeEach(() => {
     'fetch',
     vi.fn((url: string) => {
       if (url === '/api/config')
-        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+        return Promise.resolve(
+          okResponse({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
+        );
       if (url === '/api/ledgers')
         return Promise.resolve(
           okResponse({ active: 'p', items: [{ name: 'p', path: '/p.db', active: true }] }),

--- a/spa/src/test/reports.currency-footer.test.tsx
+++ b/spa/src/test/reports.currency-footer.test.tsx
@@ -1,6 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { render as rtlRender, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { expect, test } from 'vitest';
 import { CurrencyFooter } from '../components/reports/CurrencyFooter';
+import { withServerConfig } from './test-app';
+
+const render = (ui: ReactNode) => rtlRender(withServerConfig(ui));
 
 test('renders nothing when only the default currency is present', () => {
   const { container } = render(

--- a/spa/src/test/reports.expense-breakdown.test.tsx
+++ b/spa/src/test/reports.expense-breakdown.test.tsx
@@ -13,7 +13,9 @@ beforeEach(() => {
     'fetch',
     vi.fn((url: string) => {
       if (url === '/api/config')
-        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+        return Promise.resolve(
+          okResponse({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
+        );
       if (url === '/api/ledgers')
         return Promise.resolve(
           okResponse({ active: 'p', items: [{ name: 'p', path: '/p.db', active: true }] }),

--- a/spa/src/test/reports.income-breakdown.test.tsx
+++ b/spa/src/test/reports.income-breakdown.test.tsx
@@ -13,7 +13,9 @@ beforeEach(() => {
     'fetch',
     vi.fn((url: string) => {
       if (url === '/api/config') {
-        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+        return Promise.resolve(
+          okResponse({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
+        );
       }
       if (url === '/api/ledgers') {
         return Promise.resolve(

--- a/spa/src/test/reports.income-statement.test.tsx
+++ b/spa/src/test/reports.income-statement.test.tsx
@@ -46,9 +46,9 @@ const REPORT_PAYLOAD = {
 const PREV_REPORT_PAYLOAD = {
   ...REPORT_PAYLOAD,
   period: 'May 2026',
-  total_income: { USD: 400000 },   // prev income = $4,000.00; current = $5,248.00 → +$1,248.00 (+31.2%)
-  total_expense: { USD: 300000 },  // prev expense = $3,000.00; current = $2,530.00 → -$470.00 (-15.7%)
-  net_amount: { USD: 100000 },     // prev net = $1,000.00; current = $2,718.00 → +$1,718.00 (+171.8%)
+  total_income: { USD: 400000 }, // prev income = $4,000.00; current = $5,248.00 → +$1,248.00 (+31.2%)
+  total_expense: { USD: 300000 }, // prev expense = $3,000.00; current = $2,530.00 → -$470.00 (-15.7%)
+  net_amount: { USD: 100000 }, // prev net = $1,000.00; current = $2,718.00 → +$1,718.00 (+171.8%)
 };
 
 beforeEach(() => {
@@ -58,7 +58,9 @@ beforeEach(() => {
     'fetch',
     vi.fn((url: string) => {
       if (url === '/api/config') {
-        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+        return Promise.resolve(
+          okResponse({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
+        );
       }
       if (url === '/api/ledgers') {
         return Promise.resolve(
@@ -145,9 +147,9 @@ test('renders KPI cards, charts, and tables for income statement', async () => {
     const diffs = document.querySelectorAll('[data-testid="kpi-diff"]');
     expect(diffs.length).toBe(3);
   });
-  const diffTexts = Array.from(
-    document.querySelectorAll('[data-testid="kpi-diff"]'),
-  ).map((el) => el.textContent ?? '');
+  const diffTexts = Array.from(document.querySelectorAll('[data-testid="kpi-diff"]')).map(
+    (el) => el.textContent ?? '',
+  );
   // Income: +$1,248.00 vs prev $4,000.00
   expect(diffTexts.some((t) => t.includes('+$1,248.00'))).toBe(true);
   // Expense: -$470.00 vs prev $3,000.00
@@ -161,7 +163,9 @@ test('renders empty state when there are no rows', async () => {
     'fetch',
     vi.fn((url: string) => {
       if (url === '/api/config') {
-        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+        return Promise.resolve(
+          okResponse({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
+        );
       }
       if (url === '/api/ledgers') {
         return Promise.resolve(
@@ -197,7 +201,9 @@ test('omits diff lines when previous-period query is errored', async () => {
     'fetch',
     vi.fn((url: string) => {
       if (url === '/api/config') {
-        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+        return Promise.resolve(
+          okResponse({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
+        );
       }
       if (url === '/api/ledgers') {
         return Promise.resolve(

--- a/spa/src/test/reports.kpi-card.test.tsx
+++ b/spa/src/test/reports.kpi-card.test.tsx
@@ -1,6 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { render as rtlRender, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { expect, test } from 'vitest';
 import { KpiCard } from '../components/reports/KpiCard';
+import { withServerConfig } from './test-app';
+
+const render = (ui: ReactNode) => rtlRender(withServerConfig(ui));
 
 test('renders label, formatted amount, and currency', () => {
   render(<KpiCard label="Income" amount={524800} currency="USD" variant="green" />);

--- a/spa/src/test/reports.net-worth.test.tsx
+++ b/spa/src/test/reports.net-worth.test.tsx
@@ -13,7 +13,9 @@ beforeEach(() => {
     'fetch',
     vi.fn((url: string) => {
       if (url === '/api/config')
-        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+        return Promise.resolve(
+          okResponse({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
+        );
       if (url === '/api/ledgers')
         return Promise.resolve(
           okResponse({ active: 'p', items: [{ name: 'p', path: '/p.db', active: true }] }),

--- a/spa/src/test/reports.proportion-bar.test.tsx
+++ b/spa/src/test/reports.proportion-bar.test.tsx
@@ -1,8 +1,12 @@
-import { render, screen } from '@testing-library/react';
+import { render as rtlRender, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
 import { expect, test, vi } from 'vitest';
 import { ProportionBar } from '../components/reports/ProportionBar';
 import type { ReportRow } from '../lib/types';
+import { withServerConfig } from './test-app';
+
+const render = (ui: ReactNode) => rtlRender(withServerConfig(ui));
 
 const rows: ReportRow[] = [
   { account_name: 'Salary', offset_account: '', amount: 520000, currency: 'USD', tx_count: 1 },

--- a/spa/src/test/reports.report-row-table.test.tsx
+++ b/spa/src/test/reports.report-row-table.test.tsx
@@ -9,6 +9,7 @@ import { render, screen } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { ReportRowTable } from '../components/reports/ReportRowTable';
 import type { ReportRow } from '../lib/types';
+import { withServerConfig } from './test-app';
 
 function harness(node: React.ReactNode) {
   const rootRoute = new RootRoute({ component: () => <>{node}</> });
@@ -17,7 +18,7 @@ function harness(node: React.ReactNode) {
     routeTree: rootRoute.addChildren([dummy]),
     history: createMemoryHistory({ initialEntries: ['/'] }),
   });
-  return <RouterProvider router={router} />;
+  return withServerConfig(<RouterProvider router={router} />);
 }
 
 const rows: ReportRow[] = [

--- a/spa/src/test/reports.tab-nav.test.tsx
+++ b/spa/src/test/reports.tab-nav.test.tsx
@@ -13,7 +13,9 @@ beforeEach(() => {
     'fetch',
     vi.fn((url: string) => {
       if (url === '/api/config') {
-        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+        return Promise.resolve(
+          okResponse({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
+        );
       }
       if (url === '/api/ledgers') {
         return Promise.resolve(

--- a/spa/src/test/server-config.test.tsx
+++ b/spa/src/test/server-config.test.tsx
@@ -32,7 +32,9 @@ beforeEach(() => {
     'fetch',
     vi.fn((url: string) => {
       if (url === '/api/config') {
-        return Promise.resolve(okResponse({ defaults: { currency: 'TWD' } }));
+        return Promise.resolve(
+          okResponse({ defaults: { currency: 'TWD' }, display: { hide_decimals: false } }),
+        );
       }
       throw new Error(`unexpected fetch: ${url}`);
     }),

--- a/spa/src/test/test-app.tsx
+++ b/spa/src/test/test-app.tsx
@@ -1,6 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider, createMemoryHistory, createRouter } from '@tanstack/react-router';
-import { ServerConfigProvider } from '../lib/server-config';
+import type { ReactNode } from 'react';
+import { ServerConfigContext, ServerConfigProvider } from '../lib/server-config';
+import type { ServerConfig } from '../lib/types';
 import { routeTree } from '../routeTree.gen';
 
 export function makeTestApp(initialPath: string) {
@@ -16,4 +18,14 @@ export function makeTestApp(initialPath: string) {
       </ServerConfigProvider>
     </QueryClientProvider>
   );
+}
+
+// Test helper for component-level tests that render outside makeTestApp.
+// Wraps children with a stubbed ServerConfig so useServerConfig/useAmountFormat
+// can be called without standing up the full /api/config fetch stack.
+export function withServerConfig(
+  children: ReactNode,
+  config: ServerConfig = { defaults: { currency: 'USD' }, display: { hide_decimals: false } },
+) {
+  return <ServerConfigContext.Provider value={config}>{children}</ServerConfigContext.Provider>;
 }

--- a/spa/src/test/transactions.form.test.tsx
+++ b/spa/src/test/transactions.form.test.tsx
@@ -41,7 +41,9 @@ beforeEach(() => {
     'fetch',
     vi.fn((url: string, init?: RequestInit) => {
       if (url === '/api/config') {
-        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+        return Promise.resolve(
+          okResponse({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
+        );
       }
       if (url === '/api/ledgers') {
         return Promise.resolve(

--- a/spa/src/test/transactions.list.test.tsx
+++ b/spa/src/test/transactions.list.test.tsx
@@ -75,7 +75,9 @@ beforeEach(() => {
     'fetch',
     vi.fn((url: string) => {
       if (url === '/api/config') {
-        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+        return Promise.resolve(
+          okResponse({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
+        );
       }
       if (url === '/api/ledgers') {
         return Promise.resolve(

--- a/spa/src/test/transactions.reconciled.test.tsx
+++ b/spa/src/test/transactions.reconciled.test.tsx
@@ -43,7 +43,9 @@ function setupFetch(tx: typeof RECONCILED_TX) {
     'fetch',
     vi.fn((url: string) => {
       if (url === '/api/config') {
-        return Promise.resolve(okResponse({ defaults: { currency: 'USD' } }));
+        return Promise.resolve(
+          okResponse({ defaults: { currency: 'USD' }, display: { hide_decimals: false } }),
+        );
       }
       if (url === '/api/ledgers') {
         return Promise.resolve(


### PR DESCRIPTION
## Summary

- New server config `display.hide_decimals` (default `false`) rounds SPA monetary displays to whole units when on (`\$2,600.50` → `\$2,601`).
- Wired Go config → `/api/config` JSON → SPA `useServerConfig` → new `useAmountFormat()` hook → every component/route that renders an amount.
- All previously inline `toLocaleString({ minimumFractionDigits: 2 })` callers (including three components that bypassed the shared formatters) now route through the hook.

## How to enable

Add to `\$XDG_CONFIG_HOME/kea/config.yaml` (macOS: `~/Library/Application Support/kea/config.yaml`):

\`\`\`yaml
display:
  hide_decimals: true
\`\`\`

Restart \`kea serve\` and hard-reload the SPA. \`curl http://localhost:8080/api/config\` should report \`\"display\":{\"hide_decimals\":true}\`.

## Test plan

- [x] \`go test ./...\` (all packages green, including new \`internal/api\` table covering both flag states)
- [x] \`cd spa && npm run check\` (biome clean apart from one pre-existing \`noNonNullAssertion\` in \`reports.income-statement.tsx\`, unrelated to this branch)
- [x] \`cd spa && npm run test\` (235 pass; the 6 pre-existing balances test failures are unchanged by this branch — confirmed at the pre-task SHA)
- [x] \`cd spa && npm run build\` (clean)
- [x] Manual curl: \`/api/config\` returns \`hide_decimals: true\` when YAML sets it; \`false\` otherwise.
- [ ] Manual SPA browser walk-through of \`/balances\`, \`/transactions\`, every \`/reports/*\` page with the flag on, confirming whole-unit display and \`\$2,600.50\` → \`\$2,601\` rounding.

## Out of scope

- UI toggle (no settings page yet — must edit YAML and restart). Tracked as a follow-up.
- CLI/TUI behavior (unchanged; \`utils.FormatAmount\` already trims trailing zeros).
- Hot-reloading the config without a server restart.
- The \`SplitsEditor\` balance hint (\`toFixed(2)\`) — that's editing precision, not display, and is intentionally untouched.

## Carry-forward observations

- \`useAmountFormat()\` allocates fresh closures every render. Harmless today (all callsites inline), but a \`useMemo\`/\`useCallback\` would prevent footguns if formatters are ever passed as props or effect deps.
- \`ServerConfigContext\` was exported to support a new \`withServerConfig\` test helper. A dedicated \`TestServerConfigProvider\` would keep the production surface tighter.
- The default-config YAML template in \`cmd/root.go\` doesn't include a \`display:\` section, so new users won't discover the option via the generated file.