### PR TITLE
feat(spa): chart range selector, drop Liabilities table

### DIFF
--- a/spa/src/components/reports/ChartRangeSelector.tsx
+++ b/spa/src/components/reports/ChartRangeSelector.tsx
@@ -1,0 +1,68 @@
+import { cn } from '@/lib/cn';
+import type { DailyBalancePoint } from '@/lib/types';
+
+export type ChartRange = '1M' | '3M' | 'YTD' | '1Y' | 'ALL';
+
+const OPTIONS: { value: ChartRange; label: string }[] = [
+  { value: '1M', label: '1M' },
+  { value: '3M', label: '3M' },
+  { value: 'YTD', label: 'YTD' },
+  { value: '1Y', label: '1Y' },
+  { value: 'ALL', label: 'All' },
+];
+
+interface Props {
+  value: ChartRange;
+  onChange: (range: ChartRange) => void;
+  className?: string;
+}
+
+export function ChartRangeSelector({ value, onChange, className }: Props) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Chart range"
+      className={cn('flex gap-0.5', className)}
+    >
+      {OPTIONS.map((opt) => {
+        const isActive = value === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            onClick={() => onChange(opt.value)}
+            className={cn(
+              'rounded-md px-2 py-1 text-xs font-medium transition-colors',
+              isActive
+                ? 'bg-primary text-primary-foreground'
+                : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+            )}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function filterPointsByRange(
+  points: DailyBalancePoint[],
+  range: ChartRange,
+): DailyBalancePoint[] {
+  if (range === 'ALL' || points.length === 0) return points;
+  const last = points[points.length - 1].date;
+  const anchor = new Date(`${last}T00:00:00Z`);
+  let cutoff: Date;
+  if (range === 'YTD') {
+    cutoff = new Date(Date.UTC(anchor.getUTCFullYear(), 0, 1));
+  } else {
+    const months = range === '1M' ? 1 : range === '3M' ? 3 : 12;
+    cutoff = new Date(anchor);
+    cutoff.setUTCMonth(cutoff.getUTCMonth() - months);
+  }
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
+  return points.filter((p) => p.date >= cutoffStr);
+}

--- a/spa/src/components/reports/NetWorthChart.tsx
+++ b/spa/src/components/reports/NetWorthChart.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/lib/cn';
 import type { DailyBalancePoint } from '@/lib/types';
+import { useState } from 'react';
 
 interface Props {
   points: DailyBalancePoint[];
@@ -14,6 +15,8 @@ const VIEWBOX_H = 180;
 const PAD_Y = 4;
 
 export function NetWorthChart({ points, currency, formatCents, asOfDate, className }: Props) {
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+
   if (points.length < 2) return null;
 
   const balances = points.map((p) => p.balance);
@@ -59,9 +62,25 @@ export function NetWorthChart({ points, currency, formatCents, asOfDate, classNa
   const markerLeftPct = markerIdx !== null ? (xy[markerIdx].x / VIEWBOX_W) * 100 : null;
   const markerTopPct = markerIdx !== null ? (xy[markerIdx].y / VIEWBOX_H) * 100 : null;
 
+  const hoverLeftPct = hoverIdx !== null ? (xy[hoverIdx].x / VIEWBOX_W) * 100 : null;
+  const hoverTopPct = hoverIdx !== null ? (xy[hoverIdx].y / VIEWBOX_H) * 100 : null;
+
+  const handleMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    if (rect.width === 0) return;
+    const xRatio = Math.min(1, Math.max(0, (e.clientX - rect.left) / rect.width));
+    const idx = Math.round(xRatio * (points.length - 1));
+    setHoverIdx(idx);
+  };
+
   return (
     <div className={cn('w-full', className)}>
-      <div className="relative mt-4 h-40 w-full">
+      <div
+        className="relative mt-4 h-40 w-full touch-none"
+        onPointerMove={handleMove}
+        onPointerEnter={handleMove}
+        onPointerLeave={() => setHoverIdx(null)}
+      >
         <svg
           role="img"
           aria-label={`Net worth over time, ${currency}`}
@@ -86,6 +105,16 @@ export function NetWorthChart({ points, currency, formatCents, asOfDate, classNa
               strokeDasharray="3 3"
               vectorEffect="non-scaling-stroke"
               className="stroke-muted-foreground/40"
+            />
+          )}
+          {hoverIdx !== null && (
+            <line
+              x1={xy[hoverIdx].x}
+              x2={xy[hoverIdx].x}
+              y1={0}
+              y2={VIEWBOX_H}
+              vectorEffect="non-scaling-stroke"
+              className="stroke-muted-foreground/60"
             />
           )}
         </svg>
@@ -135,6 +164,29 @@ export function NetWorthChart({ points, currency, formatCents, asOfDate, classNa
             className="pointer-events-none absolute h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary"
             style={{ left: `${markerLeftPct}%`, top: `${markerTopPct}%` }}
           />
+        )}
+
+        {hoverIdx !== null && hoverLeftPct !== null && hoverTopPct !== null && (
+          <>
+            <div
+              data-testid="net-worth-hover-dot"
+              aria-hidden="true"
+              className="pointer-events-none absolute h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary ring-2 ring-background"
+              style={{ left: `${hoverLeftPct}%`, top: `${hoverTopPct}%` }}
+            />
+            <div
+              role="status"
+              aria-live="polite"
+              className={cn(
+                'pointer-events-none absolute z-10 -translate-y-full rounded-md border border-border bg-popover px-2 py-1 text-[11px] text-popover-foreground shadow-sm',
+                hoverLeftPct > 70 ? '-translate-x-full' : hoverLeftPct < 30 ? '' : '-translate-x-1/2',
+              )}
+              style={{ left: `${hoverLeftPct}%`, top: `${Math.max(hoverTopPct - 4, 0)}%` }}
+            >
+              <div className="font-medium">{formatCents(points[hoverIdx].balance)}</div>
+              <div className="text-muted-foreground">{points[hoverIdx].date}</div>
+            </div>
+          </>
         )}
       </div>
       <div className="mt-1 flex justify-between text-[10px] text-muted-foreground">

--- a/spa/src/routes/reports.balance-sheet.tsx
+++ b/spa/src/routes/reports.balance-sheet.tsx
@@ -1,18 +1,20 @@
 import { AsOfPicker } from '@/components/reports/AsOfPicker';
+import {
+  type ChartRange,
+  ChartRangeSelector,
+  filterPointsByRange,
+} from '@/components/reports/ChartRangeSelector';
 import { CurrencyFooter } from '@/components/reports/CurrencyFooter';
 import { KpiCard } from '@/components/reports/KpiCard';
 import { NetWorthChart } from '@/components/reports/NetWorthChart';
-import { ReportRowTable } from '@/components/reports/ReportRowTable';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { getBalances } from '@/lib/api';
 import { useBalanceSheet, useNetWorthSeries } from '@/lib/hooks/useReport';
 import { type AsOfSearchParams, parseAsOfSearch } from '@/lib/reports-search-params';
 import { useAmountFormat, useServerConfig } from '@/lib/server-config';
-import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { useMemo } from 'react';
+import { useState } from 'react';
 
 export const Route = createFileRoute('/reports/balance-sheet')({
   validateSearch: (s): AsOfSearchParams => parseAsOfSearch(s),
@@ -27,14 +29,7 @@ function BalanceSheetPage() {
   const navigate = useNavigate({ from: '/reports/balance-sheet' });
   const query = useBalanceSheet(search);
   const seriesQuery = useNetWorthSeries();
-
-  const balancesQuery = useQuery({ queryKey: ['balances'], queryFn: getBalances });
-  const nameToId = useMemo(() => {
-    const m = new Map<string, number>();
-    if (balancesQuery.data)
-      for (const row of balancesQuery.data.items) m.set(row.name, row.account_id);
-    return m;
-  }, [balancesQuery.data]);
+  const [chartRange, setChartRange] = useState<ChartRange>('1Y');
 
   const setAsOf = (v: number | undefined) =>
     navigate({ search: () => (v === undefined ? {} : { as_of: v }) });
@@ -70,7 +65,8 @@ function BalanceSheetPage() {
   const tl = result.total_liabilities[currency] ?? 0;
   const te = result.total_equity[currency] ?? 0;
   const nw = result.net_worth[currency] ?? 0;
-  const liabilities = (result.liabilities ?? []).filter((r) => r.currency === currency);
+  const liabilitiesCount = (result.liabilities ?? []).filter((r) => r.currency === currency)
+    .length;
 
   const assetsCount = (result.assets ?? []).filter((r) => r.currency === currency).length;
   const equityCount = (result.equity ?? []).filter((r) => r.currency === currency).length;
@@ -80,13 +76,14 @@ function BalanceSheetPage() {
     search.as_of !== undefined
       ? new Date(search.as_of * 1000).toISOString().slice(0, 10)
       : undefined;
-  const chartPoints = seriesForCurrency
+  const allChartPoints = seriesForCurrency
     ? asOfDate
       ? seriesForCurrency.points.filter((p) => p.date <= asOfDate)
       : seriesForCurrency.points
     : [];
+  const chartPoints = filterPointsByRange(allChartPoints, chartRange);
 
-  if (assetsCount === 0 && liabilities.length === 0 && equityCount === 0) {
+  if (assetsCount === 0 && liabilitiesCount === 0 && equityCount === 0) {
     return (
       <div className="space-y-4">
         <AsOfPicker label="As of" value={search.as_of} onChange={setAsOf} />
@@ -103,7 +100,7 @@ function BalanceSheetPage() {
         {assetsCount > 0 && (
           <KpiCard label="Total Assets" amount={ta} currency={currency} variant="green" />
         )}
-        {liabilities.length > 0 && (
+        {liabilitiesCount > 0 && (
           <KpiCard label="Total Liabilities" amount={tl} currency={currency} variant="red" />
         )}
         {equityCount > 0 && (
@@ -113,7 +110,12 @@ function BalanceSheetPage() {
       </div>
 
       <section>
-        <h2 className="mb-2 text-sm font-semibold">Net worth over time</h2>
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <h2 className="text-sm font-semibold">Net worth over time</h2>
+          {allChartPoints.length >= 2 && (
+            <ChartRangeSelector value={chartRange} onChange={setChartRange} />
+          )}
+        </div>
         {seriesQuery.isPending ? (
           <Skeleton className="h-48 w-full" />
         ) : seriesQuery.isError ? (
@@ -128,8 +130,12 @@ function BalanceSheetPage() {
               </Button>
             </AlertDescription>
           </Alert>
-        ) : chartPoints.length < 2 ? (
+        ) : allChartPoints.length < 2 ? (
           <p className="text-sm text-muted-foreground">Not enough history to chart net worth.</p>
+        ) : chartPoints.length < 2 ? (
+          <p className="text-sm text-muted-foreground">
+            Not enough history in this range. Try a longer range.
+          </p>
         ) : (
           <NetWorthChart
             points={chartPoints}
@@ -139,18 +145,6 @@ function BalanceSheetPage() {
           />
         )}
       </section>
-
-      {liabilities.length > 0 && (
-        <section>
-          <h2 className="mb-2 text-sm font-semibold">Liabilities</h2>
-          <ReportRowTable
-            rows={liabilities}
-            currency={currency}
-            nameToId={nameToId}
-            period={null}
-          />
-        </section>
-      )}
 
       <CurrencyFooter
         defaultCurrency={currency}


### PR DESCRIPTION
## Summary
- Add a 1M / 3M / YTD / 1Y / All range selector above the net-worth chart on the Balance Sheet page, defaulting to 1Y so long flat prefixes from early account history don't dominate the view.
- Remove the standalone Liabilities table from the Balance Sheet page; the total continues to appear in the KPI card row.

## Test plan
- [x] Open `/reports/balance-sheet` and confirm only KPI cards, net-worth chart, and currency footer render (no Liabilities table).
- [x] Confirm the range selector renders to the right of the chart heading and defaults to 1Y.
- [x] Click each range (1M / 3M / YTD / 1Y / All) and confirm the chart x-axis updates accordingly.
- [x] Confirm no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)