### PR TITLE
feat: SPA settings page with hide_decimals toggle

### DIFF
--- a/cmd/save_config.go
+++ b/cmd/save_config.go
@@ -19,8 +19,9 @@ import (
 // the entire merged in-memory state — including defaults the user never wrote
 // — which would silently grow the user's config file with keys they did not
 // type. Instead, we round-trip the YAML as a generic map and update only the
-// single key in place, preserving every other key (comments are still lost,
-// but no foreign data is added or dropped).
+// single key in place. Unrelated keys (and their comments) are preserved
+// verbatim; a comment trailing the rewritten hide_decimals value itself is
+// dropped, since we rebuild that leaf node.
 func saveDisplayHideDecimals(cfg *config.Config) error {
 	if cfg.ConfigPath == "" {
 		return fmt.Errorf("save display.hide_decimals: config path is empty")

--- a/cmd/save_config.go
+++ b/cmd/save_config.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/hance08/kea/internal/config"
+)
+
+// saveDisplayHideDecimals persists the current display.hide_decimals value to
+// the on-disk YAML config without leaking viper-registered defaults (server.*,
+// database.*) into the file. We avoid viper.WriteConfig because it serializes
+// the entire merged in-memory state — including defaults the user never wrote
+// — which would silently grow the user's config file with keys they did not
+// type. Instead, we round-trip the YAML as a generic map and update only the
+// single key in place, preserving every other key (comments are still lost,
+// but no foreign data is added or dropped).
+func saveDisplayHideDecimals(cfg *config.Config) error {
+	if cfg.ConfigPath == "" {
+		return fmt.Errorf("save display.hide_decimals: config path is empty")
+	}
+
+	raw, err := os.ReadFile(cfg.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("read config %q: %w", cfg.ConfigPath, err)
+	}
+
+	root := &yaml.Node{}
+	if err := yaml.Unmarshal(raw, root); err != nil {
+		return fmt.Errorf("parse config %q: %w", cfg.ConfigPath, err)
+	}
+
+	if err := setYAMLBool(root, []string{"display", "hide_decimals"}, cfg.Display.HideDecimals); err != nil {
+		return fmt.Errorf("update display.hide_decimals: %w", err)
+	}
+
+	out, err := yaml.Marshal(root)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+
+	if err := os.WriteFile(cfg.ConfigPath, out, 0o600); err != nil {
+		return fmt.Errorf("write config %q: %w", cfg.ConfigPath, err)
+	}
+	return nil
+}
+
+// setYAMLBool walks a yaml.Node tree following path and sets the leaf to a
+// boolean. Intermediate maps are created if missing. The root may be a
+// DocumentNode (the result of yaml.Unmarshal into a *yaml.Node) or a bare
+// MappingNode (empty document).
+func setYAMLBool(root *yaml.Node, path []string, value bool) error {
+	if len(path) == 0 {
+		return errors.New("empty path")
+	}
+
+	var mapping *yaml.Node
+	if root.Kind == yaml.DocumentNode {
+		if len(root.Content) == 0 {
+			root.Content = []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}}
+		}
+		mapping = root.Content[0]
+	} else {
+		mapping = root
+	}
+
+	if mapping.Kind != yaml.MappingNode {
+		return fmt.Errorf("expected mapping node, got kind %d", mapping.Kind)
+	}
+
+	for i, key := range path {
+		isLeaf := i == len(path)-1
+		valNode := mappingChild(mapping, key)
+		if valNode == nil {
+			keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
+			if isLeaf {
+				valNode = &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool"}
+				valNode.Value = boolToYAML(value)
+			} else {
+				valNode = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+			}
+			mapping.Content = append(mapping.Content, keyNode, valNode)
+		} else if isLeaf {
+			valNode.Kind = yaml.ScalarNode
+			valNode.Tag = "!!bool"
+			valNode.Value = boolToYAML(value)
+			valNode.Style = 0
+		}
+		if !isLeaf {
+			if valNode.Kind != yaml.MappingNode {
+				return fmt.Errorf("path component %q is not a mapping", key)
+			}
+			mapping = valNode
+		}
+	}
+	return nil
+}
+
+// mappingChild returns the value node associated with key in a MappingNode, or
+// nil if absent. MappingNode.Content alternates key, value, key, value, ...
+func mappingChild(m *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func boolToYAML(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}

--- a/cmd/save_config_test.go
+++ b/cmd/save_config_test.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"github.com/hance08/kea/internal/config"
+)
+
+// TestViperWriteLeaks_NeedsFallback documents why saveDisplayHideDecimals
+// cannot just call viper.WriteConfig: viper merges in-memory defaults
+// registered via SetDefault (here, the server.* keys registered by
+// setServerDefaults) into the on-disk YAML, silently growing the user's
+// config file with keys they never typed. This test asserts the leak
+// behavior so a future viper upgrade that fixes it will surface here and
+// signal that the in-place YAML rewrite in saveDisplayHideDecimals could be
+// simplified back to viper.WriteConfig.
+func TestViperWriteLeaks_NeedsFallback(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	initial := "defaults:\n  currency: TWD\ndisplay:\n  hide_decimals: true\n"
+	if err := os.WriteFile(cfgPath, []byte(initial), 0o600); err != nil {
+		t.Fatalf("write initial yaml: %v", err)
+	}
+
+	viper.SetConfigFile(cfgPath)
+	setServerDefaults(viper.GetViper())
+	if err := viper.ReadInConfig(); err != nil {
+		t.Fatalf("ReadInConfig: %v", err)
+	}
+
+	viper.Set("display.hide_decimals", false)
+	if err := viper.WriteConfig(); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read written yaml: %v", err)
+	}
+	written := string(raw)
+
+	leakedKeys := []string{"server", "host:", "port:", "cors_origins"}
+	leaks := 0
+	for _, leaked := range leakedKeys {
+		if strings.Contains(written, leaked) {
+			leaks++
+		}
+	}
+	if leaks == 0 {
+		t.Errorf("viper.WriteConfig no longer leaks server defaults; the "+
+			"fallback in saveDisplayHideDecimals may now be unnecessary.\n"+
+			"Full contents:\n%s", written)
+	}
+}
+
+// TestSaveDisplayHideDecimals_NoLeak_DirectMarshal exercises the production
+// saveDisplayHideDecimals closure and proves it does NOT leak
+// viper-registered server defaults into the user's config file, while still
+// updating display.hide_decimals and preserving existing keys.
+func TestSaveDisplayHideDecimals_NoLeak_DirectMarshal(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	initial := "defaults:\n  currency: TWD\ndisplay:\n  hide_decimals: true\n"
+	if err := os.WriteFile(cfgPath, []byte(initial), 0o600); err != nil {
+		t.Fatalf("write initial yaml: %v", err)
+	}
+
+	// Simulate the runtime: viper is configured with the same defaults the
+	// real `kea serve` command sets, but saveDisplayHideDecimals must not
+	// touch viper — it writes directly to disk based on cfg.
+	viper.SetConfigFile(cfgPath)
+	setServerDefaults(viper.GetViper())
+	if err := viper.ReadInConfig(); err != nil {
+		t.Fatalf("ReadInConfig: %v", err)
+	}
+
+	cfg := config.NewDefault()
+	cfg.Defaults.Currency = "TWD"
+	cfg.Display.HideDecimals = false
+	cfg.ConfigPath = cfgPath
+
+	if err := saveDisplayHideDecimals(cfg); err != nil {
+		t.Fatalf("saveDisplayHideDecimals: %v", err)
+	}
+
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read written yaml: %v", err)
+	}
+	written := string(raw)
+
+	for _, leaked := range []string{"server", "host:", "port:", "cors_origins", "database"} {
+		if strings.Contains(written, leaked) {
+			t.Errorf("written yaml contains leaked key %q.\nFull contents:\n%s", leaked, written)
+		}
+	}
+
+	if !strings.Contains(written, "hide_decimals: false") {
+		t.Errorf("written yaml missing updated hide_decimals=false.\nFull contents:\n%s", written)
+	}
+	if !strings.Contains(written, "currency: TWD") {
+		t.Errorf("written yaml dropped existing currency.\nFull contents:\n%s", written)
+	}
+}
+
+// TestSaveDisplayHideDecimals_PreservesUnrelatedKeys ensures the in-place
+// rewrite preserves any keys the user has actually written to their config
+// (e.g. customized server.port), since the default-config template ships
+// with a server block. Only the targeted key may change.
+func TestSaveDisplayHideDecimals_PreservesUnrelatedKeys(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	initial := "defaults:\n  currency: USD\ndisplay:\n  hide_decimals: false\n" +
+		"server:\n  host: 0.0.0.0\n  port: 9999\n  cors_origins:\n    - http://example.test\n" +
+		"database:\n  path: /custom/path.db\n"
+	if err := os.WriteFile(cfgPath, []byte(initial), 0o600); err != nil {
+		t.Fatalf("write initial yaml: %v", err)
+	}
+
+	cfg := config.NewDefault()
+	cfg.Defaults.Currency = "USD"
+	cfg.Display.HideDecimals = true
+	cfg.ConfigPath = cfgPath
+
+	if err := saveDisplayHideDecimals(cfg); err != nil {
+		t.Fatalf("saveDisplayHideDecimals: %v", err)
+	}
+
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read written yaml: %v", err)
+	}
+	written := string(raw)
+
+	for _, want := range []string{
+		"hide_decimals: true",
+		"host: 0.0.0.0",
+		"port: 9999",
+		"http://example.test",
+		"/custom/path.db",
+		"currency: USD",
+	} {
+		if !strings.Contains(written, want) {
+			t.Errorf("written yaml missing %q.\nFull contents:\n%s", want, written)
+		}
+	}
+}
+
+// TestSaveDisplayHideDecimals_CreatesKeyWhenMissing covers the case where
+// the user's existing YAML has no display block at all — the closure must
+// add display.hide_decimals rather than failing.
+func TestSaveDisplayHideDecimals_CreatesKeyWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	initial := "defaults:\n  currency: JPY\n"
+	if err := os.WriteFile(cfgPath, []byte(initial), 0o600); err != nil {
+		t.Fatalf("write initial yaml: %v", err)
+	}
+
+	cfg := config.NewDefault()
+	cfg.Defaults.Currency = "JPY"
+	cfg.Display.HideDecimals = true
+	cfg.ConfigPath = cfgPath
+
+	if err := saveDisplayHideDecimals(cfg); err != nil {
+		t.Fatalf("saveDisplayHideDecimals: %v", err)
+	}
+
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read written yaml: %v", err)
+	}
+	written := string(raw)
+
+	if !strings.Contains(written, "hide_decimals: true") {
+		t.Errorf("written yaml missing hide_decimals: true.\nFull contents:\n%s", written)
+	}
+	if !strings.Contains(written, "currency: JPY") {
+		t.Errorf("written yaml dropped existing currency.\nFull contents:\n%s", written)
+	}
+	if strings.Contains(written, "server") {
+		t.Errorf("written yaml leaked server block.\nFull contents:\n%s", written)
+	}
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -41,6 +41,7 @@ func NewServeCmd(application *app.App, migrationFS fs.FS, appDir string) *cobra.
 				migrationFS,
 				appDir,
 				application.SwitchLedger,
+				func() error { return nil },
 				logger,
 			)
 			return srv.Run(cmd.Context())

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -6,14 +6,17 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"log/slog"
 	"os"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 
 	"github.com/hance08/kea/internal/api"
 	"github.com/hance08/kea/internal/app"
+	"github.com/hance08/kea/internal/config"
 )
 
 func NewServeCmd(application *app.App, migrationFS fs.FS, appDir string) *cobra.Command {
@@ -41,10 +44,119 @@ func NewServeCmd(application *app.App, migrationFS fs.FS, appDir string) *cobra.
 				migrationFS,
 				appDir,
 				application.SwitchLedger,
-				func() error { return nil },
+				func() error {
+					return saveDisplayHideDecimals(application.Config())
+				},
 				logger,
 			)
 			return srv.Run(cmd.Context())
 		},
 	}
+}
+
+// saveDisplayHideDecimals persists the current display.hide_decimals value to
+// the on-disk YAML config without leaking viper-registered defaults (server.*,
+// database.*) into the file. We avoid viper.WriteConfig because it serializes
+// the entire merged in-memory state — including defaults the user never wrote
+// — which would silently grow the user's config file with keys they did not
+// type. Instead, we round-trip the YAML as a generic map and update only the
+// single key in place, preserving every other key (comments are still lost,
+// but no foreign data is added or dropped).
+func saveDisplayHideDecimals(cfg *config.Config) error {
+	if cfg.ConfigPath == "" {
+		return fmt.Errorf("save display.hide_decimals: config path is empty")
+	}
+
+	raw, err := os.ReadFile(cfg.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("read config %q: %w", cfg.ConfigPath, err)
+	}
+
+	root := &yaml.Node{}
+	if err := yaml.Unmarshal(raw, root); err != nil {
+		return fmt.Errorf("parse config %q: %w", cfg.ConfigPath, err)
+	}
+
+	if err := setYAMLBool(root, []string{"display", "hide_decimals"}, cfg.Display.HideDecimals); err != nil {
+		return fmt.Errorf("update display.hide_decimals: %w", err)
+	}
+
+	out, err := yaml.Marshal(root)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+
+	if err := os.WriteFile(cfg.ConfigPath, out, 0o600); err != nil {
+		return fmt.Errorf("write config %q: %w", cfg.ConfigPath, err)
+	}
+	return nil
+}
+
+// setYAMLBool walks a yaml.Node tree following path and sets the leaf to a
+// boolean. Intermediate maps are created if missing. The root may be a
+// DocumentNode (the result of yaml.Unmarshal into a *yaml.Node) or a bare
+// MappingNode (empty document).
+func setYAMLBool(root *yaml.Node, path []string, value bool) error {
+	if len(path) == 0 {
+		return errors.New("empty path")
+	}
+
+	var mapping *yaml.Node
+	if root.Kind == yaml.DocumentNode {
+		if len(root.Content) == 0 {
+			root.Content = []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}}
+		}
+		mapping = root.Content[0]
+	} else {
+		mapping = root
+	}
+
+	if mapping.Kind != yaml.MappingNode {
+		return fmt.Errorf("expected mapping node, got kind %d", mapping.Kind)
+	}
+
+	for i, key := range path {
+		isLeaf := i == len(path)-1
+		valNode := mappingChild(mapping, key)
+		if valNode == nil {
+			keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
+			if isLeaf {
+				valNode = &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool"}
+				valNode.Value = boolToYAML(value)
+			} else {
+				valNode = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+			}
+			mapping.Content = append(mapping.Content, keyNode, valNode)
+		} else if isLeaf {
+			valNode.Kind = yaml.ScalarNode
+			valNode.Tag = "!!bool"
+			valNode.Value = boolToYAML(value)
+			valNode.Style = 0
+		}
+		if !isLeaf {
+			if valNode.Kind != yaml.MappingNode {
+				return fmt.Errorf("path component %q is not a mapping", key)
+			}
+			mapping = valNode
+		}
+	}
+	return nil
+}
+
+// mappingChild returns the value node associated with key in a MappingNode, or
+// nil if absent. MappingNode.Content alternates key, value, key, value, ...
+func mappingChild(m *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func boolToYAML(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -6,17 +6,14 @@ package cmd
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io/fs"
 	"log/slog"
 	"os"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 
 	"github.com/hance08/kea/internal/api"
 	"github.com/hance08/kea/internal/app"
-	"github.com/hance08/kea/internal/config"
 )
 
 func NewServeCmd(application *app.App, migrationFS fs.FS, appDir string) *cobra.Command {
@@ -52,111 +49,4 @@ func NewServeCmd(application *app.App, migrationFS fs.FS, appDir string) *cobra.
 			return srv.Run(cmd.Context())
 		},
 	}
-}
-
-// saveDisplayHideDecimals persists the current display.hide_decimals value to
-// the on-disk YAML config without leaking viper-registered defaults (server.*,
-// database.*) into the file. We avoid viper.WriteConfig because it serializes
-// the entire merged in-memory state — including defaults the user never wrote
-// — which would silently grow the user's config file with keys they did not
-// type. Instead, we round-trip the YAML as a generic map and update only the
-// single key in place, preserving every other key (comments are still lost,
-// but no foreign data is added or dropped).
-func saveDisplayHideDecimals(cfg *config.Config) error {
-	if cfg.ConfigPath == "" {
-		return fmt.Errorf("save display.hide_decimals: config path is empty")
-	}
-
-	raw, err := os.ReadFile(cfg.ConfigPath)
-	if err != nil {
-		return fmt.Errorf("read config %q: %w", cfg.ConfigPath, err)
-	}
-
-	root := &yaml.Node{}
-	if err := yaml.Unmarshal(raw, root); err != nil {
-		return fmt.Errorf("parse config %q: %w", cfg.ConfigPath, err)
-	}
-
-	if err := setYAMLBool(root, []string{"display", "hide_decimals"}, cfg.Display.HideDecimals); err != nil {
-		return fmt.Errorf("update display.hide_decimals: %w", err)
-	}
-
-	out, err := yaml.Marshal(root)
-	if err != nil {
-		return fmt.Errorf("marshal config: %w", err)
-	}
-
-	if err := os.WriteFile(cfg.ConfigPath, out, 0o600); err != nil {
-		return fmt.Errorf("write config %q: %w", cfg.ConfigPath, err)
-	}
-	return nil
-}
-
-// setYAMLBool walks a yaml.Node tree following path and sets the leaf to a
-// boolean. Intermediate maps are created if missing. The root may be a
-// DocumentNode (the result of yaml.Unmarshal into a *yaml.Node) or a bare
-// MappingNode (empty document).
-func setYAMLBool(root *yaml.Node, path []string, value bool) error {
-	if len(path) == 0 {
-		return errors.New("empty path")
-	}
-
-	var mapping *yaml.Node
-	if root.Kind == yaml.DocumentNode {
-		if len(root.Content) == 0 {
-			root.Content = []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}}
-		}
-		mapping = root.Content[0]
-	} else {
-		mapping = root
-	}
-
-	if mapping.Kind != yaml.MappingNode {
-		return fmt.Errorf("expected mapping node, got kind %d", mapping.Kind)
-	}
-
-	for i, key := range path {
-		isLeaf := i == len(path)-1
-		valNode := mappingChild(mapping, key)
-		if valNode == nil {
-			keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
-			if isLeaf {
-				valNode = &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool"}
-				valNode.Value = boolToYAML(value)
-			} else {
-				valNode = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
-			}
-			mapping.Content = append(mapping.Content, keyNode, valNode)
-		} else if isLeaf {
-			valNode.Kind = yaml.ScalarNode
-			valNode.Tag = "!!bool"
-			valNode.Value = boolToYAML(value)
-			valNode.Style = 0
-		}
-		if !isLeaf {
-			if valNode.Kind != yaml.MappingNode {
-				return fmt.Errorf("path component %q is not a mapping", key)
-			}
-			mapping = valNode
-		}
-	}
-	return nil
-}
-
-// mappingChild returns the value node associated with key in a MappingNode, or
-// nil if absent. MappingNode.Content alternates key, value, key, value, ...
-func mappingChild(m *yaml.Node, key string) *yaml.Node {
-	for i := 0; i+1 < len(m.Content); i += 2 {
-		if m.Content[i].Value == key {
-			return m.Content[i+1]
-		}
-	}
-	return nil
-}
-
-func boolToYAML(b bool) string {
-	if b {
-		return "true"
-	}
-	return "false"
 }

--- a/docs/superpowers/plans/2026-06-18-spa-hide-decimals-toggle.md
+++ b/docs/superpowers/plans/2026-06-18-spa-hide-decimals-toggle.md
@@ -1,0 +1,1135 @@
+# SPA hide_decimals toggle — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users flip `display.hide_decimals` from a new `/settings` page in the SPA without editing YAML or restarting the server.
+
+**Architecture:** Add `PATCH /api/config` that mutates `*config.Config` in place and persists via an injected save closure (so the api package stays free of viper). The SPA gets a `/settings` route with a single Switch that calls `setConfig` and invalidates the `['server-config']` query, causing every page's amount formatter to re-render.
+
+**Tech Stack:** Go 1.21+, chi, viper, encoding/json. React 18, TanStack Query 5, TanStack Router, Radix UI, sonner, vitest, @testing-library/react.
+
+---
+
+## Design decision: injected `saveConfig`, not viper-in-api
+
+The spec sketched calling `viper.Set` + `viper.WriteConfig` directly from the handler. On a closer look that gives the `internal/api` package a dependency on viper's global state and forces every API test to wire viper.
+
+Instead: add `saveConfig func() error` to `*Server`. The handler mutates `cfg.Display.HideDecimals`, then calls `s.saveConfig()`. In production (`cmd/serve.go`) the closure does `viper.Set("display.hide_decimals", cfg.Display.HideDecimals)` + `viper.WriteConfig()`. In tests, the closure is a stub that records calls. The leak-prevention test lives in `cmd/`, where viper already lives. This matches the existing `switchLedger` injection pattern.
+
+The handler still goes through `viper.WriteConfig` in production, so the spec's "try viper first, fall back to direct YAML marshal if it leaks server defaults" plan still applies — the leak test just lives in `cmd/` instead of `internal/api`.
+
+---
+
+## File map
+
+**Backend:**
+- Modify: `internal/api/server.go` — add `saveConfig` field + constructor arg.
+- Modify: `internal/api/router.go` — register `PATCH /api/config`.
+- Modify: `internal/api/config.go` — add `handlePatchConfig` + request types.
+- Modify: `internal/api/testhelper_test.go` — give test helpers a default no-op `saveConfig`, plus a variant that records calls.
+- Modify: `internal/api/config_test.go` — add PATCH tests.
+- Modify: `cmd/serve.go` — wire the production `saveConfig` closure.
+- Create: `cmd/save_config_test.go` — verify viper write doesn't leak server defaults into a minimal user YAML.
+
+**Frontend:**
+- Modify: `spa/package.json` — add `@radix-ui/react-switch`.
+- Create: `spa/src/components/ui/switch.tsx` — shadcn-style Switch.
+- Modify: `spa/src/lib/api.ts` — add `setConfig`.
+- Create: `spa/src/routes/settings.tsx` — Settings page.
+- Modify: `spa/src/components/Sidebar.tsx` — bottom-pinned Settings link.
+- Modify: `spa/src/test/test-app.tsx` — extend `withServerConfig` to accept an override.
+- Create: `spa/src/test/api.setConfig.test.ts` — unit test.
+- Create: `spa/src/test/settings.test.tsx` — integration test.
+
+---
+
+## Task 1: Refactor `Server` to accept an injected `saveConfig`
+
+**Files:**
+- Modify: `internal/api/server.go`
+- Modify: `internal/api/testhelper_test.go:71-115` (the `newServerForWriteWithCurrency` and `newServerForWriteWithDisplay` helpers)
+- Modify: `internal/api/testhelper_test.go:151-197` (the `newTestServerWithLedger` helper)
+- Modify: `cmd/serve.go:37-45`
+
+### Step 1: Add `saveConfig` to `Server` struct
+
+- [ ] Edit `internal/api/server.go`: add field and constructor arg.
+
+```go
+// in Server struct, after switchLedger:
+saveConfig func() error
+```
+
+```go
+// in NewServer signature, after switchLedger arg:
+saveConfig func() error,
+```
+
+```go
+// in NewServer body, after switchLedger assignment:
+saveConfig: saveConfig,
+```
+
+The handler doesn't exist yet — the field will be unused this commit. That's fine; it gets used in Task 3.
+
+### Step 2: Update call site in `cmd/serve.go`
+
+- [ ] Edit `cmd/serve.go:37-45`. Pass a no-op closure for now (the real viper logic comes in Task 2):
+
+```go
+srv := api.NewServer(
+    application.Config(),
+    application.Service,
+    application.Registry,
+    migrationFS,
+    appDir,
+    application.SwitchLedger,
+    func() error { return nil },
+    logger,
+)
+```
+
+### Step 3: Update all test helpers
+
+- [ ] Edit `internal/api/testhelper_test.go`. Every `NewServer(...)` call gets a `func() error { return nil }` between `switchLedger` and `discardLogger()`.
+
+Lines to update (search for `NewServer(`):
+- `newServerForWriteWithCurrency` around line 84
+- `newServerForWriteWithDisplay` around line 109
+- `newTestServerWithLedger` around line 192
+
+Example diff for one of them:
+
+```go
+// before
+srv := NewServer(cfg, svc, nil, nil, "", nil, discardLogger())
+// after
+srv := NewServer(cfg, svc, nil, nil, "", nil, func() error { return nil }, discardLogger())
+```
+
+### Step 4: Build + run tests
+
+- [ ] Run: `go build ./... && go test ./internal/api/... ./cmd/...`
+- [ ] Expected: PASS (no behavior change yet).
+
+### Step 5: Commit
+
+- [ ] 
+```bash
+git add internal/api/server.go internal/api/testhelper_test.go cmd/serve.go
+git commit -m "refactor(api): inject saveConfig closure into Server"
+```
+
+---
+
+## Task 2: Wire viper-backed `saveConfig` + prove no leaks
+
+**Files:**
+- Modify: `cmd/serve.go`
+- Create: `cmd/save_config_test.go`
+
+### Step 1: Write the failing leak-prevention test
+
+- [ ] Create `cmd/save_config_test.go`:
+
+```go
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026  Hance Chin
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// TestSaveDisplayHideDecimals_NoLeak verifies that writing the
+// display.hide_decimals flag back to disk does NOT leak viper-registered
+// server defaults (server.host, server.port, server.cors_origins, etc.)
+// into the user's config file.
+func TestSaveDisplayHideDecimals_NoLeak(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	initial := "defaults:\n  currency: TWD\ndisplay:\n  hide_decimals: true\n"
+	if err := os.WriteFile(cfgPath, []byte(initial), 0o600); err != nil {
+		t.Fatalf("write initial yaml: %v", err)
+	}
+
+	viper.SetConfigFile(cfgPath)
+	setServerDefaults(viper.GetViper())
+	if err := viper.ReadInConfig(); err != nil {
+		t.Fatalf("ReadInConfig: %v", err)
+	}
+
+	viper.Set("display.hide_decimals", false)
+	if err := viper.WriteConfig(); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read written yaml: %v", err)
+	}
+	written := string(raw)
+
+	for _, leaked := range []string{"server", "host:", "port:", "cors_origins", "database"} {
+		if strings.Contains(written, leaked) {
+			t.Errorf("written yaml contains leaked key %q.\nFull contents:\n%s", leaked, written)
+		}
+	}
+
+	if !strings.Contains(written, "hide_decimals: false") {
+		t.Errorf("written yaml missing updated hide_decimals=false.\nFull contents:\n%s", written)
+	}
+	if !strings.Contains(written, "currency: TWD") {
+		t.Errorf("written yaml dropped existing currency.\nFull contents:\n%s", written)
+	}
+}
+```
+
+### Step 2: Run the test to see whether it passes or fails
+
+- [ ] Run: `go test ./cmd/ -run TestSaveDisplayHideDecimals_NoLeak -v`
+- [ ] Two outcomes:
+  - **PASS** → viper doesn't leak; the simple closure in Step 3 works. Proceed.
+  - **FAIL** → viper writes server.* into the file. Stop here and switch to the fallback in Step 3b below.
+
+### Step 3 (path A — viper write is clean): Wire production `saveConfig` closure
+
+- [ ] Edit `cmd/serve.go`. Replace the `func() error { return nil }` placeholder from Task 1 with a viper-backed closure that snapshots the current `*config.Config`:
+
+```go
+srv := api.NewServer(
+    application.Config(),
+    application.Service,
+    application.Registry,
+    migrationFS,
+    appDir,
+    application.SwitchLedger,
+    func() error {
+        cfg := application.Config()
+        viper.Set("display.hide_decimals", cfg.Display.HideDecimals)
+        if err := viper.WriteConfig(); err != nil {
+            return fmt.Errorf("failed to persist config: %w", err)
+        }
+        return nil
+    },
+    logger,
+)
+```
+
+Add imports as needed (`fmt`, `github.com/spf13/viper`).
+
+### Step 3b (path B — viper write leaks): switch to direct YAML marshal
+
+Only if Step 2 failed. The closure re-marshals the persisted subset and writes the file directly:
+
+```go
+func() error {
+    cfg := application.Config()
+    persisted := struct {
+        Defaults struct {
+            Currency string `yaml:"currency"`
+        } `yaml:"defaults"`
+        Display struct {
+            HideDecimals bool `yaml:"hide_decimals"`
+        } `yaml:"display"`
+    }{}
+    persisted.Defaults.Currency = cfg.Defaults.Currency
+    persisted.Display.HideDecimals = cfg.Display.HideDecimals
+
+    data, err := yaml.Marshal(persisted)
+    if err != nil {
+        return fmt.Errorf("marshal config: %w", err)
+    }
+    if err := os.WriteFile(cfg.ConfigPath, data, 0o600); err != nil {
+        return fmt.Errorf("write config: %w", err)
+    }
+    return nil
+}
+```
+
+Add `gopkg.in/yaml.v3` to go.mod (already used elsewhere? check first with `go mod why gopkg.in/yaml.v3`; if not, run `go get gopkg.in/yaml.v3`).
+
+Also adjust the leak test from Step 1: it currently asserts on the viper-written file, but if we go path B the test should call the closure (or call into `viper.WriteConfig` to confirm it leaks AND then assert path-B behavior). Simplest: keep the existing test asserting on viper-leak behavior renamed to `TestViperWriteLeaks_NeedsFallback`, and add a new test that calls the path-B closure directly and asserts no leak.
+
+### Step 4: Run all tests
+
+- [ ] Run: `go test ./cmd/...`
+- [ ] Expected: PASS.
+
+### Step 5: Commit
+
+- [ ] 
+```bash
+git add cmd/serve.go cmd/save_config_test.go go.mod go.sum
+git commit -m "feat(cmd): persist display.hide_decimals via injected saveConfig"
+```
+
+(If you took path B, also include the yaml dependency change in the same commit.)
+
+---
+
+## Task 3: Implement `PATCH /api/config` handler
+
+**Files:**
+- Modify: `internal/api/config.go`
+- Modify: `internal/api/router.go`
+- Modify: `internal/api/testhelper_test.go` (add a helper that wires a recording saveConfig)
+- Modify: `internal/api/config_test.go`
+
+### Step 1: Write failing tests
+
+- [ ] Edit `internal/api/testhelper_test.go`. Add a new helper that returns the server, the cfg pointer (so tests can assert in-memory mutation), and a slice that records each `saveConfig` call. Place it next to `newServerForWriteWithDisplay`:
+
+```go
+// newServerForPatchConfig builds a server whose saveConfig closure records
+// every call into the returned slice and returns the slice pointer plus the
+// *config.Config so tests can assert in-memory mutation independently of
+// persistence. The saveConfig stub returns nil unless tests inject an error
+// via *saveErr.
+func newServerForPatchConfig(t *testing.T, currency string, hideDecimals bool) (
+    ts *httptest.Server,
+    cfg *config.Config,
+    saveCalls *int,
+    saveErr *error,
+) {
+    t.Helper()
+
+    dbPath := filepath.Join(t.TempDir(), "test.db")
+    st, err := store.NewStore(dbPath, migrations.FS)
+    if err != nil {
+        t.Fatalf("NewStore: %v", err)
+    }
+    t.Cleanup(func() { _ = st.Close() })
+
+    cfg = config.NewDefault()
+    cfg.Defaults.Currency = currency
+    cfg.Display.HideDecimals = hideDecimals
+
+    svc := service.NewService(st, st, st, cfg)
+
+    calls := 0
+    var injErr error
+    save := func() error {
+        calls++
+        return injErr
+    }
+    srv := NewServer(cfg, svc, nil, nil, "", nil, save, discardLogger())
+    ts = httptest.NewServer(srv.routes())
+    t.Cleanup(ts.Close)
+    return ts, cfg, &calls, &injErr
+}
+```
+
+- [ ] Edit `internal/api/config_test.go`. Append PATCH tests:
+
+```go
+func TestPatchConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         string
+		wantStatus   int
+		wantHide     bool // expected cfg.Display.HideDecimals after the request
+		wantSaveCalls int
+	}{
+		{
+			name:          "set_true",
+			body:          `{"display":{"hide_decimals":true}}`,
+			wantStatus:    http.StatusOK,
+			wantHide:      true,
+			wantSaveCalls: 1,
+		},
+		{
+			name:          "set_false",
+			body:          `{"display":{"hide_decimals":false}}`,
+			wantStatus:    http.StatusOK,
+			wantHide:      false,
+			wantSaveCalls: 1,
+		},
+		{
+			name:          "malformed_json",
+			body:          `not json`,
+			wantStatus:    http.StatusBadRequest,
+			wantHide:      false,
+			wantSaveCalls: 0,
+		},
+		{
+			name:          "unknown_top_field",
+			body:          `{"defaults":{"currency":"EUR"}}`,
+			wantStatus:    http.StatusBadRequest,
+			wantHide:      false,
+			wantSaveCalls: 0,
+		},
+		{
+			name:          "empty_body",
+			body:          `{}`,
+			wantStatus:    http.StatusBadRequest,
+			wantHide:      false,
+			wantSaveCalls: 0,
+		},
+		{
+			name:          "empty_display",
+			body:          `{"display":{}}`,
+			wantStatus:    http.StatusBadRequest,
+			wantHide:      false,
+			wantSaveCalls: 0,
+		},
+		{
+			name:          "wrong_type",
+			body:          `{"display":{"hide_decimals":"yes"}}`,
+			wantStatus:    http.StatusBadRequest,
+			wantHide:      false,
+			wantSaveCalls: 0,
+		},
+		{
+			name:          "unknown_display_field",
+			body:          `{"display":{"foo":true}}`,
+			wantStatus:    http.StatusBadRequest,
+			wantHide:      false,
+			wantSaveCalls: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, cfg, saveCalls, _ := newServerForPatchConfig(t, "USD", false)
+
+			req, err := http.NewRequest(http.MethodPatch, ts.URL+"/api/config", strings.NewReader(tt.body))
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("PATCH: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tt.wantStatus {
+				body, _ := io.ReadAll(resp.Body)
+				t.Errorf("status: got %d, want %d. body=%s", resp.StatusCode, tt.wantStatus, body)
+			}
+			if cfg.Display.HideDecimals != tt.wantHide {
+				t.Errorf("cfg.Display.HideDecimals: got %v, want %v", cfg.Display.HideDecimals, tt.wantHide)
+			}
+			if *saveCalls != tt.wantSaveCalls {
+				t.Errorf("saveCalls: got %d, want %d", *saveCalls, tt.wantSaveCalls)
+			}
+		})
+	}
+}
+
+func TestPatchConfig_DoesNotTouchOtherFields(t *testing.T) {
+	ts, cfg, _, _ := newServerForPatchConfig(t, "TWD", false)
+	originalCurrency := cfg.Defaults.Currency
+	originalHost := cfg.Server.Host
+	originalPort := cfg.Server.Port
+
+	req, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/config",
+		strings.NewReader(`{"display":{"hide_decimals":true}}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if cfg.Defaults.Currency != originalCurrency {
+		t.Errorf("Defaults.Currency changed: got %q, want %q", cfg.Defaults.Currency, originalCurrency)
+	}
+	if cfg.Server.Host != originalHost {
+		t.Errorf("Server.Host changed: got %q, want %q", cfg.Server.Host, originalHost)
+	}
+	if cfg.Server.Port != originalPort {
+		t.Errorf("Server.Port changed: got %d, want %d", cfg.Server.Port, originalPort)
+	}
+}
+
+func TestPatchConfig_RoundTrip(t *testing.T) {
+	ts, _, _, _ := newServerForPatchConfig(t, "USD", false)
+
+	patch := func(value bool) {
+		body := fmt.Sprintf(`{"display":{"hide_decimals":%t}}`, value)
+		req, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/config", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("PATCH: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("PATCH status: %d", resp.StatusCode)
+		}
+	}
+
+	getHide := func() bool {
+		resp, err := http.Get(ts.URL + "/api/config")
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		var parsed struct {
+			Display struct {
+				HideDecimals bool `json:"hide_decimals"`
+			} `json:"display"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return parsed.Display.HideDecimals
+	}
+
+	patch(true)
+	if got := getHide(); got != true {
+		t.Errorf("after PATCH true: GET returned %v", got)
+	}
+	patch(false)
+	if got := getHide(); got != false {
+		t.Errorf("after PATCH false: GET returned %v", got)
+	}
+}
+
+func TestPatchConfig_SaveErrorReturns500(t *testing.T) {
+	ts, _, _, saveErr := newServerForPatchConfig(t, "USD", false)
+	*saveErr = errors.New("disk full")
+
+	req, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/config",
+		strings.NewReader(`{"display":{"hide_decimals":true}}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status: got %d, want 500", resp.StatusCode)
+	}
+}
+```
+
+- [ ] Update imports at the top of `config_test.go` to include `errors` and `fmt`.
+
+### Step 2: Run tests to verify they fail
+
+- [ ] Run: `go test ./internal/api/ -run TestPatchConfig -v`
+- [ ] Expected: FAIL (PATCH /api/config returns 404 because the route doesn't exist yet).
+
+### Step 3: Add the route
+
+- [ ] Edit `internal/api/router.go:27`. Immediately after the GET line:
+
+```go
+r.Method(http.MethodGet, "/config", apiHandler(s.handleGetConfig))
+r.Method(http.MethodPatch, "/config", apiHandler(s.handlePatchConfig))
+```
+
+### Step 4: Implement the handler
+
+- [ ] Edit `internal/api/config.go`. Append the patch request types and handler:
+
+```go
+type configPatchRequest struct {
+	Display *configDisplayPatch `json:"display"`
+}
+
+type configDisplayPatch struct {
+	HideDecimals *bool `json:"hide_decimals"`
+}
+
+func (s *Server) handlePatchConfig(w http.ResponseWriter, r *http.Request) error {
+	var req configPatchRequest
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		return &service.ValidationError{Field: "body", Message: "invalid JSON: " + err.Error()}
+	}
+	if req.Display == nil || req.Display.HideDecimals == nil {
+		return &service.ValidationError{Field: "display.hide_decimals", Message: "required"}
+	}
+
+	cfg := s.svc.Config()
+	cfg.Display.HideDecimals = *req.Display.HideDecimals
+
+	if err := s.saveConfig(); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+
+	return writeJSON(w, http.StatusOK, configResponse{
+		Defaults: configDefaults{Currency: cfg.Defaults.Currency},
+		Display:  configDisplay{HideDecimals: cfg.Display.HideDecimals},
+	})
+}
+```
+
+- [ ] Update the imports at the top of `config.go`:
+
+```go
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hance08/kea/internal/service"
+)
+```
+
+(`service` is the existing validation-error type used elsewhere in the api package — wrapping our 400 in it routes through `mapError` and produces the standard `{"error":"validation_failed","message":...}` body. The save error wraps with `%w` and falls through to the default 500 case in `mapError`.)
+
+### Step 5: Run tests to verify pass
+
+- [ ] Run: `go test ./internal/api/ -run TestPatchConfig -v`
+- [ ] Expected: PASS for all eight `TestPatchConfig` subtests plus `_DoesNotTouchOtherFields`, `_RoundTrip`, and `_SaveErrorReturns500`.
+
+- [ ] Run full api suite: `go test ./internal/api/`
+- [ ] Expected: PASS (no regressions in existing GET tests).
+
+### Step 6: Commit
+
+- [ ] 
+```bash
+git add internal/api/config.go internal/api/router.go internal/api/config_test.go internal/api/testhelper_test.go
+git commit -m "feat(api): add PATCH /api/config for display settings"
+```
+
+---
+
+## Task 4: Add `@radix-ui/react-switch` + create `Switch` primitive
+
+**Files:**
+- Modify: `spa/package.json`
+- Create: `spa/src/components/ui/switch.tsx`
+
+### Step 1: Install the dependency
+
+- [ ] Run from the `spa/` directory: `npm install @radix-ui/react-switch@^1`
+- [ ] Verify `spa/package.json` now lists `@radix-ui/react-switch` in `dependencies`.
+
+### Step 2: Create the Switch component
+
+- [ ] Create `spa/src/components/ui/switch.tsx`:
+
+```tsx
+import * as SwitchPrimitives from '@radix-ui/react-switch';
+import * as React from 'react';
+import { cn } from '@/lib/cn';
+
+export const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors',
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+      'disabled:cursor-not-allowed disabled:opacity-50',
+      'data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
+        'data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0',
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = 'Switch';
+```
+
+### Step 3: Verify it builds
+
+- [ ] Run from `spa/`: `npm run build` (or at minimum `npx tsc -b`).
+- [ ] Expected: success.
+
+### Step 4: Commit
+
+- [ ] 
+```bash
+git add spa/package.json spa/package-lock.json spa/src/components/ui/switch.tsx
+git commit -m "feat(spa): add Switch UI primitive (Radix)"
+```
+
+---
+
+## Task 5: Add `setConfig` API client function
+
+**Files:**
+- Modify: `spa/src/lib/api.ts`
+- Create: `spa/src/test/api.setConfig.test.ts`
+
+### Step 1: Write failing test
+
+- [ ] Create `spa/src/test/api.setConfig.test.ts`:
+
+```ts
+import { ApiError, setConfig } from '@/lib/api';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+const okResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const errorResponse = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchSpy = vi.fn();
+  vi.stubGlobal('fetch', fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test('sends PATCH /api/config with the supplied body', async () => {
+  fetchSpy.mockResolvedValueOnce(
+    okResponse({ defaults: { currency: 'USD' }, display: { hide_decimals: true } }),
+  );
+
+  const result = await setConfig({ display: { hide_decimals: true } });
+
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
+  const [url, init] = fetchSpy.mock.calls[0];
+  expect(url).toBe('/api/config');
+  expect(init?.method).toBe('PATCH');
+  expect(init?.headers).toEqual({ 'Content-Type': 'application/json' });
+  expect(init?.body).toBe('{"display":{"hide_decimals":true}}');
+  expect(result).toEqual({ defaults: { currency: 'USD' }, display: { hide_decimals: true } });
+});
+
+test('rejects with ApiError when the server returns 400', async () => {
+  fetchSpy.mockResolvedValueOnce(
+    errorResponse(400, { error: 'validation_failed', message: 'bad body', field: 'display.hide_decimals' }),
+  );
+
+  await expect(setConfig({ display: { hide_decimals: true } })).rejects.toMatchObject({
+    name: 'ApiError',
+    status: 400,
+    message: 'bad body',
+    field: 'display.hide_decimals',
+  });
+  expect(setConfig({ display: { hide_decimals: true } })).rejects.toBeInstanceOf(ApiError);
+});
+```
+
+### Step 2: Run to verify failure
+
+- [ ] Run from `spa/`: `npx vitest run src/test/api.setConfig.test.ts`
+- [ ] Expected: FAIL with "setConfig is not exported from @/lib/api" or similar.
+
+### Step 3: Implement `setConfig`
+
+- [ ] Edit `spa/src/lib/api.ts`. Append after the existing `getConfig` (line 50):
+
+```ts
+export interface ConfigPatch {
+  display?: { hide_decimals?: boolean };
+}
+
+export function setConfig(patch: ConfigPatch): Promise<ServerConfig> {
+  return apiFetch<ServerConfig>('/api/config', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+}
+```
+
+### Step 4: Run test to verify pass
+
+- [ ] Run from `spa/`: `npx vitest run src/test/api.setConfig.test.ts`
+- [ ] Expected: PASS (both tests).
+
+### Step 5: Commit
+
+- [ ] 
+```bash
+git add spa/src/lib/api.ts spa/src/test/api.setConfig.test.ts
+git commit -m "feat(spa): add setConfig API client"
+```
+
+---
+
+## Task 6: Add `/settings` route with the hide_decimals toggle
+
+**Files:**
+- Modify: `spa/src/test/test-app.tsx` — extend `withServerConfig` (optional but cleaner)
+- Create: `spa/src/routes/settings.tsx`
+- Create: `spa/src/test/settings.test.tsx`
+
+### Step 1: Extend `withServerConfig` to accept overrides
+
+- [ ] Edit `spa/src/test/test-app.tsx`. Replace lines 26-31 with a version that deep-merges an override:
+
+```tsx
+export function withServerConfig(
+  children: ReactNode,
+  override?: Partial<ServerConfig>,
+) {
+  const config: ServerConfig = {
+    defaults: { currency: 'USD', ...(override?.defaults ?? {}) },
+    display: { hide_decimals: false, ...(override?.display ?? {}) },
+  };
+  return <ServerConfigContext.Provider value={config}>{children}</ServerConfigContext.Provider>;
+}
+```
+
+### Step 2: Run existing tests to confirm nothing breaks
+
+- [ ] Run from `spa/`: `npx vitest run`
+- [ ] Expected: PASS (existing call sites pass no second argument, so the default merge resolves to the previous defaults).
+
+### Step 3: Write the failing integration test
+
+- [ ] Create `spa/src/test/settings.test.tsx`:
+
+```tsx
+import SettingsRouteModule from '@/routes/settings';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { withServerConfig } from './test-app';
+
+const SettingsPage = SettingsRouteModule.Route.options.component as React.FC;
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchSpy = vi.fn();
+  vi.stubGlobal('fetch', fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function renderSettings(hideDecimals: boolean) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  // Pre-seed the cache so useServerConfig (used inside the page) reflects the
+  // initial value, AND the wrapping Provider serves the same value.
+  queryClient.setQueryData(['server-config'], {
+    defaults: { currency: 'USD' },
+    display: { hide_decimals: hideDecimals },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+  const tree = render(
+    <QueryClientProvider client={queryClient}>
+      {withServerConfig(<SettingsPage />, { display: { hide_decimals: hideDecimals } })}
+    </QueryClientProvider>,
+  );
+  return { ...tree, queryClient, invalidateSpy };
+}
+
+test('renders the hide_decimals switch with the current value', () => {
+  renderSettings(false);
+  const sw = screen.getByRole('switch', { name: /hide decimal places/i });
+  expect(sw).toHaveAttribute('aria-checked', 'false');
+});
+
+test('clicking the switch PATCHes /api/config and invalidates server-config', async () => {
+  fetchSpy.mockResolvedValueOnce(
+    new Response(JSON.stringify({ defaults: { currency: 'USD' }, display: { hide_decimals: true } }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+
+  const { invalidateSpy } = renderSettings(false);
+
+  await userEvent.click(screen.getByRole('switch', { name: /hide decimal places/i }));
+
+  await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+  const [url, init] = fetchSpy.mock.calls[0];
+  expect(url).toBe('/api/config');
+  expect(init?.method).toBe('PATCH');
+  expect(init?.body).toBe('{"display":{"hide_decimals":true}}');
+
+  await waitFor(() =>
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['server-config'] }),
+  );
+});
+
+test('shows an error toast and does not invalidate when PATCH fails', async () => {
+  fetchSpy.mockResolvedValueOnce(
+    new Response(JSON.stringify({ error: 'validation_failed', message: 'bad' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+  const { invalidateSpy } = renderSettings(false);
+
+  await userEvent.click(screen.getByRole('switch', { name: /hide decimal places/i }));
+
+  await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+  // No invalidate on error.
+  expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ['server-config'] });
+});
+```
+
+### Step 4: Run to verify failure
+
+- [ ] Run from `spa/`: `npx vitest run src/test/settings.test.tsx`
+- [ ] Expected: FAIL with "Cannot find module '@/routes/settings'" or similar.
+
+### Step 5: Implement the settings route
+
+- [ ] Create `spa/src/routes/settings.tsx`:
+
+```tsx
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { setConfig } from '@/lib/api';
+import { useServerConfig } from '@/lib/server-config';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createFileRoute } from '@tanstack/react-router';
+import { toast } from 'sonner';
+
+export const Route = createFileRoute('/settings')({ component: SettingsPage });
+
+function SettingsPage() {
+  const cfg = useServerConfig();
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (hide: boolean) => setConfig({ display: { hide_decimals: hide } }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['server-config'] });
+    },
+    onError: (err: Error) => {
+      toast.error(`Failed to update setting: ${err.message}`);
+    },
+  });
+
+  return (
+    <div className="max-w-xl space-y-6">
+      <h1 className="text-2xl font-semibold">Settings</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Display</CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <Label htmlFor="hide-decimals" className="text-sm">
+              Hide decimal places in amounts
+            </Label>
+            <p className="text-sm text-muted-foreground">
+              When on, amounts like $12.00 display as $12 across all pages.
+            </p>
+          </div>
+          <Switch
+            id="hide-decimals"
+            aria-label="Hide decimal places in amounts"
+            checked={cfg.display.hide_decimals}
+            disabled={mutation.isPending}
+            onCheckedChange={(checked) => mutation.mutate(checked)}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default Route;
+```
+
+(The `export default Route` is so the test can pull the component via `SettingsRouteModule.Route`. The TanStack Router file-based router only requires the named `Route` export; the default is just a test-import convenience.)
+
+### Step 6: Regenerate the route tree
+
+- [ ] Run from `spa/`: `npm run dev` once briefly (or `npx tsr generate` if that script is wired) so `routeTree.gen.ts` picks up `/settings`. Stop after the regeneration step.
+- [ ] Verify `spa/src/routeTree.gen.ts` now references `SettingsRoute` / `/settings`.
+
+(If the project relies on `vite-plugin-router` auto-generating on dev/build, running `npm run build` from `spa/` is sufficient.)
+
+### Step 7: Run the test to verify pass
+
+- [ ] Run from `spa/`: `npx vitest run src/test/settings.test.tsx`
+- [ ] Expected: PASS (all three tests).
+
+### Step 8: Run the full SPA suite
+
+- [ ] Run from `spa/`: `npx vitest run`
+- [ ] Expected: PASS.
+
+### Step 9: Commit
+
+- [ ] 
+```bash
+git add spa/src/routes/settings.tsx spa/src/test/settings.test.tsx spa/src/test/test-app.tsx spa/src/routeTree.gen.ts
+git commit -m "feat(spa): add /settings route with hide_decimals toggle"
+```
+
+---
+
+## Task 7: Add a Settings link to the sidebar (pinned to bottom)
+
+**Files:**
+- Modify: `spa/src/components/Sidebar.tsx`
+
+### Step 1: Update Sidebar layout
+
+- [ ] Edit `spa/src/components/Sidebar.tsx`. Replace the file with:
+
+```tsx
+import { LedgerSwitcher } from '@/components/LedgerSwitcher';
+import { cn } from '@/lib/cn';
+import { Link, useRouterState } from '@tanstack/react-router';
+
+interface NavItem {
+  label: string;
+  to?: string;
+  prefix?: boolean; // when true, isActive matches any pathname starting with `to`
+}
+
+const NAV: NavItem[] = [
+  { label: 'Balances', to: '/balances' },
+  { label: 'Accounts', to: '/accounts' },
+  { label: 'Transactions', to: '/transactions' },
+  { label: 'Reports', to: '/reports', prefix: true },
+  { label: 'Reconcile' },
+];
+
+const FOOTER_NAV: NavItem[] = [{ label: 'Settings', to: '/settings' }];
+
+export function Sidebar() {
+  const { location } = useRouterState();
+  return (
+    <nav
+      aria-label="Main navigation"
+      className="flex w-56 shrink-0 flex-col border-r bg-muted/30 p-4"
+    >
+      <LedgerSwitcher />
+      <NavList items={NAV} pathname={location.pathname} className="flex-1" />
+      <NavList items={FOOTER_NAV} pathname={location.pathname} />
+    </nav>
+  );
+}
+
+function NavList({
+  items,
+  pathname,
+  className,
+}: {
+  items: NavItem[];
+  pathname: string;
+  className?: string;
+}) {
+  return (
+    <ul className={cn('space-y-1', className)}>
+      {items.map((item) => {
+        if (!item.to) {
+          return (
+            <li key={item.label}>
+              <span
+                aria-disabled="true"
+                className="block cursor-not-allowed rounded px-3 py-2 text-sm text-muted-foreground"
+                title="Coming soon"
+              >
+                {item.label}
+              </span>
+            </li>
+          );
+        }
+        const isActive = item.prefix
+          ? pathname === item.to || pathname.startsWith(`${item.to}/`)
+          : pathname === item.to;
+        return (
+          <li key={item.label}>
+            <Link
+              to={item.to}
+              className={cn(
+                'block rounded px-3 py-2 text-sm transition-colors',
+                isActive ? 'bg-primary text-primary-foreground font-medium' : 'hover:bg-muted',
+              )}
+            >
+              {item.label}
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+```
+
+The `flex-1` on the primary list pushes the footer list to the bottom of the sidebar.
+
+### Step 2: Run SPA tests + build to confirm no regressions
+
+- [ ] Run from `spa/`: `npx vitest run && npm run build`
+- [ ] Expected: PASS.
+
+### Step 3: Manual smoke check
+
+- [ ] Start the backend (`make run` from repo root) and the dev SPA (`npm run dev` from `spa/`).
+- [ ] Open the SPA in the browser.
+- [ ] Confirm the Settings link is pinned to the bottom of the sidebar.
+- [ ] Click Settings; toggle the switch; verify amounts on `/balances` and `/transactions` change precision without a reload.
+
+### Step 4: Commit
+
+- [ ] 
+```bash
+git add spa/src/components/Sidebar.tsx
+git commit -m "feat(spa): add Settings link to sidebar bottom"
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- `PATCH /api/config` with body validation + unknown-field rejection → Task 3 (handler) + Task 3 tests (`unknown_top_field`, `unknown_display_field`, `wrong_type`, `empty_body`, `empty_display`, `malformed_json`).
+- Mutates only `display.hide_decimals` → Task 3 `TestPatchConfig_DoesNotTouchOtherFields`.
+- In-memory cfg update visible to subsequent GETs → Task 3 `TestPatchConfig_RoundTrip`.
+- Viper write doesn't leak server defaults → Task 2 `TestSaveDisplayHideDecimals_NoLeak`, with path B fallback documented.
+- `/settings` route with single toggle using existing UI primitives → Task 6.
+- `setConfig` in api.ts wrapping PATCH → Task 5.
+- Invalidate `['server-config']` on success → Task 6 settings page + integration test.
+- Sidebar Settings link in existing nav style → Task 7.
+- Unit test for setConfig with mocked fetch → Task 5.
+- Integration test for the settings page (click + assert PATCH body + cache invalidation) → Task 6.
+- `withServerConfig` extended for override → Task 6 Step 1.
+
+**Placeholder scan:** No "TBD" / "TODO" / "fill in details". The viper-vs-fallback decision is the one place with a branch, and both branches contain concrete code rather than handwaving.
+
+**Type consistency:**
+- Handler reads `*configPatchRequest` with `Display *configDisplayPatch` and `HideDecimals *bool` — tests' bodies (`{"display":{"hide_decimals":true}}`) match.
+- `saveConfig func() error` in the Server struct matches the closure signature in `cmd/serve.go` and the recording stub in test helpers.
+- `setConfig(patch: ConfigPatch)` returns `Promise<ServerConfig>` — the route's `useMutation` consumes it as `() => setConfig(...)` and the test asserts the resolved `ServerConfig` shape.
+- `Switch` props: `checked`, `disabled`, `onCheckedChange`, `id`, `aria-label` — all are valid `SwitchPrimitives.Root` props.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-06-18-spa-hide-decimals-toggle.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-06-18-spa-hide-decimals-toggle-design.md
+++ b/docs/superpowers/specs/2026-06-18-spa-hide-decimals-toggle-design.md
@@ -1,0 +1,294 @@
+# SPA hide-decimals UI toggle — Design
+
+**Date:** 2026-06-18
+**Status:** Approved
+
+## Goal
+
+Let users flip `display.hide_decimals` from the SPA without editing
+`~/Library/Application Support/kea/config.yaml` (or `~/.config/kea/config.yaml`
+on Linux) and restarting the server.
+
+## Current state
+
+- `cfg.Display.HideDecimals` (bool, default false) loads from YAML config.
+- `GET /api/config` returns it as `{"display":{"hide_decimals":<bool>}}`.
+- The SPA reads it via `useServerConfig()` and exposes config-bound formatters
+  through `useAmountFormat()` in `spa/src/lib/server-config.tsx`.
+- Every SPA component and route uses the hook — no direct imports of
+  `formatCents` / `formatBalanceAbs` from `@/lib/format` outside the hook
+  itself and its tests.
+
+## Out of scope
+
+- Persisting per-user preferences (the YAML config is global per server).
+- Hot-reloading other config fields (`defaults.currency`, server settings)
+  — those still require a server restart.
+- A "preview" mode that toggles only for the current browser session
+  without writing to disk.
+
+## Architecture
+
+Two changes, one new HTTP endpoint and one new SPA route:
+
+```
+SPA /settings (toggle)  --PATCH /api/config-->  handlePatchConfig
+       ^                                              |
+       |                                              v
+       |                                       viper.Set + WriteConfig
+       |                                       mutate *config.Config in place
+       |                                              |
+       +------- invalidate ['server-config'] <--------+
+                       |
+                       v
+              useAmountFormat re-renders
+              all amounts across all pages
+```
+
+## Component 1: `PATCH /api/config`
+
+### Route
+
+Add to `internal/api/router.go` alongside the existing GET:
+
+```go
+r.Method(http.MethodPatch, "/config", apiHandler(s.handlePatchConfig))
+```
+
+### Handler
+
+Lives in `internal/api/config.go`:
+
+```go
+type configPatchRequest struct {
+    Display *configDisplayPatch `json:"display"`
+}
+
+type configDisplayPatch struct {
+    HideDecimals *bool `json:"hide_decimals"`
+}
+
+func (s *Server) handlePatchConfig(w http.ResponseWriter, r *http.Request) error {
+    var req configPatchRequest
+    dec := json.NewDecoder(r.Body)
+    dec.DisallowUnknownFields()
+    if err := dec.Decode(&req); err != nil {
+        return badRequest("invalid JSON body: " + err.Error())
+    }
+    if req.Display == nil || req.Display.HideDecimals == nil {
+        return badRequest("display.hide_decimals is required")
+    }
+
+    cfg := s.svc.Config()
+    cfg.Display.HideDecimals = *req.Display.HideDecimals
+    viper.Set("display.hide_decimals", *req.Display.HideDecimals)
+    if err := viper.WriteConfig(); err != nil {
+        return fmt.Errorf("failed to persist config: %w", err)
+    }
+    return writeJSON(w, http.StatusOK, configResponse{
+        Defaults: configDefaults{Currency: cfg.Defaults.Currency},
+        Display:  configDisplay{HideDecimals: cfg.Display.HideDecimals},
+    })
+}
+```
+
+Key points:
+
+- `DisallowUnknownFields()` rejects extra top-level keys (`defaults`,
+  `database`, `server`) at the JSON decode layer — this is how we enforce
+  "must not touch other settings."
+- Both `Display` and `HideDecimals` are pointers so we can distinguish
+  "field omitted" from "explicit false." Today only `hide_decimals` is
+  patchable, so missing → 400. If we ever add more fields, missing →
+  "leave as-is."
+- Mutating `cfg` in place is safe: `s.svc.Config()` returns the
+  `*config.Config` that's shared through `NewServer` and used by every
+  read handler. Subsequent `GET /api/config` calls see the new value
+  without a server restart.
+- The response echoes the full updated config (same shape as GET).
+- `badRequest` is the existing error helper used elsewhere in the API
+  package (returns a 400 with a JSON error body).
+
+### Write strategy
+
+Use `viper.Set` + `viper.WriteConfig`, matching the existing pattern in
+`cmd/root.go:262` (`setCurrency`). The risk is that viper's merged in-memory
+state includes defaults set via `viper.SetDefault` (`server.host`,
+`server.port`, `server.cors_origins`) and could leak them into the
+user's config file.
+
+This is verified by a test (see "Tests" below). If the leak test fails,
+the fallback is to re-marshal a `persistedConfig` struct subset to YAML and
+write the file directly, but per the brainstorming decision we try viper
+first.
+
+### Tests
+
+Table-driven in `internal/api/config_test.go`:
+
+| Case | Body | Expected |
+|------|------|----------|
+| Happy path | `{"display":{"hide_decimals":true}}` | 200, file updated, in-memory cfg updated, subsequent GET returns true |
+| Round-trip | PATCH true → PATCH false | GET returns false |
+| Malformed JSON | `not json` | 400 |
+| Unknown top-level field | `{"defaults":{"currency":"EUR"}}` | 400 (DisallowUnknownFields) |
+| Empty body | `{}` | 400 (HideDecimals missing) |
+| Empty display | `{"display":{}}` | 400 (HideDecimals missing) |
+| Wrong type | `{"display":{"hide_decimals":"yes"}}` | 400 |
+| Leak prevention | Load minimal YAML (only `defaults.currency: TWD` + `display.hide_decimals: true`), PATCH to false, read file back | File does NOT contain `server.host`, `server.port`, `server.cors_origins`, `database.path` |
+
+## Component 2: SPA settings page
+
+### New UI primitive
+
+`spa/src/components/ui/switch.tsx` — shadcn-style switch wrapping
+`@radix-ui/react-switch`. ~25 lines. Requires adding
+`@radix-ui/react-switch` to `spa/package.json`. Matches the styling
+conventions of the existing `label.tsx`, `input.tsx`, etc.
+
+### API client
+
+Add to `spa/src/lib/api.ts`:
+
+```ts
+export interface ConfigPatch {
+  display?: { hide_decimals?: boolean };
+}
+
+export async function setConfig(patch: ConfigPatch): Promise<ServerConfig> {
+  const res = await fetch('/api/config', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  if (!res.ok) throw await apiError(res);
+  return res.json();
+}
+```
+
+(The snippet is illustrative; match the local `fetch` / error helper
+pattern used by other write functions in `api.ts`.)
+
+### Route
+
+New file `spa/src/routes/settings.tsx`:
+
+```tsx
+export const Route = createFileRoute('/settings')({ component: SettingsPage });
+
+function SettingsPage() {
+  const { data: cfg } = useServerConfig();
+  const qc = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (hide: boolean) => setConfig({ display: { hide_decimals: hide } }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['server-config'] }),
+    onError: (err) => toast.error(`Failed to update setting: ${err.message}`),
+  });
+
+  return (
+    <div className="max-w-xl space-y-6">
+      <h1 className="text-2xl font-semibold">Settings</h1>
+      <Card>
+        <CardHeader><CardTitle>Display</CardTitle></CardHeader>
+        <CardContent className="flex items-center justify-between">
+          <div>
+            <Label htmlFor="hide-decimals">Hide decimal places in amounts</Label>
+            <p className="text-sm text-muted-foreground">
+              When on, amounts like $12.00 show as $12 across all pages.
+            </p>
+          </div>
+          <Switch
+            id="hide-decimals"
+            checked={cfg?.display.hide_decimals ?? false}
+            disabled={mutation.isPending || !cfg}
+            onCheckedChange={(checked) => mutation.mutate(checked)}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+```
+
+Invalidate-only update strategy: on success, invalidate the
+`['server-config']` query so `useServerConfig` re-fetches; amounts across
+all pages re-render with the new precision without a manual reload. Toast
+on failure (already wired via `spa/src/components/ui/sonner.tsx`).
+`disabled` during the in-flight request prevents double-clicks.
+
+### Sidebar update
+
+Modify `spa/src/components/Sidebar.tsx`:
+
+- Change the `<nav>` to `flex flex-col` and give the primary `<ul>`
+  `flex-1` so the settings link sits pinned at the bottom regardless of
+  viewport height.
+- Add a separate `<ul>` (or divider + second list) at the bottom
+  containing only the `Settings` item.
+- Reuse the same active-state styling as the other items.
+- No icon (plain text "Settings") to stay consistent with the existing
+  sidebar items and avoid pulling in `lucide-react` solely for this.
+
+## Component 3: Tests
+
+### API
+
+Covered above ("Tests" under Component 1).
+
+### SPA — `setConfig` unit test
+
+In the existing API-client test file (location matches project layout):
+
+- Mock `fetch`, call `setConfig({ display: { hide_decimals: true } })`.
+- Assert: PATCH method, `/api/config` URL, `Content-Type: application/json`,
+  body is exactly `{"display":{"hide_decimals":true}}`.
+- Mock a 400 response → assert the promise rejects with the parsed error.
+
+### SPA — settings page integration test
+
+New file `spa/src/routes/settings.test.tsx`:
+
+- Render `<SettingsPage />` inside `withServerConfig` (with
+  `hide_decimals: false` stub) using the existing `test-app.tsx` helpers.
+- Mock `fetch` for the PATCH call → returns the updated config.
+- Find the switch by accessible name "Hide decimal places in amounts",
+  click it.
+- Assert: `fetch` was called once with the right URL/method/body, and
+  `queryClient.invalidateQueries({ queryKey: ['server-config'] })`
+  happened (either by spying on the QueryClient or by asserting a
+  subsequent re-render reflects the new value after the mocked GET
+  resolves).
+
+### `withServerConfig` helper update
+
+In `spa/src/test/test-app.tsx`:
+
+- Today it seeds the `['server-config']` query with a default. If the
+  helper already takes an override arg, no change is needed. If not,
+  extend it to accept an optional `Partial<ServerConfig>` that is
+  deep-merged into the default before being written into the cache.
+- Inspect the file before changing to keep the surface minimal.
+
+### No e2e or smoke tests
+
+The existing `useAmountFormat` consumers already prove the hook re-renders
+when config changes. The toggle just changes the config; propagation is
+already covered.
+
+## Commit structure
+
+Two commits, conventional-commits style, no `Co-Authored-By`:
+
+1. `feat(api): add PATCH /api/config for display settings`
+2. `feat(spa): add /settings route with hide_decimals toggle`
+
+## Project conventions to honor
+
+- SPDX header on new Go files (`internal/api/config.go` already has one
+  — the new types/handler go in the same file, so no new file is needed
+  for the API change).
+- No SPDX on TS files.
+- English only.
+- All repository methods take `context.Context` first (not relevant here
+  — no repo calls).
+- Amounts are int64 cents (not relevant here).

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hance08/kea/internal/config"
 	"github.com/hance08/kea/internal/service"
 )
 
@@ -23,12 +24,16 @@ type configDisplay struct {
 	HideDecimals bool `json:"hide_decimals"`
 }
 
-func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) error {
-	cfg := s.svc.Config()
-	return writeJSON(w, http.StatusOK, configResponse{
+func buildConfigResponse(cfg *config.Config) configResponse {
+	return configResponse{
 		Defaults: configDefaults{Currency: cfg.Defaults.Currency},
 		Display:  configDisplay{HideDecimals: cfg.Display.HideDecimals},
-	})
+	}
+}
+
+func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) error {
+	cfg := s.svc.Config()
+	return writeJSON(w, http.StatusOK, buildConfigResponse(cfg))
 }
 
 type configPatchRequest struct {
@@ -55,8 +60,5 @@ func (s *Server) handlePatchConfig(w http.ResponseWriter, r *http.Request) error
 		return fmt.Errorf("save config: %w", err)
 	}
 
-	return writeJSON(w, http.StatusOK, configResponse{
-		Defaults: configDefaults{Currency: cfg.Defaults.Currency},
-		Display:  configDisplay{HideDecimals: cfg.Display.HideDecimals},
-	})
+	return writeJSON(w, http.StatusOK, buildConfigResponse(cfg))
 }

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -3,7 +3,12 @@
 
 package api
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/hance08/kea/internal/service"
+)
 
 type configResponse struct {
 	Defaults configDefaults `json:"defaults"`
@@ -20,6 +25,36 @@ type configDisplay struct {
 
 func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) error {
 	cfg := s.svc.Config()
+	return writeJSON(w, http.StatusOK, configResponse{
+		Defaults: configDefaults{Currency: cfg.Defaults.Currency},
+		Display:  configDisplay{HideDecimals: cfg.Display.HideDecimals},
+	})
+}
+
+type configPatchRequest struct {
+	Display *configDisplayPatch `json:"display"`
+}
+
+type configDisplayPatch struct {
+	HideDecimals *bool `json:"hide_decimals"`
+}
+
+func (s *Server) handlePatchConfig(w http.ResponseWriter, r *http.Request) error {
+	var req configPatchRequest
+	if err := decodeJSON(r, &req); err != nil {
+		return err
+	}
+	if req.Display == nil || req.Display.HideDecimals == nil {
+		return &service.ValidationError{Field: "display.hide_decimals", Message: "required"}
+	}
+
+	cfg := s.svc.Config()
+	cfg.Display.HideDecimals = *req.Display.HideDecimals
+
+	if err := s.saveConfig(); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+
 	return writeJSON(w, http.StatusOK, configResponse{
 		Defaults: configDefaults{Currency: cfg.Defaults.Currency},
 		Display:  configDisplay{HideDecimals: cfg.Display.HideDecimals},

--- a/internal/api/config_test.go
+++ b/internal/api/config_test.go
@@ -5,6 +5,8 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -67,5 +69,141 @@ func TestGetConfig(t *testing.T) {
 				t.Errorf("parsed hide_decimals: got %v, want %v", parsed.Display.HideDecimals, tt.hideDecimals)
 			}
 		})
+	}
+}
+
+func TestPatchConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		wantStatus    int
+		wantHide      bool
+		wantSaveCalls int
+	}{
+		{"set_true", `{"display":{"hide_decimals":true}}`, http.StatusOK, true, 1},
+		{"set_false", `{"display":{"hide_decimals":false}}`, http.StatusOK, false, 1},
+		{"malformed_json", `not json`, http.StatusBadRequest, false, 0},
+		{"unknown_top_field", `{"defaults":{"currency":"EUR"}}`, http.StatusBadRequest, false, 0},
+		{"empty_body", `{}`, http.StatusBadRequest, false, 0},
+		{"empty_display", `{"display":{}}`, http.StatusBadRequest, false, 0},
+		{"wrong_type", `{"display":{"hide_decimals":"yes"}}`, http.StatusBadRequest, false, 0},
+		{"unknown_display_field", `{"display":{"foo":true}}`, http.StatusBadRequest, false, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, cfg, saveCalls, _ := newServerForPatchConfig(t, "USD", false)
+
+			req, err := http.NewRequest(http.MethodPatch, ts.URL+"/api/config", strings.NewReader(tt.body))
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("PATCH: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tt.wantStatus {
+				body, _ := io.ReadAll(resp.Body)
+				t.Errorf("status: got %d, want %d. body=%s", resp.StatusCode, tt.wantStatus, body)
+			}
+			if cfg.Display.HideDecimals != tt.wantHide {
+				t.Errorf("cfg.Display.HideDecimals: got %v, want %v", cfg.Display.HideDecimals, tt.wantHide)
+			}
+			if *saveCalls != tt.wantSaveCalls {
+				t.Errorf("saveCalls: got %d, want %d", *saveCalls, tt.wantSaveCalls)
+			}
+		})
+	}
+}
+
+func TestPatchConfig_DoesNotTouchOtherFields(t *testing.T) {
+	ts, cfg, _, _ := newServerForPatchConfig(t, "TWD", false)
+	originalCurrency := cfg.Defaults.Currency
+	originalHost := cfg.Server.Host
+	originalPort := cfg.Server.Port
+
+	req, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/config",
+		strings.NewReader(`{"display":{"hide_decimals":true}}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if cfg.Defaults.Currency != originalCurrency {
+		t.Errorf("Defaults.Currency changed: got %q, want %q", cfg.Defaults.Currency, originalCurrency)
+	}
+	if cfg.Server.Host != originalHost {
+		t.Errorf("Server.Host changed: got %q, want %q", cfg.Server.Host, originalHost)
+	}
+	if cfg.Server.Port != originalPort {
+		t.Errorf("Server.Port changed: got %d, want %d", cfg.Server.Port, originalPort)
+	}
+}
+
+func TestPatchConfig_RoundTrip(t *testing.T) {
+	ts, _, _, _ := newServerForPatchConfig(t, "USD", false)
+
+	patch := func(value bool) {
+		body := fmt.Sprintf(`{"display":{"hide_decimals":%t}}`, value)
+		req, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/config", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("PATCH: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("PATCH status: %d", resp.StatusCode)
+		}
+	}
+
+	getHide := func() bool {
+		resp, err := http.Get(ts.URL + "/api/config")
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		var parsed struct {
+			Display struct {
+				HideDecimals bool `json:"hide_decimals"`
+			} `json:"display"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return parsed.Display.HideDecimals
+	}
+
+	patch(true)
+	if got := getHide(); got != true {
+		t.Errorf("after PATCH true: GET returned %v", got)
+	}
+	patch(false)
+	if got := getHide(); got != false {
+		t.Errorf("after PATCH false: GET returned %v", got)
+	}
+}
+
+func TestPatchConfig_SaveErrorReturns500(t *testing.T) {
+	ts, _, _, saveErr := newServerForPatchConfig(t, "USD", false)
+	*saveErr = errors.New("disk full")
+
+	req, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/config",
+		strings.NewReader(`{"display":{"hide_decimals":true}}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status: got %d, want 500", resp.StatusCode)
 	}
 }

--- a/internal/api/config_test.go
+++ b/internal/api/config_test.go
@@ -190,6 +190,41 @@ func TestPatchConfig_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestPatchConfig_ResponseEchoesUpdatedConfig(t *testing.T) {
+	ts, _, _, _ := newServerForPatchConfig(t, "TWD", false)
+
+	req, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/config",
+		strings.NewReader(`{"display":{"hide_decimals":true}}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+
+	var parsed struct {
+		Defaults struct {
+			Currency string `json:"currency"`
+		} `json:"defaults"`
+		Display struct {
+			HideDecimals bool `json:"hide_decimals"`
+		} `json:"display"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if parsed.Defaults.Currency != "TWD" {
+		t.Errorf("defaults.currency: got %q, want %q", parsed.Defaults.Currency, "TWD")
+	}
+	if parsed.Display.HideDecimals != true {
+		t.Errorf("display.hide_decimals: got %v, want true", parsed.Display.HideDecimals)
+	}
+}
+
 func TestPatchConfig_SaveErrorReturns500(t *testing.T) {
 	ts, _, _, saveErr := newServerForPatchConfig(t, "USD", false)
 	*saveErr = errors.New("disk full")

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -25,6 +25,7 @@ func (s *Server) routes() http.Handler {
 		r.Method(http.MethodGet, "/health", apiHandler(s.handleHealth))
 		r.Method(http.MethodGet, "/version", apiHandler(s.handleVersion))
 		r.Method(http.MethodGet, "/config", apiHandler(s.handleGetConfig))
+		r.Method(http.MethodPatch, "/config", apiHandler(s.handlePatchConfig))
 		r.Method(http.MethodGet, "/accounts", apiHandler(s.handleListAccounts))
 		r.Method(http.MethodPost, "/accounts", apiHandler(s.handleCreateAccount))
 		r.Method(http.MethodGet, "/accounts/tree", apiHandler(s.handleAccountTree))

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -22,7 +22,7 @@ func newTestServer(t *testing.T) *httptest.Server {
 			CORSOrigins: []string{"http://localhost:5173"},
 		},
 	}
-	srv := NewServer(cfg, nil, nil, nil, "", nil, discardLogger())
+	srv := NewServer(cfg, nil, nil, nil, "", nil, func() error { return nil }, discardLogger())
 	ts := httptest.NewServer(srv.routes())
 	t.Cleanup(ts.Close)
 	return ts

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -27,6 +27,7 @@ type Server struct {
 	migrations fs.FS
 	appDir     string
 	switchLedger func(name string) error
+	saveConfig func() error
 	logger     *slog.Logger
 	http       *http.Server
 }
@@ -38,6 +39,7 @@ func NewServer(
 	migrations fs.FS,
 	appDir string,
 	switchLedger func(name string) error,
+	saveConfig func() error,
 	logger *slog.Logger,
 ) *Server {
 	s := &Server{
@@ -47,6 +49,7 @@ func NewServer(
 		migrations: migrations,
 		appDir:     appDir,
 		switchLedger: switchLedger,
+		saveConfig: saveConfig,
 		logger:     logger,
 	}
 	addr := net.JoinHostPort(cfg.Server.Host, strconv.Itoa(cfg.Server.Port))

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -18,7 +18,7 @@ func TestRunReturnsWhenContextCancelled(t *testing.T) {
 			Port: 0, // Let the kernel pick a free port.
 		},
 	}
-	srv := NewServer(cfg, nil, nil, nil, "", nil, discardLogger())
+	srv := NewServer(cfg, nil, nil, nil, "", nil, func() error { return nil }, discardLogger())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)

--- a/internal/api/testhelper_test.go
+++ b/internal/api/testhelper_test.go
@@ -114,6 +114,43 @@ func newServerForWriteWithDisplay(t *testing.T, currency string, hideDecimals bo
 	return ts, svc, st
 }
 
+// newServerForPatchConfig builds a server whose saveConfig closure records
+// every call into the returned counter and returns the *config.Config so
+// tests can assert in-memory mutation independently of persistence. The
+// saveConfig stub returns nil unless tests inject an error via *saveErr.
+func newServerForPatchConfig(t *testing.T, currency string, hideDecimals bool) (
+	ts *httptest.Server,
+	cfg *config.Config,
+	saveCalls *int,
+	saveErr *error,
+) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	st, err := store.NewStore(dbPath, migrations.FS)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	cfg = config.NewDefault()
+	cfg.Defaults.Currency = currency
+	cfg.Display.HideDecimals = hideDecimals
+
+	svc := service.NewService(st, st, st, cfg)
+
+	calls := 0
+	var injErr error
+	save := func() error {
+		calls++
+		return injErr
+	}
+	srv := NewServer(cfg, svc, nil, nil, "", nil, save, discardLogger())
+	ts = httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts, cfg, &calls, &injErr
+}
+
 // newServerForWrite is a variant of newServerWithStore that also returns the
 // underlying *store.Store, so write tests can manipulate reconcile state and
 // inject a parent cycle directly via the repo (bypassing the service layer

--- a/internal/api/testhelper_test.go
+++ b/internal/api/testhelper_test.go
@@ -82,7 +82,7 @@ func newServerForWriteWithCurrency(t *testing.T, currency string) (*httptest.Ser
 	cfg.Defaults.Currency = currency
 
 	svc := service.NewService(st, st, st, cfg)
-	srv := NewServer(cfg, svc, nil, nil, "", nil, discardLogger())
+	srv := NewServer(cfg, svc, nil, nil, "", nil, func() error { return nil }, discardLogger())
 	ts := httptest.NewServer(srv.routes())
 	t.Cleanup(ts.Close)
 
@@ -107,7 +107,7 @@ func newServerForWriteWithDisplay(t *testing.T, currency string, hideDecimals bo
 	cfg.Display.HideDecimals = hideDecimals
 
 	svc := service.NewService(st, st, st, cfg)
-	srv := NewServer(cfg, svc, nil, nil, "", nil, discardLogger())
+	srv := NewServer(cfg, svc, nil, nil, "", nil, func() error { return nil }, discardLogger())
 	ts := httptest.NewServer(srv.routes())
 	t.Cleanup(ts.Close)
 
@@ -189,7 +189,7 @@ func newTestServerWithLedger(t *testing.T) (
 	}
 
 	cfg := config.NewDefault()
-	srv := NewServer(cfg, nil, reg, migrations.FS, appDir, switchLedger, discardLogger())
+	srv := NewServer(cfg, nil, reg, migrations.FS, appDir, switchLedger, func() error { return nil }, discardLogger())
 	ts = httptest.NewServer(srv.routes())
 	t.Cleanup(ts.Close)
 

--- a/spa/package-lock.json
+++ b/spa/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@radix-ui/react-slot": "^1.2.5",
+        "@radix-ui/react-switch": "^1.3.1",
         "@tanstack/react-query": "^5.51.0",
         "@tanstack/react-router": "^1.46.0",
         "class-variance-authority": "^0.7.0",
@@ -1581,6 +1582,76 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.1.tgz",
+      "integrity": "sha512-55bQtCnOB0BohomSHi6qvQXpJEEqUGDm6hRrM0Bph5OXwhSegqkd8IqgBAQkM1IlgUlWZIxpxRcpOEfRIgimyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
+      "integrity": "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
@@ -1655,6 +1726,21 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
       "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.2.tgz",
+      "integrity": "sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",

--- a/spa/package.json
+++ b/spa/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@radix-ui/react-slot": "^1.2.5",
+    "@radix-ui/react-switch": "^1.3.1",
     "@tanstack/react-query": "^5.51.0",
     "@tanstack/react-router": "^1.46.0",
     "class-variance-authority": "^0.7.0",

--- a/spa/src/components/Sidebar.tsx
+++ b/spa/src/components/Sidebar.tsx
@@ -16,44 +16,64 @@ const NAV: NavItem[] = [
   { label: 'Reconcile' },
 ];
 
+const FOOTER_NAV: NavItem[] = [{ label: 'Settings', to: '/settings' }];
+
 export function Sidebar() {
   const { location } = useRouterState();
   return (
-    <nav aria-label="Main navigation" className="w-56 shrink-0 border-r bg-muted/30 p-4">
+    <nav
+      aria-label="Main navigation"
+      className="flex w-56 shrink-0 flex-col border-r bg-muted/30 p-4"
+    >
       <LedgerSwitcher />
-      <ul className="space-y-1">
-        {NAV.map((item) => {
-          if (!item.to) {
-            return (
-              <li key={item.label}>
-                <span
-                  aria-disabled="true"
-                  className="block cursor-not-allowed rounded px-3 py-2 text-sm text-muted-foreground"
-                  title="Coming soon"
-                >
-                  {item.label}
-                </span>
-              </li>
-            );
-          }
-          const isActive = item.prefix
-            ? location.pathname === item.to || location.pathname.startsWith(`${item.to}/`)
-            : location.pathname === item.to;
+      <NavList items={NAV} pathname={location.pathname} className="flex-1" />
+      <NavList items={FOOTER_NAV} pathname={location.pathname} />
+    </nav>
+  );
+}
+
+function NavList({
+  items,
+  pathname,
+  className,
+}: {
+  items: NavItem[];
+  pathname: string;
+  className?: string;
+}) {
+  return (
+    <ul className={cn('space-y-1', className)}>
+      {items.map((item) => {
+        if (!item.to) {
           return (
             <li key={item.label}>
-              <Link
-                to={item.to}
-                className={cn(
-                  'block rounded px-3 py-2 text-sm transition-colors',
-                  isActive ? 'bg-primary text-primary-foreground font-medium' : 'hover:bg-muted',
-                )}
+              <span
+                aria-disabled="true"
+                className="block cursor-not-allowed rounded px-3 py-2 text-sm text-muted-foreground"
+                title="Coming soon"
               >
                 {item.label}
-              </Link>
+              </span>
             </li>
           );
-        })}
-      </ul>
-    </nav>
+        }
+        const isActive = item.prefix
+          ? pathname === item.to || pathname.startsWith(`${item.to}/`)
+          : pathname === item.to;
+        return (
+          <li key={item.label}>
+            <Link
+              to={item.to}
+              className={cn(
+                'block rounded px-3 py-2 text-sm transition-colors',
+                isActive ? 'bg-primary text-primary-foreground font-medium' : 'hover:bg-muted',
+              )}
+            >
+              {item.label}
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
   );
 }

--- a/spa/src/components/ui/switch.tsx
+++ b/spa/src/components/ui/switch.tsx
@@ -1,0 +1,28 @@
+import * as SwitchPrimitives from '@radix-ui/react-switch';
+import * as React from 'react';
+import { cn } from '@/lib/cn';
+
+export const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors',
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+      'disabled:cursor-not-allowed disabled:opacity-50',
+      'data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
+        'data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0',
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = 'Switch';

--- a/spa/src/lib/api.ts
+++ b/spa/src/lib/api.ts
@@ -49,6 +49,18 @@ export function getConfig(): Promise<ServerConfig> {
   return apiFetch<ServerConfig>('/api/config');
 }
 
+export interface ConfigPatch {
+  display?: { hide_decimals?: boolean };
+}
+
+export function setConfig(patch: ConfigPatch): Promise<ServerConfig> {
+  return apiFetch<ServerConfig>('/api/config', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+}
+
 export function getLedgers(): Promise<LedgerListResponse> {
   return apiFetch<LedgerListResponse>('/api/ledgers');
 }

--- a/spa/src/routeTree.gen.ts
+++ b/spa/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as TransactionsRouteImport } from './routes/transactions'
+import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ReportsRouteImport } from './routes/reports'
 import { Route as BalancesRouteImport } from './routes/balances'
 import { Route as AccountsRouteImport } from './routes/accounts'
@@ -34,6 +35,11 @@ import { Route as AccountsIdEditRouteImport } from './routes/accounts.$id.edit'
 const TransactionsRoute = TransactionsRouteImport.update({
   id: '/transactions',
   path: '/transactions',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SettingsRoute = SettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ReportsRoute = ReportsRouteImport.update({
@@ -142,6 +148,7 @@ export interface FileRoutesByFullPath {
   '/accounts': typeof AccountsRouteWithChildren
   '/balances': typeof BalancesRoute
   '/reports': typeof ReportsRouteWithChildren
+  '/settings': typeof SettingsRoute
   '/transactions': typeof TransactionsRouteWithChildren
   '/accounts/$id': typeof AccountsIdRouteWithChildren
   '/accounts/new': typeof AccountsNewRoute
@@ -163,6 +170,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/balances': typeof BalancesRoute
+  '/settings': typeof SettingsRoute
   '/accounts/new': typeof AccountsNewRoute
   '/reports/balance-sheet': typeof ReportsBalanceSheetRoute
   '/reports/expense-breakdown': typeof ReportsExpenseBreakdownRoute
@@ -184,6 +192,7 @@ export interface FileRoutesById {
   '/accounts': typeof AccountsRouteWithChildren
   '/balances': typeof BalancesRoute
   '/reports': typeof ReportsRouteWithChildren
+  '/settings': typeof SettingsRoute
   '/transactions': typeof TransactionsRouteWithChildren
   '/accounts/$id': typeof AccountsIdRouteWithChildren
   '/accounts/new': typeof AccountsNewRoute
@@ -209,6 +218,7 @@ export interface FileRouteTypes {
     | '/accounts'
     | '/balances'
     | '/reports'
+    | '/settings'
     | '/transactions'
     | '/accounts/$id'
     | '/accounts/new'
@@ -230,6 +240,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/balances'
+    | '/settings'
     | '/accounts/new'
     | '/reports/balance-sheet'
     | '/reports/expense-breakdown'
@@ -250,6 +261,7 @@ export interface FileRouteTypes {
     | '/accounts'
     | '/balances'
     | '/reports'
+    | '/settings'
     | '/transactions'
     | '/accounts/$id'
     | '/accounts/new'
@@ -274,6 +286,7 @@ export interface RootRouteChildren {
   AccountsRoute: typeof AccountsRouteWithChildren
   BalancesRoute: typeof BalancesRoute
   ReportsRoute: typeof ReportsRouteWithChildren
+  SettingsRoute: typeof SettingsRoute
   TransactionsRoute: typeof TransactionsRouteWithChildren
 }
 
@@ -284,6 +297,13 @@ declare module '@tanstack/react-router' {
       path: '/transactions'
       fullPath: '/transactions'
       preLoaderRoute: typeof TransactionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/reports': {
@@ -515,6 +535,7 @@ const rootRouteChildren: RootRouteChildren = {
   AccountsRoute: AccountsRouteWithChildren,
   BalancesRoute: BalancesRoute,
   ReportsRoute: ReportsRouteWithChildren,
+  SettingsRoute: SettingsRoute,
   TransactionsRoute: TransactionsRouteWithChildren,
 }
 export const routeTree = rootRouteImport

--- a/spa/src/routes/settings.tsx
+++ b/spa/src/routes/settings.tsx
@@ -1,0 +1,52 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { setConfig } from '@/lib/api';
+import { useServerConfig } from '@/lib/server-config';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createFileRoute } from '@tanstack/react-router';
+import { toast } from 'sonner';
+
+export const Route = createFileRoute('/settings')({ component: SettingsPage });
+
+function SettingsPage() {
+  const cfg = useServerConfig();
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (hide: boolean) => setConfig({ display: { hide_decimals: hide } }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['server-config'] });
+    },
+    onError: (err: Error) => {
+      toast.error(`Failed to update setting: ${err.message}`);
+    },
+  });
+
+  return (
+    <div className="max-w-xl space-y-6">
+      <h1 className="text-2xl font-semibold">Settings</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Display</CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <Label htmlFor="hide-decimals" className="text-sm">
+              Hide decimal places in amounts
+            </Label>
+            <p className="text-sm text-muted-foreground">
+              When on, amounts like $12.00 display as $12 across all pages.
+            </p>
+          </div>
+          <Switch
+            id="hide-decimals"
+            aria-label="Hide decimal places in amounts"
+            checked={cfg.display.hide_decimals}
+            disabled={mutation.isPending}
+            onCheckedChange={(checked) => mutation.mutate(checked)}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/spa/src/routes/settings.tsx
+++ b/spa/src/routes/settings.tsx
@@ -18,7 +18,7 @@ function SettingsPage() {
       queryClient.invalidateQueries({ queryKey: ['server-config'] });
     },
     onError: (err: Error) => {
-      toast.error(`Failed to update setting: ${err.message}`);
+      toast.error(err.message);
     },
   });
 
@@ -34,13 +34,13 @@ function SettingsPage() {
             <Label htmlFor="hide-decimals" className="text-sm">
               Hide decimal places in amounts
             </Label>
-            <p className="text-sm text-muted-foreground">
+            <p id="hide-decimals-desc" className="text-sm text-muted-foreground">
               When on, amounts like $12.00 display as $12 across all pages.
             </p>
           </div>
           <Switch
             id="hide-decimals"
-            aria-label="Hide decimal places in amounts"
+            aria-describedby="hide-decimals-desc"
             checked={cfg.display.hide_decimals}
             disabled={mutation.isPending}
             onCheckedChange={(checked) => mutation.mutate(checked)}

--- a/spa/src/test/api.setConfig.test.ts
+++ b/spa/src/test/api.setConfig.test.ts
@@ -1,0 +1,64 @@
+import { ApiError, setConfig } from '@/lib/api';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+const okResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const errorResponse = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchSpy = vi.fn();
+  vi.stubGlobal('fetch', fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test('sends PATCH /api/config with the supplied body', async () => {
+  fetchSpy.mockResolvedValueOnce(
+    okResponse({ defaults: { currency: 'USD' }, display: { hide_decimals: true } }),
+  );
+
+  const result = await setConfig({ display: { hide_decimals: true } });
+
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
+  const [url, init] = fetchSpy.mock.calls[0];
+  expect(url).toBe('/api/config');
+  expect(init?.method).toBe('PATCH');
+  expect(init?.headers).toEqual({ 'Content-Type': 'application/json' });
+  expect(init?.body).toBe('{"display":{"hide_decimals":true}}');
+  expect(result).toEqual({ defaults: { currency: 'USD' }, display: { hide_decimals: true } });
+});
+
+test('rejects with ApiError when the server returns 400', async () => {
+  fetchSpy.mockResolvedValueOnce(
+    errorResponse(400, {
+      error: 'validation_failed',
+      message: 'bad body',
+      field: 'display.hide_decimals',
+    }),
+  );
+
+  await expect(setConfig({ display: { hide_decimals: true } })).rejects.toMatchObject({
+    name: 'ApiError',
+    status: 400,
+    message: 'bad body',
+    field: 'display.hide_decimals',
+  });
+});
+
+test('thrown error is an ApiError instance', async () => {
+  fetchSpy.mockResolvedValueOnce(errorResponse(500, { message: 'boom' }));
+
+  await expect(setConfig({ display: { hide_decimals: false } })).rejects.toBeInstanceOf(ApiError);
+});

--- a/spa/src/test/settings.test.tsx
+++ b/spa/src/test/settings.test.tsx
@@ -1,3 +1,4 @@
+import { Route as SettingsRoute } from '@/routes/settings';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -16,16 +17,11 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-async function renderSettings(hideDecimals: boolean) {
-  const SettingsRouteModule = await import('@/routes/settings');
-  const SettingsPage = SettingsRouteModule.Route.options.component as React.FC;
+function renderSettings(hideDecimals: boolean) {
+  const SettingsPage = SettingsRoute.options.component as React.FC;
 
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
-  });
-  queryClient.setQueryData(['server-config'], {
-    defaults: { currency: 'USD' },
-    display: { hide_decimals: hideDecimals },
   });
   const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
@@ -37,8 +33,8 @@ async function renderSettings(hideDecimals: boolean) {
   return { ...tree, queryClient, invalidateSpy };
 }
 
-test('renders the hide_decimals switch with the current value', async () => {
-  await renderSettings(false);
+test('renders the hide_decimals switch with the current value', () => {
+  renderSettings(false);
   const sw = screen.getByRole('switch', { name: /hide decimal places/i });
   expect(sw).toHaveAttribute('aria-checked', 'false');
 });
@@ -51,7 +47,7 @@ test('clicking the switch PATCHes /api/config and invalidates server-config', as
     ),
   );
 
-  const { invalidateSpy } = await renderSettings(false);
+  const { invalidateSpy } = renderSettings(false);
 
   await userEvent.click(screen.getByRole('switch', { name: /hide decimal places/i }));
 
@@ -74,7 +70,7 @@ test('does not invalidate the server-config query when PATCH fails', async () =>
     }),
   );
 
-  const { invalidateSpy } = await renderSettings(false);
+  const { invalidateSpy } = renderSettings(false);
 
   await userEvent.click(screen.getByRole('switch', { name: /hide decimal places/i }));
 

--- a/spa/src/test/settings.test.tsx
+++ b/spa/src/test/settings.test.tsx
@@ -1,0 +1,83 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type React from 'react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { withServerConfig } from './test-app';
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchSpy = vi.fn();
+  vi.stubGlobal('fetch', fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function renderSettings(hideDecimals: boolean) {
+  const SettingsRouteModule = await import('@/routes/settings');
+  const SettingsPage = SettingsRouteModule.Route.options.component as React.FC;
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  queryClient.setQueryData(['server-config'], {
+    defaults: { currency: 'USD' },
+    display: { hide_decimals: hideDecimals },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+  const tree = render(
+    <QueryClientProvider client={queryClient}>
+      {withServerConfig(<SettingsPage />, { display: { hide_decimals: hideDecimals } })}
+    </QueryClientProvider>,
+  );
+  return { ...tree, queryClient, invalidateSpy };
+}
+
+test('renders the hide_decimals switch with the current value', async () => {
+  await renderSettings(false);
+  const sw = screen.getByRole('switch', { name: /hide decimal places/i });
+  expect(sw).toHaveAttribute('aria-checked', 'false');
+});
+
+test('clicking the switch PATCHes /api/config and invalidates server-config', async () => {
+  fetchSpy.mockResolvedValueOnce(
+    new Response(
+      JSON.stringify({ defaults: { currency: 'USD' }, display: { hide_decimals: true } }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ),
+  );
+
+  const { invalidateSpy } = await renderSettings(false);
+
+  await userEvent.click(screen.getByRole('switch', { name: /hide decimal places/i }));
+
+  await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+  const [url, init] = fetchSpy.mock.calls[0];
+  expect(url).toBe('/api/config');
+  expect(init?.method).toBe('PATCH');
+  expect(init?.body).toBe('{"display":{"hide_decimals":true}}');
+
+  await waitFor(() =>
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['server-config'] }),
+  );
+});
+
+test('does not invalidate the server-config query when PATCH fails', async () => {
+  fetchSpy.mockResolvedValueOnce(
+    new Response(JSON.stringify({ error: 'validation_failed', message: 'bad' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+
+  const { invalidateSpy } = await renderSettings(false);
+
+  await userEvent.click(screen.getByRole('switch', { name: /hide decimal places/i }));
+
+  await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+  expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ['server-config'] });
+});

--- a/spa/src/test/test-app.tsx
+++ b/spa/src/test/test-app.tsx
@@ -25,7 +25,11 @@ export function makeTestApp(initialPath: string) {
 // can be called without standing up the full /api/config fetch stack.
 export function withServerConfig(
   children: ReactNode,
-  config: ServerConfig = { defaults: { currency: 'USD' }, display: { hide_decimals: false } },
+  override?: Partial<ServerConfig>,
 ) {
+  const config: ServerConfig = {
+    defaults: { currency: 'USD', ...(override?.defaults ?? {}) },
+    display: { hide_decimals: false, ...(override?.display ?? {}) },
+  };
   return <ServerConfigContext.Provider value={config}>{children}</ServerConfigContext.Provider>;
 }


### PR DESCRIPTION
## Summary

- Adds `PATCH /api/config` that mutates `display.hide_decimals` in place on the shared `*config.Config` and persists via an injected `saveConfig` closure (no viper dependency in `internal/api`).
- Adds an SPA `/settings` route with a single toggle wired to a new `setConfig` API client; on success invalidates the `['server-config']` query so every amount formatter re-renders without a reload.
- Adds a Settings link pinned to the bottom of the sidebar.
- Persistence uses an in-place `yaml.Node` rewrite (in `cmd/save_config.go`) instead of `viper.WriteConfig`, which leaked registered server defaults (`server.host`, `server.port`, `server.cors_origins`) into the user's YAML. A canary test `TestViperWriteLeaks_NeedsFallback` documents the upstream bug so we can revisit if viper fixes it.

## Test plan

- [ ] `go test ./...` — all packages green (verified).
- [ ] `cd spa && npx vitest run src/test/api.setConfig.test.ts src/test/settings.test.tsx` — new tests pass.
- [ ] Run `make run`, open the SPA, navigate to `/settings`, toggle "Hide decimal places in amounts".
- [ ] Confirm amounts on `/balances` and `/transactions` change precision without a reload.
- [ ] Edit the user YAML to add a `# comment on server.port`, toggle the setting via the UI, confirm the comment survives.
- [ ] Restart the server and confirm the toggle state persists.

## Notes

- The 6 failing tests in `spa/src/test/balances.test.tsx` and `spa/src/test/balances.link.test.tsx` are pre-existing on master and untouched by this branch (verified — diff is empty for both files). A follow-up task chip was spawned to address them.
- Spec: `docs/superpowers/specs/2026-06-18-spa-hide-decimals-toggle-design.md`
- Plan: `docs/superpowers/plans/2026-06-18-spa-hide-decimals-toggle.md`