### PR TITLE
feat(spa): composition bar on Income/Expense Breakdown pages with row-cap scroll

### DIFF
--- a/docs/superpowers/plans/2026-06-24-report-row-table-scroll.md
+++ b/docs/superpowers/plans/2026-06-24-report-row-table-scroll.md
@@ -1,0 +1,334 @@
+# Breakdown Row Table 8-Row Scroll Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cap the `ReportRowTable` at 8 visible rows with a sticky header and vertical scroll on the Income/Expense Breakdown pages, leaving Balance Sheet's usage unchanged.
+
+**Architecture:** `ReportRowTable` gains an optional `maxVisibleRows?: number` prop. When set, the table is wrapped in a scroll container whose `max-height` is `(rows * 2 + 2)rem` (accounting for the 2rem-tall sticky header), and the existing `<thead>` becomes `sticky top-0 z-10 bg-background`. When unset, the rendering is byte-identical to today.
+
+**Tech Stack:** React 18 + TypeScript, Tailwind CSS (inline `style` for the dynamic max-height because Tailwind's JIT can't template arbitrary runtime classnames), Vitest + Testing Library. No new dependencies.
+
+Spec: `docs/superpowers/specs/2026-06-24-report-row-table-scroll-design.md`
+
+---
+
+## File Map
+
+**Frontend — modify:**
+- `spa/src/components/reports/ReportRowTable.tsx` — new optional prop, conditional scroll wrapper, sticky header classes.
+- `spa/src/test/components/ReportRowTable.test.tsx` — 2 new tests (wrapper absent when prop unset; wrapper + sticky-header present when prop set).
+- `spa/src/routes/reports.expense-breakdown.tsx` — pass `maxVisibleRows={8}`.
+- `spa/src/routes/reports.income-breakdown.tsx` — pass `maxVisibleRows={8}`.
+- `internal/web/dist/index.html` — refresh bundle placeholder so `kea serve` picks up the change.
+
+**Frontend — leave untouched:**
+- `spa/src/routes/reports.balance-sheet.tsx` — does not pass the new prop, so its Liabilities table renders unchanged.
+
+---
+
+## Conventions
+
+- Run tests from `/Users/hance/programming/kea` with `cd spa && npm test -- <pattern>`.
+- Run lint/typecheck with `cd spa && npm run check && tsc -b`. 3 pre-existing errors in `ChartRangeSelector.tsx`, `NetWorthChart.tsx`, and `reports.income-statement.tsx:32` are not yours.
+- The full `npm test` suite has 6 pre-existing failures in `balances.test.tsx` and `balances.link.test.tsx` — confirmed not caused by this work.
+- Bundle build: `cd spa && npm run build`. Only commit `internal/web/dist/index.html` (the rest under `dist/` is gitignored).
+
+---
+
+## Task 1: Add `maxVisibleRows` prop with scroll wrapper and sticky header
+
+**Files:**
+- Modify: `spa/src/components/reports/ReportRowTable.tsx`
+- Modify: `spa/src/test/components/ReportRowTable.test.tsx`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `spa/src/test/components/ReportRowTable.test.tsx`:
+
+```tsx
+test('ReportRowTable: no scroll wrapper when maxVisibleRows is undefined', () => {
+  const { container } = render(
+    withServerConfig(
+      <ReportRowTable rows={rows} currency="USD" nameToId={nameToId} period={null} />,
+    ),
+  );
+  expect(container.querySelector('[data-testid="report-row-scroll"]')).toBeNull();
+});
+
+test('ReportRowTable: scroll wrapper and sticky header when maxVisibleRows is set', () => {
+  const { container } = render(
+    withServerConfig(
+      <ReportRowTable
+        rows={rows}
+        currency="USD"
+        nameToId={nameToId}
+        period={null}
+        maxVisibleRows={8}
+      />,
+    ),
+  );
+  const wrapper = container.querySelector<HTMLElement>('[data-testid="report-row-scroll"]');
+  expect(wrapper).not.toBeNull();
+  expect(wrapper?.className).toContain('overflow-y-auto');
+  // 8 rows × 2rem + 2rem (sticky header) = 18rem
+  expect(wrapper?.style.maxHeight).toBe('18rem');
+
+  const thead = container.querySelector('thead');
+  expect(thead?.className).toContain('sticky');
+  expect(thead?.className).toContain('top-0');
+});
+```
+
+- [ ] **Step 2: Run tests to verify failures**
+
+Run: `cd spa && npm test -- ReportRowTable`
+
+Expected: 2 new tests fail — `report-row-scroll` testid not found; the `maxVisibleRows` prop is rejected by TypeScript (compile error surfaces as failed render).
+
+- [ ] **Step 3: Implement the prop and conditional wrapping**
+
+Edit `spa/src/components/reports/ReportRowTable.tsx`:
+
+- Add to the `Props` interface (place under the existing `swatchColors?: string[]` field):
+
+```ts
+// when set, the table scrolls vertically and the header sticks to the top
+// after this many rows fit. Unset → render unchanged (no wrapper, no sticky).
+maxVisibleRows?: number;
+```
+
+- Update the destructure in the function signature:
+
+```ts
+export function ReportRowTable({
+  rows,
+  currency,
+  nameToId,
+  period,
+  swatchColors,
+  maxVisibleRows,
+}: Props) {
+```
+
+- After the existing early `if (rows.length === 0) return …` guard, but before the `return (` block, build the table element once and wrap it conditionally. Replace the entire `return ( <table …> … </table> );` with the block below. Note the `<thead>` inside this block also picks up the conditional sticky classes — that's the single source of truth for the header markup; there is no separate `<thead>` change.
+
+```tsx
+const table = (
+  <table className="w-full text-sm">
+    <thead
+      className={cn(
+        'text-xs uppercase text-muted-foreground',
+        maxVisibleRows !== undefined && 'sticky top-0 z-10 bg-background',
+      )}
+    >
+      <tr>
+        <th className="py-1 text-left font-medium">Account</th>
+        <th className="py-1 text-left font-medium">Offset</th>
+        <th className="py-1 text-right font-medium">Amount</th>
+        <th className="py-1 text-right font-medium">Tx</th>
+      </tr>
+    </thead>
+    <tbody>
+      {rows.map((row, rowIndex) => {
+        const id = nameToId.get(row.account_name);
+        const labelSpan = (
+          <span className="truncate" title={row.account_name}>
+            {stripAccountTypePrefix(row.account_name)}
+          </span>
+        );
+        const swatch = swatchColors?.[rowIndex] ? (
+          <span
+            data-testid="row-swatch"
+            className={cn(
+              'mr-2 inline-block h-2 w-2 rounded-[2px] align-middle',
+              swatchColors[rowIndex],
+            )}
+            aria-hidden="true"
+          />
+        ) : null;
+        const linkContent = swatch ? (
+          <span className="inline-flex min-w-0 items-center">
+            {swatch}
+            {labelSpan}
+          </span>
+        ) : (
+          labelSpan
+        );
+        return (
+          <tr key={row.account_name} className="border-t hover:bg-muted/40">
+            <td className="py-1.5 max-w-[260px]">
+              {period === null ? (
+                id !== undefined ? (
+                  <Link
+                    to="/accounts/$id"
+                    params={{ id: String(id) }}
+                    search={{ include_hidden: false, show_parents: false, limit: 10, offset: 0 }}
+                    className="hover:underline"
+                  >
+                    {linkContent}
+                  </Link>
+                ) : (
+                  linkContent
+                )
+              ) : (
+                <Link
+                  to="/transactions"
+                  search={{
+                    ...(id !== undefined ? { account_id: id } : {}),
+                    start_time: period.startUnix,
+                    end_time: period.endUnix,
+                    limit: DEFAULT_TRANSACTIONS_LIMIT,
+                    offset: 0,
+                  }}
+                  className="hover:underline"
+                >
+                  {linkContent}
+                </Link>
+              )}
+            </td>
+            <td className="py-1.5 text-muted-foreground" title={row.offset_account}>
+              {stripAccountTypePrefix(row.offset_account)}
+            </td>
+            <td className="py-1.5 text-right font-mono tabular-nums">
+              {formatCents(row.amount, currency)}
+            </td>
+            <td className="py-1.5 text-right text-muted-foreground">{row.tx_count}</td>
+          </tr>
+        );
+      })}
+    </tbody>
+  </table>
+);
+
+if (maxVisibleRows === undefined) return table;
+
+return (
+  <div
+    data-testid="report-row-scroll"
+    className="overflow-y-auto rounded-md border"
+    style={{ maxHeight: `${maxVisibleRows * 2 + 2}rem` }}
+  >
+    {table}
+  </div>
+);
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd spa && npm test -- ReportRowTable`
+
+Expected: all 4 tests in this file pass (2 previously existing + 2 new).
+
+- [ ] **Step 5: Type-check and lint**
+
+Run: `cd spa && npm run check && tsc -b`
+
+Expected: 3 pre-existing errors unrelated to this file. No new errors on `ReportRowTable.tsx` or its test. If Biome rewrites your formatting, accept with `npx biome check --write src/components/reports/ReportRowTable.tsx` and re-run the tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add spa/src/components/reports/ReportRowTable.tsx spa/src/test/components/ReportRowTable.test.tsx
+git commit -m "feat(spa): optional row-cap scroll + sticky header in ReportRowTable"
+```
+
+---
+
+## Task 2: Wire `maxVisibleRows={8}` into both breakdown pages
+
+**Files:**
+- Modify: `spa/src/routes/reports.expense-breakdown.tsx`
+- Modify: `spa/src/routes/reports.income-breakdown.tsx`
+
+- [ ] **Step 1: Edit Expense Breakdown page**
+
+In `spa/src/routes/reports.expense-breakdown.tsx`, find the `<ReportRowTable>` element. Add `maxVisibleRows={8}` to its prop list. Final element:
+
+```tsx
+<ReportRowTable
+  rows={rows}
+  currency={currency}
+  nameToId={nameToId}
+  period={{ startUnix: period.startUnix, endUnix: period.endUnix }}
+  swatchColors={swatchColors}
+  maxVisibleRows={8}
+/>
+```
+
+- [ ] **Step 2: Edit Income Breakdown page**
+
+Same change in `spa/src/routes/reports.income-breakdown.tsx` — add `maxVisibleRows={8}` to the `<ReportRowTable>` prop list.
+
+- [ ] **Step 3: Run the breakdown page tests**
+
+Run: `cd spa && npm test -- reports.income-breakdown reports.expense-breakdown`
+
+Expected: both files pass. The existing tests query by `data-testid="row-swatch"` and `data-testid="composition-segment"`; both still render inside the new scroll wrapper so the queries continue to work.
+
+- [ ] **Step 4: Run the full breakdown-related suite as belt and suspenders**
+
+Run: `cd spa && npm test -- reports`
+
+Expected: all matching tests pass except the 6 pre-existing `balances*` failures (those don't match `reports`, so this command won't surface them anyway).
+
+- [ ] **Step 5: Type-check and lint**
+
+Run: `cd spa && npm run check && tsc -b`
+
+Expected: still just the 3 pre-existing errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add spa/src/routes/reports.expense-breakdown.tsx spa/src/routes/reports.income-breakdown.tsx
+git commit -m "feat(spa): cap breakdown row tables at 8 visible rows"
+```
+
+---
+
+## Task 3: Rebuild and commit the embedded SPA bundle
+
+**Files:**
+- Modify: `internal/web/dist/index.html` (the rest of `dist/` is gitignored).
+
+- [ ] **Step 1: Build the SPA**
+
+Run: `cd spa && npm run build`
+
+Expected: build succeeds, no errors. The build writes new hashed asset files under `internal/web/dist/assets/`, and `internal/web/dist/index.html` updates its `<script>` / `<link>` references to the new hashes.
+
+- [ ] **Step 2: Check the index.html diff**
+
+Run: `cd /Users/hance/programming/kea && git diff -- internal/web/dist/index.html`
+
+Expected: a small diff updating the asset hash filenames in the `<script type="module" src="…">` and `<link rel="stylesheet" href="…">` attributes.
+
+- [ ] **Step 3: Commit if changed**
+
+```bash
+git add internal/web/dist/index.html
+git commit -m "build(spa): refresh embedded bundle"
+```
+
+If `git status` shows `internal/web/dist/index.html` is unchanged after the build (unlikely, since the source changed), no commit is needed.
+
+- [ ] **Step 4: Final sanity check**
+
+Run: `cd /Users/hance/programming/kea && git log --oneline fb3d940..HEAD`
+
+Expected: three new commits, in order:
+
+```
+<sha> build(spa): refresh embedded bundle
+<sha> feat(spa): cap breakdown row tables at 8 visible rows
+<sha> feat(spa): optional row-cap scroll + sticky header in ReportRowTable
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage**: every requirement maps to a task. Prop name and signature (T1), conditional wrapper and sticky header (T1), inline-style max-height formula `(rows × 2 + 2)rem` (T1 Step 3 + test in T1 Step 1), two new tests (T1 Step 1), `maxVisibleRows={8}` on both breakdown pages (T2), bundle rebuild (T3).
+- **Out of scope respected**: Balance Sheet (`reports.balance-sheet.tsx`) is not modified, so its Liabilities table stays unscrolled — matches spec.
+- **No placeholders**: every step has the actual code or the actual command + expected output.
+- **Type consistency**: `maxVisibleRows?: number` defined once in T1, consumed unchanged in T2's prop usage.

--- a/docs/superpowers/plans/2026-06-24-spa-breakdown-composition-bar.md
+++ b/docs/superpowers/plans/2026-06-24-spa-breakdown-composition-bar.md
@@ -1,0 +1,1223 @@
+# SPA Breakdown Composition Bar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the per-row `ProportionBar` on `/reports/income-breakdown` and `/reports/expense-breakdown` with a single compact `CompositionBar`; the existing detail table acts as the bar's legend via colored swatches per row.
+
+**Architecture:** A new `CompositionBar.tsx` component renders one horizontal bar with up to 6 colored segments plus an optional "Other" segment, with inline labels on wide-enough segments and hover tooltips. A pure helper `partitionForComposition` produces both the bar segments and a parallel `swatchColors` array for the table. `ReportRowTable` gains an optional `swatchColors` prop. The Income/Expense Breakdown route components swap `ProportionBar` for `CompositionBar` and pass swatches to the table. `ProportionBar` itself stays — Income Statement still uses it.
+
+**Tech Stack:** React 18 + TypeScript, Tailwind CSS (existing palette only — no new colors), Vitest + Testing Library, `clsx`/`cn` for class composition. No new dependencies.
+
+Spec: `docs/superpowers/specs/2026-06-24-spa-breakdown-composition-bar-design.md`
+
+---
+
+## File Map
+
+**Frontend — create:**
+- `spa/src/components/reports/CompositionBar.tsx` — bar component + `partitionForComposition` helper + `CompositionSegment` type.
+- `spa/src/test/reports.composition-bar.test.tsx` — component + helper tests.
+
+**Frontend — modify:**
+- `spa/src/components/reports/ReportRowTable.tsx` — add optional `swatchColors?: string[]` prop and render a swatch dot before each account name when provided.
+- `spa/src/routes/reports.income-breakdown.tsx` — replace `ProportionBar` with `CompositionBar`, derive `swatchColors`, pass to `ReportRowTable`.
+- `spa/src/routes/reports.expense-breakdown.tsx` — same as above for expenses.
+- `spa/src/test/reports.income-breakdown.test.tsx` — add assertions for the composition bar and swatch dots.
+- `spa/src/test/reports.expense-breakdown.test.tsx` — same.
+
+**Frontend — leave untouched:**
+- `spa/src/components/reports/ProportionBar.tsx` and `spa/src/test/reports.proportion-bar.test.tsx` — still used by Income Statement.
+- `spa/src/routes/reports.income-statement.tsx` — unchanged.
+
+---
+
+## Conventions used throughout
+
+- All new files: no copyright header (matches existing SPA components like `NetWorthChart.tsx`).
+- Type imports from `@/lib/types` (e.g. `ReportRow`).
+- Class composition via `cn` from `@/lib/cn`.
+- Money formatting via `useAmountFormat()` from `@/lib/server-config`.
+- Account label stripping via `stripAccountTypePrefix` from `@/lib/accounts`.
+
+---
+
+## Task 1: Add `partitionForComposition` helper with tests
+
+This is a pure function — implement and test first so later tasks can rely on it without doubt.
+
+**Files:**
+- Create: `spa/src/components/reports/CompositionBar.tsx` (helper + types only at this task)
+- Create: `spa/src/test/reports.composition-bar.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `spa/src/test/reports.composition-bar.test.tsx`:
+
+```tsx
+import { expect, test } from 'vitest';
+import { partitionForComposition } from '../components/reports/CompositionBar';
+import type { ReportRow } from '../lib/types';
+
+const row = (name: string, amount: number, offset = ''): ReportRow => ({
+  account_name: name,
+  offset_account: offset,
+  amount,
+  currency: 'USD',
+  tx_count: 1,
+});
+
+test('partition: returns one segment per row when rows ≤ 6', () => {
+  const rows = [
+    row('Rent', 1800),
+    row('Groceries', 642),
+    row('Dining', 520),
+  ];
+  const { segments, swatchColors } = partitionForComposition(rows, 2962, 'expense');
+  expect(segments).toHaveLength(3);
+  expect(segments[0].label).toBe('Rent');
+  expect(segments[0].amount).toBe(1800);
+  expect(segments[0].isOther).toBe(false);
+  expect(swatchColors).toHaveLength(3);
+});
+
+test('partition: rows beyond top 6 collapse into a single Other segment', () => {
+  const rows = [
+    row('A', 1000), row('B', 900), row('C', 800), row('D', 700),
+    row('E', 600), row('F', 500), row('G', 400), row('H', 300), row('I', 200),
+  ];
+  const total = 5400;
+  const { segments } = partitionForComposition(rows, total, 'expense');
+  expect(segments).toHaveLength(7); // top 6 + Other
+  const other = segments[6];
+  expect(other.isOther).toBe(true);
+  expect(other.amount).toBe(900); // G+H+I = 400+300+200
+  expect(other.label).toBe('Other (3)');
+});
+
+test('partition: sorts segments by |amount| descending', () => {
+  const rows = [
+    row('Small', 100),
+    row('Big', 5000),
+    row('Mid', 1000),
+  ];
+  const { segments } = partitionForComposition(rows, 6100, 'expense');
+  expect(segments.map((s) => s.label)).toEqual(['Big', 'Mid', 'Small']);
+});
+
+test('partition: segment pcts use |total| as denominator', () => {
+  const rows = [row('A', -1000), row('B', -3000)];
+  const { segments } = partitionForComposition(rows, -4000, 'expense');
+  expect(segments[0].pct).toBeCloseTo(75, 5);
+  expect(segments[1].pct).toBeCloseTo(25, 5);
+});
+
+test('partition: total of 0 yields pct=0 for every segment (no NaN)', () => {
+  const rows = [row('A', 0), row('B', 0)];
+  const { segments } = partitionForComposition(rows, 0, 'expense');
+  expect(segments.every((s) => s.pct === 0)).toBe(true);
+});
+
+test('partition: expense variant uses red gradient, income uses emerald', () => {
+  const rows = [row('A', 100)];
+  expect(partitionForComposition(rows, 100, 'expense').segments[0].colorClass).toBe('bg-red-700');
+  expect(partitionForComposition(rows, 100, 'income').segments[0].colorClass).toBe('bg-emerald-700');
+});
+
+test('partition: swatchColors is parallel to input rows (not segment order)', () => {
+  // Big-Mid-Small is the sort order for segments, but the table needs
+  // colors in input order: Small, Big, Mid.
+  const rows = [
+    row('Small', 100),
+    row('Big', 5000),
+    row('Mid', 1000),
+  ];
+  const { swatchColors, segments } = partitionForComposition(rows, 6100, 'expense');
+  // The "Big" row (input index 1) maps to the darkest shade.
+  expect(swatchColors[1]).toBe(segments[0].colorClass);
+  // "Mid" → second darkest, "Small" → third darkest.
+  expect(swatchColors[2]).toBe(segments[1].colorClass);
+  expect(swatchColors[0]).toBe(segments[2].colorClass);
+});
+
+test('partition: rows beyond top 6 get the Other (neutral) swatch', () => {
+  const rows = [
+    row('A', 1000), row('B', 900), row('C', 800), row('D', 700),
+    row('E', 600), row('F', 500), row('G', 400),
+  ];
+  const { swatchColors, segments } = partitionForComposition(rows, 4900, 'expense');
+  const otherSeg = segments.find((s) => s.isOther);
+  expect(otherSeg).toBeDefined();
+  expect(swatchColors[6]).toBe(otherSeg?.colorClass); // G is collapsed
+});
+```
+
+- [ ] **Step 2: Run tests to verify they all fail (import error)**
+
+Run: `cd spa && npm test -- reports.composition-bar`
+
+Expected: All tests fail because `CompositionBar.tsx` does not yet export `partitionForComposition`.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `spa/src/components/reports/CompositionBar.tsx`:
+
+```tsx
+import type { ReportRow } from '@/lib/types';
+
+export type CompositionVariant = 'income' | 'expense';
+
+export interface CompositionSegment {
+  label: string;            // account name (stripped of type prefix), or "Other (N)"
+  amount: number;           // |amount|
+  pct: number;              // 0..100, exact (not rounded)
+  colorClass: string;       // Tailwind background class
+  textClass: string;        // Tailwind text class for in-segment label contrast
+  isOther: boolean;
+}
+
+const GRADIENT: Record<CompositionVariant, { bg: string; text: string }[]> = {
+  expense: [
+    { bg: 'bg-red-700', text: 'text-white' },
+    { bg: 'bg-red-600', text: 'text-white' },
+    { bg: 'bg-red-500', text: 'text-white' },
+    { bg: 'bg-red-400', text: 'text-white' },
+    { bg: 'bg-red-300', text: 'text-red-900' },
+    { bg: 'bg-red-200', text: 'text-red-900' },
+  ],
+  income: [
+    { bg: 'bg-emerald-700', text: 'text-white' },
+    { bg: 'bg-emerald-600', text: 'text-white' },
+    { bg: 'bg-emerald-500', text: 'text-white' },
+    { bg: 'bg-emerald-400', text: 'text-white' },
+    { bg: 'bg-emerald-300', text: 'text-emerald-900' },
+    { bg: 'bg-emerald-200', text: 'text-emerald-900' },
+  ],
+};
+
+const OTHER_BG = 'bg-slate-300';
+const OTHER_TEXT = 'text-slate-700';
+
+// Strip an account-type prefix like "Expenses:" or "Income:".
+// Mirrors stripAccountTypePrefix from @/lib/accounts but inline so this
+// helper has no surprise import cycles when used in tests.
+function shortLabel(name: string): string {
+  const i = name.indexOf(':');
+  return i >= 0 ? name.slice(i + 1) : name;
+}
+
+export function partitionForComposition(
+  rows: ReportRow[],
+  total: number,
+  variant: CompositionVariant,
+  topN = 6,
+): { segments: CompositionSegment[]; swatchColors: string[] } {
+  const palette = GRADIENT[variant];
+  const denom = Math.abs(total);
+
+  // Sort by |amount| descending, but remember each row's original index so
+  // we can build a parallel swatchColors array.
+  const indexed = rows.map((r, i) => ({ row: r, i }));
+  indexed.sort((a, b) => Math.abs(b.row.amount) - Math.abs(a.row.amount));
+
+  const swatchColors: string[] = new Array(rows.length).fill(OTHER_BG);
+  const segments: CompositionSegment[] = [];
+
+  const primary = indexed.slice(0, topN);
+  const rest = indexed.slice(topN);
+
+  primary.forEach(({ row, i }, segIdx) => {
+    const color = palette[segIdx];
+    const amount = Math.abs(row.amount);
+    segments.push({
+      label: shortLabel(row.account_name),
+      amount,
+      pct: denom === 0 ? 0 : (amount / denom) * 100,
+      colorClass: color.bg,
+      textClass: color.text,
+      isOther: false,
+    });
+    swatchColors[i] = color.bg;
+  });
+
+  if (rest.length > 0) {
+    const sum = rest.reduce((acc, { row }) => acc + Math.abs(row.amount), 0);
+    segments.push({
+      label: `Other (${rest.length})`,
+      amount: sum,
+      pct: denom === 0 ? 0 : (sum / denom) * 100,
+      colorClass: OTHER_BG,
+      textClass: OTHER_TEXT,
+      isOther: true,
+    });
+    // swatchColors for rest indices remain OTHER_BG (already set above).
+  } else {
+    // No rest → swatchColors for indices beyond primary should not exist;
+    // but rows.length === primary.length here, so the fill is harmless.
+  }
+
+  return { segments, swatchColors };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd spa && npm test -- reports.composition-bar`
+
+Expected: All 8 helper tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/components/reports/CompositionBar.tsx spa/src/test/reports.composition-bar.test.tsx
+git commit -m "feat(spa): add partitionForComposition helper for breakdown bar"
+```
+
+---
+
+## Task 2: Render the CompositionBar with segment widths and palette
+
+Implement the bar element itself — segments, widths, classes — without inline labels, tooltip, or ticks yet.
+
+**Files:**
+- Modify: `spa/src/components/reports/CompositionBar.tsx`
+- Modify: `spa/src/test/reports.composition-bar.test.tsx`
+
+- [ ] **Step 1: Add failing tests for the component**
+
+Append to `spa/src/test/reports.composition-bar.test.tsx`:
+
+```tsx
+import { render as rtlRender } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { CompositionBar } from '../components/reports/CompositionBar';
+import { withServerConfig } from './test-app';
+
+// All component tests wrap with withServerConfig so they keep working once
+// Task 4 adds useAmountFormat() to the component.
+const renderBar = (ui: ReactNode) => rtlRender(withServerConfig(ui));
+
+test('component: returns null when rows is empty', () => {
+  const { container } = renderBar(
+    <CompositionBar rows={[]} total={0} currency="USD" variant="expense" />,
+  );
+  // ServerConfig wrapper renders, but the component itself returns null.
+  expect(container.querySelector('[data-testid="composition-bar"]')).toBeNull();
+});
+
+test('component: returns null when total is 0', () => {
+  const rows = [row('A', 0)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={0} currency="USD" variant="expense" />,
+  );
+  expect(container.querySelector('[data-testid="composition-bar"]')).toBeNull();
+});
+
+test('component: renders one DOM segment per partition segment', () => {
+  const rows = [row('Rent', 1800), row('Groceries', 642), row('Dining', 520)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={2962} currency="USD" variant="expense" />,
+  );
+  const segs = container.querySelectorAll('[data-testid="composition-segment"]');
+  expect(segs).toHaveLength(3);
+});
+
+test('component: segment widths reflect partition pcts', () => {
+  const rows = [row('A', 7500), row('B', 2500)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={10000} currency="USD" variant="expense" />,
+  );
+  const segs = container.querySelectorAll<HTMLElement>(
+    '[data-testid="composition-segment"]',
+  );
+  expect(segs[0].style.width).toBe('75%');
+  expect(segs[1].style.width).toBe('25%');
+});
+
+test('component: expense variant applies red gradient to biggest segment', () => {
+  const rows = [row('A', 100)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={100} currency="USD" variant="expense" />,
+  );
+  const seg = container.querySelector('[data-testid="composition-segment"]');
+  expect(seg?.className).toContain('bg-red-700');
+});
+
+test('component: container has role=img and an aria-label', () => {
+  const rows = [row('Rent', 1800), row('Groceries', 642), row('Dining', 520)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={2962} currency="USD" variant="expense" />,
+  );
+  const bar = container.querySelector('[data-testid="composition-bar"]');
+  expect(bar?.getAttribute('role')).toBe('img');
+  expect(bar?.getAttribute('aria-label')).toMatch(/Rent/);
+});
+```
+
+- [ ] **Step 2: Run tests to confirm failures**
+
+Run: `cd spa && npm test -- reports.composition-bar`
+
+Expected: 6 new tests fail because `CompositionBar` is not exported.
+
+- [ ] **Step 3: Implement the component**
+
+Append to `spa/src/components/reports/CompositionBar.tsx`:
+
+```tsx
+import { cn } from '@/lib/cn';
+import type { ReportRow } from '@/lib/types';
+
+interface Props {
+  rows: ReportRow[];
+  total: number;
+  currency: string;
+  variant: CompositionVariant;
+  className?: string;
+}
+
+function buildAriaLabel(segments: CompositionSegment[], variant: CompositionVariant): string {
+  const which = variant === 'income' ? 'Income' : 'Expense';
+  const top = segments.slice(0, 3).map((s) => `${s.label} ${Math.round(s.pct)}%`).join(', ');
+  return `${which} composition: ${top}`;
+}
+
+export function CompositionBar({ rows, total, currency: _currency, variant, className }: Props) {
+  if (rows.length === 0 || total === 0) return null;
+  const { segments } = partitionForComposition(rows, total, variant);
+  return (
+    <div
+      data-testid="composition-bar"
+      role="img"
+      aria-label={buildAriaLabel(segments, variant)}
+      className={cn('flex h-7 w-full overflow-hidden rounded text-[10px] font-medium', className)}
+    >
+      {segments.map((seg, i) => (
+        <div
+          // Segment indices are stable within a single render; rows are not
+          // mutated mid-render, so index keys are safe here.
+          key={i}
+          data-testid="composition-segment"
+          className={cn('flex items-center justify-start', seg.colorClass, seg.textClass)}
+          style={{ width: `${seg.pct}%` }}
+          title={`${seg.label}: ${Math.round(seg.pct)}%`}
+        />
+      ))}
+    </div>
+  );
+}
+```
+
+Note: the import for `cn` and the unused-currency rename (`_currency`) prevent the lint/TS noise; currency will be used in Task 4 (tooltip).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd spa && npm test -- reports.composition-bar`
+
+Expected: All 14 tests pass (8 helper + 6 component).
+
+- [ ] **Step 5: Type-check and lint**
+
+Run: `cd spa && npm run check && tsc -b --noEmit`
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add spa/src/components/reports/CompositionBar.tsx spa/src/test/reports.composition-bar.test.tsx
+git commit -m "feat(spa): render CompositionBar segments with width and palette"
+```
+
+---
+
+## Task 3: Add inline segment labels and tick markers
+
+Show `name · NN%` inline on segments ≥9%, just `NN%` between 5–9%, nothing below 5%. Add the 0% / 50% / 100% tick row.
+
+**Files:**
+- Modify: `spa/src/components/reports/CompositionBar.tsx`
+- Modify: `spa/src/test/reports.composition-bar.test.tsx`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `spa/src/test/reports.composition-bar.test.tsx`:
+
+```tsx
+test('inline label: segment ≥9% shows "name · NN%"', () => {
+  // 1800/2962 ≈ 60.8% → ≥9%
+  const rows = [row('Rent', 1800), row('Groceries', 642), row('Dining', 520)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={2962} currency="USD" variant="expense" />,
+  );
+  const big = container.querySelectorAll<HTMLElement>(
+    '[data-testid="composition-segment"]',
+  )[0];
+  expect(big.textContent).toContain('Rent');
+  expect(big.textContent).toMatch(/61%/);
+});
+
+test('inline label: segment between 5% and 9% shows only "NN%"', () => {
+  // Construct: total 100, one row at 7
+  const rows = [row('Big', 93), row('Tiny', 7)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={100} currency="USD" variant="expense" />,
+  );
+  const small = container.querySelectorAll<HTMLElement>(
+    '[data-testid="composition-segment"]',
+  )[1];
+  expect(small.textContent?.trim()).toBe('7%');
+  expect(small.textContent).not.toContain('Tiny');
+});
+
+test('inline label: segment <5% shows nothing', () => {
+  const rows = [row('Big', 98), row('Tiny', 2)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={100} currency="USD" variant="expense" />,
+  );
+  const small = container.querySelectorAll<HTMLElement>(
+    '[data-testid="composition-segment"]',
+  )[1];
+  expect(small.textContent?.trim()).toBe('');
+});
+
+test('ticks: 0% / 50% / 100% labels render below the bar', () => {
+  const rows = [row('A', 100)];
+  const { getByText } = renderBar(
+    <CompositionBar rows={rows} total={100} currency="USD" variant="expense" />,
+  );
+  expect(getByText('0%')).toBeInTheDocument();
+  expect(getByText('50%')).toBeInTheDocument();
+  expect(getByText('100%')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run tests to confirm failures**
+
+Run: `cd spa && npm test -- reports.composition-bar`
+
+Expected: The 4 new tests fail (no inline labels, no ticks).
+
+- [ ] **Step 3: Update the component**
+
+Edit `spa/src/components/reports/CompositionBar.tsx`. Replace the `CompositionBar` function body with:
+
+```tsx
+function labelFor(seg: CompositionSegment): string {
+  const rounded = Math.round(seg.pct);
+  if (seg.pct >= 9) return `${seg.label} · ${rounded}%`;
+  if (seg.pct >= 5) return `${rounded}%`;
+  return '';
+}
+
+export function CompositionBar({ rows, total, currency: _currency, variant, className }: Props) {
+  if (rows.length === 0 || total === 0) return null;
+  const { segments } = partitionForComposition(rows, total, variant);
+  return (
+    <div className={cn('w-full', className)}>
+      <div
+        data-testid="composition-bar"
+        role="img"
+        aria-label={buildAriaLabel(segments, variant)}
+        className="flex h-7 w-full overflow-hidden rounded text-[10px] font-medium"
+      >
+        {segments.map((seg, i) => (
+          <div
+            key={i}
+            data-testid="composition-segment"
+            className={cn(
+              'flex items-center overflow-hidden whitespace-nowrap',
+              seg.colorClass,
+              seg.textClass,
+              seg.pct >= 9 ? 'px-1.5' : seg.pct >= 5 ? 'px-1 justify-center' : '',
+            )}
+            style={{ width: `${seg.pct}%` }}
+            title={`${seg.label}: ${Math.round(seg.pct)}%`}
+          >
+            {labelFor(seg)}
+          </div>
+        ))}
+      </div>
+      <div className="mt-1 flex justify-between text-[9px] text-muted-foreground">
+        <span>0%</span>
+        <span>50%</span>
+        <span>100%</span>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd spa && npm test -- reports.composition-bar`
+
+Expected: All 18 tests pass.
+
+- [ ] **Step 5: Type-check and lint**
+
+Run: `cd spa && npm run check && tsc -b --noEmit`
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add spa/src/components/reports/CompositionBar.tsx spa/src/test/reports.composition-bar.test.tsx
+git commit -m "feat(spa): inline segment labels and tick row for CompositionBar"
+```
+
+---
+
+## Task 4: Add hover tooltip and keyboard focus accessibility
+
+On hover or keyboard focus of any segment, show a tooltip with full account name, formatted amount, and percent; dim other segments. Make segments focusable buttons with the same behavior on focus.
+
+**Files:**
+- Modify: `spa/src/components/reports/CompositionBar.tsx`
+- Modify: `spa/src/test/reports.composition-bar.test.tsx`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `spa/src/test/reports.composition-bar.test.tsx`:
+
+```tsx
+import { withServerConfig } from './test-app';
+import userEvent from '@testing-library/user-event';
+
+test('a11y: segments are focusable buttons', () => {
+  const rows = [row('Rent', 1800), row('Groceries', 642)];
+  const { container } = render(
+    withServerConfig(
+      <CompositionBar rows={rows} total={2442} currency="USD" variant="expense" />,
+    ),
+  );
+  const segs = container.querySelectorAll<HTMLElement>(
+    '[data-testid="composition-segment"]',
+  );
+  expect(segs[0].tagName).toBe('BUTTON');
+  expect(segs[0].getAttribute('type')).toBe('button');
+});
+
+test('tooltip: hovering a segment shows name, amount, and percent', async () => {
+  const user = userEvent.setup();
+  const rows = [row('Rent', 180000), row('Groceries', 64200)];
+  const { container, findByText } = render(
+    withServerConfig(
+      <CompositionBar rows={rows} total={244200} currency="USD" variant="expense" />,
+    ),
+  );
+  const seg = container.querySelector<HTMLElement>(
+    '[data-testid="composition-segment"]',
+  )!;
+  await user.hover(seg);
+  // formatCents("USD", 180000) → "$1,800.00" with default config
+  expect(await findByText('$1,800.00')).toBeInTheDocument();
+  expect(await findByText('Rent')).toBeInTheDocument();
+});
+
+test('tooltip: hovered segment dims the others (opacity-60 on non-hovered)', async () => {
+  const user = userEvent.setup();
+  const rows = [row('A', 60), row('B', 40)];
+  const { container } = render(
+    withServerConfig(
+      <CompositionBar rows={rows} total={100} currency="USD" variant="expense" />,
+    ),
+  );
+  const segs = container.querySelectorAll<HTMLElement>(
+    '[data-testid="composition-segment"]',
+  );
+  await user.hover(segs[0]);
+  // Hovered segment NOT dimmed; sibling dimmed.
+  expect(segs[0].className).not.toContain('opacity-60');
+  expect(segs[1].className).toContain('opacity-60');
+});
+
+test('tooltip: keyboard focus also activates the tooltip', async () => {
+  const user = userEvent.setup();
+  const rows = [row('Rent', 180000), row('Groceries', 64200)];
+  const { container, findByText } = render(
+    withServerConfig(
+      <CompositionBar rows={rows} total={244200} currency="USD" variant="expense" />,
+    ),
+  );
+  const seg = container.querySelector<HTMLElement>(
+    '[data-testid="composition-segment"]',
+  )!;
+  seg.focus();
+  // Same content as hover tooltip.
+  expect(await findByText('$1,800.00')).toBeInTheDocument();
+  // Tab to next segment; tooltip swaps.
+  await user.tab();
+  expect(await findByText('$642.00')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run tests to confirm failures**
+
+Run: `cd spa && npm test -- reports.composition-bar`
+
+Expected: 4 new tests fail.
+
+- [ ] **Step 3: Add original account name to segments and rewrite the component**
+
+First, extend the partition output so the tooltip has the full (non-stripped) account name and stripped label both available.
+
+Edit `partitionForComposition` in `spa/src/components/reports/CompositionBar.tsx` — replace the primary-loop body so it stores the original name:
+
+```tsx
+// In the CompositionSegment interface, add:
+//   fullName: string; // for "Other": "Other (N)"; same as label otherwise
+```
+
+Update the interface:
+
+```tsx
+export interface CompositionSegment {
+  label: string;
+  fullName: string;
+  amount: number;
+  pct: number;
+  colorClass: string;
+  textClass: string;
+  isOther: boolean;
+}
+```
+
+In `partitionForComposition`, when pushing a primary segment, include `fullName: row.account_name`. For the Other segment, set `fullName` equal to its `label` (e.g. `"Other (3)"`).
+
+Now rewrite `CompositionBar`:
+
+```tsx
+import { useState } from 'react';
+import { useAmountFormat } from '@/lib/server-config';
+
+export function CompositionBar({ rows, total, currency, variant, className }: Props) {
+  const { formatCents } = useAmountFormat();
+  const [activeIdx, setActiveIdx] = useState<number | null>(null);
+
+  if (rows.length === 0 || total === 0) return null;
+  const { segments } = partitionForComposition(rows, total, variant);
+
+  return (
+    <div className={cn('w-full', className)}>
+      <div className="relative">
+        <div
+          data-testid="composition-bar"
+          role="img"
+          aria-label={buildAriaLabel(segments, variant)}
+          className="flex h-7 w-full overflow-hidden rounded text-[10px] font-medium"
+        >
+          {segments.map((seg, i) => (
+            <button
+              key={i}
+              type="button"
+              data-testid="composition-segment"
+              className={cn(
+                'flex items-center overflow-hidden whitespace-nowrap transition-opacity',
+                seg.colorClass,
+                seg.textClass,
+                seg.pct >= 9 ? 'px-1.5' : seg.pct >= 5 ? 'px-1 justify-center' : '',
+                activeIdx !== null && activeIdx !== i ? 'opacity-60' : '',
+              )}
+              style={{ width: `${seg.pct}%` }}
+              onPointerEnter={() => setActiveIdx(i)}
+              onPointerLeave={() => setActiveIdx((cur) => (cur === i ? null : cur))}
+              onFocus={() => setActiveIdx(i)}
+              onBlur={() => setActiveIdx((cur) => (cur === i ? null : cur))}
+              aria-label={`${seg.fullName}: ${formatCents(seg.amount, currency)} (${Math.round(seg.pct)}%)`}
+            >
+              {labelFor(seg)}
+            </button>
+          ))}
+        </div>
+
+        {activeIdx !== null &&
+          (() => {
+            const seg = segments[activeIdx];
+            // Anchor tooltip at the segment's left edge in % of bar width.
+            // Center it under the segment using its width; flip when near the right edge.
+            const leftPctSum = segments.slice(0, activeIdx).reduce((acc, s) => acc + s.pct, 0);
+            const centerPct = leftPctSum + seg.pct / 2;
+            const flip = centerPct > 70;
+            return (
+              <div
+                role="status"
+                aria-live="polite"
+                data-testid="composition-tooltip"
+                className={cn(
+                  'pointer-events-none absolute z-10 mt-1 rounded-md border border-border bg-popover px-2 py-1 text-[11px] text-popover-foreground shadow-sm',
+                )}
+                style={{
+                  left: `${centerPct}%`,
+                  top: '100%',
+                  transform: flip ? 'translateX(-100%)' : 'translateX(-50%)',
+                }}
+              >
+                <div className="font-medium">{seg.fullName}</div>
+                <div className="font-mono">{formatCents(seg.amount, currency)}</div>
+                <div className="text-muted-foreground">{Math.round(seg.pct)}%</div>
+              </div>
+            );
+          })()}
+      </div>
+
+      <div className="mt-1 flex justify-between text-[9px] text-muted-foreground">
+        <span>0%</span>
+        <span>50%</span>
+        <span>100%</span>
+      </div>
+    </div>
+  );
+}
+```
+
+Remember to update the test from Task 2 that checked `seg.tagName === 'BUTTON'` — already covered in the new tests. The earlier "renders one DOM segment per partition segment" test still passes because the `data-testid` matches the `<button>`.
+
+Update the earlier helper test for `swatchColors` parallelism and the segment interface — `fullName` is a new required field, so existing tests that destructure `segments[0]` still pass (extra field doesn't break assertions). No edits needed there.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd spa && npm test -- reports.composition-bar`
+
+Expected: All 22 tests pass.
+
+- [ ] **Step 5: Type-check and lint**
+
+Run: `cd spa && npm run check && tsc -b --noEmit`
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add spa/src/components/reports/CompositionBar.tsx spa/src/test/reports.composition-bar.test.tsx
+git commit -m "feat(spa): hover/focus tooltip and dimming for CompositionBar"
+```
+
+---
+
+## Task 5: Add `swatchColors` support to `ReportRowTable`
+
+**Files:**
+- Modify: `spa/src/components/reports/ReportRowTable.tsx`
+- Modify: `spa/src/test/components/BalanceColumn.test.tsx` (verify untouched — sanity)
+- New tests: append to an existing or new file — use `spa/src/test/reports.composition-bar.test.tsx` for swatch-rendering tests if you prefer a focused location, otherwise create `spa/src/test/components/ReportRowTable.test.tsx`. This plan uses the latter.
+
+- [ ] **Step 1: Create the new test file**
+
+Create `spa/src/test/components/ReportRowTable.test.tsx`:
+
+```tsx
+import { render } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { ReportRowTable } from '../../components/reports/ReportRowTable';
+import type { ReportRow } from '../../lib/types';
+import { withServerConfig } from '../test-app';
+
+// ReportRowTable needs a Router for <Link>. The simplest workaround for a
+// unit test is to render only the swatch by stubbing the Link import via a
+// vi.mock at module scope. To avoid that complexity, this test uses the
+// real router-aware render path via makeTestApp in the page tests
+// (Tasks 7/8). Here we just assert the swatch markup with a Router-less
+// render — Link will throw without a router, so we wrap rendering in a
+// try/catch and only assert on what renders before the error.
+//
+// Simpler approach: skip the unit test here and rely on page-level tests
+// (Tasks 7/8) for swatch assertions.
+
+// Placeholder so the file is non-empty if you choose this option.
+test('see page-level tests for swatch rendering', () => {
+  expect(true).toBe(true);
+});
+```
+
+If you instead want a true unit test, prefer mocking `@tanstack/react-router` for this file:
+
+```tsx
+import { render } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import type { ReportRow } from '../../lib/types';
+import { withServerConfig } from '../test-app';
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+}));
+
+// Import AFTER the mock so the component picks up the stub.
+import { ReportRowTable } from '../../components/reports/ReportRowTable';
+
+const rows: ReportRow[] = [
+  { account_name: 'Expenses:Rent', offset_account: '', amount: 1800, currency: 'USD', tx_count: 1 },
+  { account_name: 'Expenses:Food', offset_account: '', amount: 642, currency: 'USD', tx_count: 1 },
+];
+const nameToId = new Map<string, number>([
+  ['Expenses:Rent', 1],
+  ['Expenses:Food', 2],
+]);
+
+test('ReportRowTable: renders no swatches when swatchColors is undefined', () => {
+  const { container } = render(
+    withServerConfig(
+      <ReportRowTable rows={rows} currency="USD" nameToId={nameToId} period={null} />,
+    ),
+  );
+  expect(container.querySelectorAll('[data-testid="row-swatch"]').length).toBe(0);
+});
+
+test('ReportRowTable: renders one swatch per row when swatchColors provided', () => {
+  const { container } = render(
+    withServerConfig(
+      <ReportRowTable
+        rows={rows}
+        currency="USD"
+        nameToId={nameToId}
+        period={null}
+        swatchColors={['bg-red-700', 'bg-red-600']}
+      />,
+    ),
+  );
+  const swatches = container.querySelectorAll('[data-testid="row-swatch"]');
+  expect(swatches).toHaveLength(2);
+  expect(swatches[0].className).toContain('bg-red-700');
+  expect(swatches[1].className).toContain('bg-red-600');
+});
+```
+
+Use the second (real-test) version of the file. Delete the placeholder version.
+
+- [ ] **Step 2: Run tests to confirm failures**
+
+Run: `cd spa && npm test -- ReportRowTable`
+
+Expected: Both tests fail — `swatchColors` prop not recognized; no swatch element.
+
+- [ ] **Step 3: Update `ReportRowTable.tsx`**
+
+Edit `spa/src/components/reports/ReportRowTable.tsx`:
+
+- Add to `interface Props`:
+
+```ts
+swatchColors?: string[]; // parallel to rows; if provided, renders a colored swatch before each account name
+```
+
+- Update the function signature to accept it:
+
+```tsx
+export function ReportRowTable({ rows, currency, nameToId, period, swatchColors }: Props) {
+```
+
+- Inside the row map, change `linkContent` to include the swatch when present:
+
+```tsx
+const swatch =
+  swatchColors && swatchColors[/* rowIndex */ ] ? (
+    <span
+      data-testid="row-swatch"
+      className={cn('mr-2 inline-block h-2 w-2 rounded-[2px] align-middle', swatchColors[/* rowIndex */])}
+      aria-hidden="true"
+    />
+  ) : null;
+
+const linkContent = (
+  <span className="inline-flex items-center min-w-0">
+    {swatch}
+    <span className="truncate" title={row.account_name}>
+      {stripAccountTypePrefix(row.account_name)}
+    </span>
+  </span>
+);
+```
+
+You'll need the row index — change `rows.map((row) => …)` to `rows.map((row, rowIndex) => …)` and substitute `rowIndex` in the two `[/* rowIndex */]` placeholders above.
+
+Add `import { cn } from '@/lib/cn';` to the imports.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd spa && npm test -- ReportRowTable`
+
+Expected: Both tests pass.
+
+Also run the full SPA test suite to make sure no existing test broke:
+
+```bash
+cd spa && npm test
+```
+
+Expected: all tests pass (the composition-bar suite still passes, and existing pages that don't pass `swatchColors` still render exactly the same DOM minus a wrapping `<span class="inline-flex …">` — verify by spot-checking failures, if any. If wrapping the link content changed test expectations in `reports.balance-sheet.test.tsx` or similar, adjust the inline-flex wrap so behavior matches more closely; see Step 5).
+
+- [ ] **Step 5: If wrapping the link content broke an existing test, narrow the change**
+
+Only wrap with `inline-flex` when `swatchColors` is provided; otherwise leave the original `<span class="truncate">` exactly as it was. Update the JSX:
+
+```tsx
+const labelSpan = (
+  <span className="truncate" title={row.account_name}>
+    {stripAccountTypePrefix(row.account_name)}
+  </span>
+);
+
+const linkContent = swatch ? (
+  <span className="inline-flex min-w-0 items-center">
+    {swatch}
+    {labelSpan}
+  </span>
+) : (
+  labelSpan
+);
+```
+
+Re-run `cd spa && npm test` — all tests pass.
+
+- [ ] **Step 6: Type-check and lint**
+
+Run: `cd spa && npm run check && tsc -b --noEmit`
+
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add spa/src/components/reports/ReportRowTable.tsx spa/src/test/components/ReportRowTable.test.tsx
+git commit -m "feat(spa): optional colored swatches in ReportRowTable"
+```
+
+---
+
+## Task 6: Wire CompositionBar into Expense Breakdown page
+
+**Files:**
+- Modify: `spa/src/routes/reports.expense-breakdown.tsx`
+
+- [ ] **Step 1: Edit the route**
+
+Open `spa/src/routes/reports.expense-breakdown.tsx`.
+
+- Remove the import:
+
+```tsx
+import { ProportionBar } from '@/components/reports/ProportionBar';
+```
+
+- Add:
+
+```tsx
+import { CompositionBar, partitionForComposition } from '@/components/reports/CompositionBar';
+```
+
+- Replace the line:
+
+```tsx
+<ProportionBar rows={rows} total={expense} currency={currency} variant="expense" />
+```
+
+with:
+
+```tsx
+<section>
+  <h2 className="mb-2 text-sm font-semibold">Composition</h2>
+  <CompositionBar rows={rows} total={expense} currency={currency} variant="expense" />
+</section>
+```
+
+- Just above the existing `<ReportRowTable …>`, compute swatch colors:
+
+```tsx
+const { swatchColors } = partitionForComposition(rows, expense, 'expense');
+```
+
+Add this inside the component, after `const rows = …` and before the `return`. (Recomputation on each render is fine — pure function, O(n log n) where n is small.)
+
+- Update the table prop list:
+
+```tsx
+<ReportRowTable
+  rows={rows}
+  currency={currency}
+  nameToId={nameToId}
+  period={{ startUnix: period.startUnix, endUnix: period.endUnix }}
+  swatchColors={swatchColors}
+/>
+```
+
+- [ ] **Step 2: Type-check and lint**
+
+Run: `cd spa && npm run check && tsc -b --noEmit`
+
+Expected: clean. If `ProportionBar` still appears in an unused-import error, remove the leftover import line.
+
+- [ ] **Step 3: Run page tests**
+
+Run: `cd spa && npm test -- reports.expense-breakdown`
+
+Expected: existing test (`renders total expense KPI and rows`) still passes — the assertions check KPI text and row labels, not the chart.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spa/src/routes/reports.expense-breakdown.tsx
+git commit -m "feat(spa): use CompositionBar on Expense Breakdown page"
+```
+
+---
+
+## Task 7: Wire CompositionBar into Income Breakdown page
+
+**Files:**
+- Modify: `spa/src/routes/reports.income-breakdown.tsx`
+
+- [ ] **Step 1: Edit the route**
+
+Open `spa/src/routes/reports.income-breakdown.tsx`. Apply the same changes as Task 6, with these differences:
+
+- `variant="income"`
+- Replace `<ProportionBar rows={rows} total={income} currency={currency} variant="income" />` with the new heading + `<CompositionBar … variant="income">`.
+- Compute swatches as: `const { swatchColors } = partitionForComposition(rows, income, 'income');`
+- Pass `swatchColors` to `<ReportRowTable>`.
+
+- [ ] **Step 2: Type-check and lint**
+
+Run: `cd spa && npm run check && tsc -b --noEmit`
+
+Expected: clean.
+
+- [ ] **Step 3: Run page tests**
+
+Run: `cd spa && npm test -- reports.income-breakdown`
+
+Expected: existing test passes unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spa/src/routes/reports.income-breakdown.tsx
+git commit -m "feat(spa): use CompositionBar on Income Breakdown page"
+```
+
+---
+
+## Task 8: Add page-level assertions for the new bar and swatches
+
+Add a small assertion to each breakdown page test that the composition bar is rendered and that the table rows include swatches.
+
+**Files:**
+- Modify: `spa/src/test/reports.expense-breakdown.test.tsx`
+- Modify: `spa/src/test/reports.income-breakdown.test.tsx`
+
+- [ ] **Step 1: Edit `reports.expense-breakdown.test.tsx`**
+
+In the existing test, add assertions after the KPI/row checks:
+
+```tsx
+// Composition bar is rendered.
+const bar = document.querySelector('[data-testid="composition-bar"]');
+expect(bar).not.toBeNull();
+expect(document.querySelectorAll('[data-testid="composition-segment"]').length).toBe(2);
+
+// Table rows have colored swatches matching the bar segments.
+const swatches = document.querySelectorAll('[data-testid="row-swatch"]');
+expect(swatches.length).toBe(2);
+// Top expense (Rent, 180000) is the darkest red.
+expect(swatches[0].className).toContain('bg-red-700');
+```
+
+(The fixture has `expense_rows` of length 2: Rent then Food, both within top-6 so no Other.)
+
+Note: the existing fixture has `Expenses:Rent` first in the rows array, but `partitionForComposition` sorts by `|amount|` desc, and Rent's amount is larger than Food's. So the row at table index 0 (Rent) gets the darkest swatch — matches the assertion.
+
+- [ ] **Step 2: Edit `reports.income-breakdown.test.tsx`**
+
+Same pattern, for income:
+
+```tsx
+const bar = document.querySelector('[data-testid="composition-bar"]');
+expect(bar).not.toBeNull();
+expect(document.querySelectorAll('[data-testid="composition-segment"]').length).toBe(2);
+
+const swatches = document.querySelectorAll('[data-testid="row-swatch"]');
+expect(swatches.length).toBe(2);
+// Top income (Salary, 520000) is the darkest emerald.
+expect(swatches[0].className).toContain('bg-emerald-700');
+```
+
+- [ ] **Step 3: Run both page tests**
+
+Run: `cd spa && npm test -- reports.income-breakdown reports.expense-breakdown`
+
+Expected: both files pass.
+
+- [ ] **Step 4: Run the full SPA suite**
+
+Run: `cd spa && npm test`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spa/src/test/reports.expense-breakdown.test.tsx spa/src/test/reports.income-breakdown.test.tsx
+git commit -m "test(spa): assert CompositionBar and swatches on breakdown pages"
+```
+
+---
+
+## Task 9: Manual smoke check and final commit (if needed)
+
+The SPA bundles into `internal/web/dist/`. The dev server gives the fastest visual loop.
+
+- [ ] **Step 1: Start the dev server**
+
+```bash
+cd spa && npm run dev
+```
+
+This serves the SPA at `http://localhost:5173` and proxies API calls to the Go server. In another terminal, start the Go server against a real or seeded ledger:
+
+```bash
+go run ./cmd/kea serve
+```
+
+- [ ] **Step 2: Verify Expense Breakdown**
+
+Navigate to `http://localhost:5173/reports/expense-breakdown`. Confirm:
+
+- The Composition heading and bar render above the detail table.
+- Segments are red, darkest on the biggest. "Other" (if >6 expense categories) is grey at the end.
+- Hover a segment → tooltip shows full account name, amount in the right currency, and percent. Other segments dim.
+- Tab into the bar with the keyboard → focus moves segment-to-segment, tooltip swaps each time.
+- The detail table shows a small colored dot before each account name, matching the bar.
+- 0% / 50% / 100% ticks render under the bar.
+
+- [ ] **Step 3: Verify Income Breakdown**
+
+Same checks at `http://localhost:5173/reports/income-breakdown`, with emerald-green palette.
+
+- [ ] **Step 4: Verify Income Statement is unchanged**
+
+Navigate to `http://localhost:5173/reports/income-statement`. Confirm the existing Top 5 Income / Top 5 Expense `ProportionBar`s render exactly as before.
+
+- [ ] **Step 5: If everything looks correct, no commit needed**
+
+The previous tasks have already committed the implementation. If you spotted a visual bug, fix it in a small additional commit referencing the specific issue.
+
+- [ ] **Step 6: Build the bundle**
+
+Run: `cd spa && npm run build`
+
+Expected: build succeeds. The built bundle replaces files under `internal/web/dist/`; commit only `internal/web/dist/index.html` if it changed (per `.gitignore`, only the placeholder is tracked).
+
+```bash
+git status internal/web/dist/
+# Commit only if index.html changed:
+git add internal/web/dist/index.html && git commit -m "build: refresh embedded SPA bundle placeholder"
+```
+
+---
+
+## Self-Review Notes
+
+- All spec requirements have a task: partition + Other (T1), bar widths and gradient (T2), inline labels and ticks (T3), tooltip + focus + dim + a11y (T4), table swatches (T5), wiring + tests + smoke (T6–T9).
+- `ProportionBar` deliberately stays alive (Income Statement still uses it) — matches spec's "Out of scope".
+- Type consistency: `CompositionSegment` is defined in T1, extended in T4 with `fullName`. Both interfaces are listed explicitly in their tasks. `partitionForComposition`'s signature is stable from T1 onward.
+- No placeholders: every step has the code/command/expected output it needs.

--- a/docs/superpowers/specs/2026-06-24-report-row-table-scroll-design.md
+++ b/docs/superpowers/specs/2026-06-24-report-row-table-scroll-design.md
@@ -1,0 +1,67 @@
+# SPA Reports — Cap Breakdown Row Table at 8 Rows with Sticky Header
+
+## Goal
+
+On the Income Breakdown and Expense Breakdown report pages, cap the detail row table at 8 visible rows. When there are more rows, the table scrolls vertically inside its container and the column headers stay visible at the top via a sticky `<thead>`. The Balance Sheet's Liabilities table is unchanged.
+
+## Scope
+
+### In scope
+
+- New optional prop `maxVisibleRows?: number` on `ReportRowTable`.
+- When the prop is set, the table is wrapped in a scroll container that limits height and enables vertical scrolling.
+- When the prop is set, the `<thead>` becomes `sticky top-0` so headers remain visible while scrolling.
+- Pass `maxVisibleRows={8}` from `reports.income-breakdown.tsx` and `reports.expense-breakdown.tsx`.
+
+### Out of scope
+
+- Balance Sheet's Liabilities table — leaves it tall and unscrolled (it typically has few rows; the prop is opt-in).
+- Income Statement's Top-5 ProportionBars — they already show a hard limit.
+- A configurable per-page row-cap (e.g. a "show 25 / 50 / 100" picker). 8 is a fixed product decision for this iteration.
+- Virtualized rendering — at the row counts in this app (single-digit to low hundreds), plain DOM scroll is sufficient. No `react-window` or similar dependency.
+- Horizontal scrolling. Existing `truncate` on long account names handles overflow already.
+
+## Frontend
+
+### `ReportRowTable` changes
+
+File: `spa/src/components/reports/ReportRowTable.tsx`.
+
+Add to `interface Props`:
+
+```ts
+maxVisibleRows?: number; // when set, table scrolls with a sticky header after this many rows
+```
+
+The render becomes:
+
+- If `maxVisibleRows` is undefined, render exactly as today (no wrapper, no max-height, no sticky header).
+- If `maxVisibleRows` is set:
+  - Wrap the existing `<table>` in a scroll container: `<div data-testid="report-row-scroll" className="overflow-y-auto rounded-md border" style={{ maxHeight: \`${maxVisibleRows * 2 + 2}rem\` }}>`. The body row height is ~2rem (32px from `py-1.5` + `text-sm`), and the sticky header eats ~2rem of the same space (`py-1` + `text-xs` + a bit of headroom). So `(rows × 2) + 2` rem fits exactly the requested number of data rows AND the visible header, with `rows + 1` rows triggering scroll. The container's max-height scales with the prop value, so a future `maxVisibleRows={5}` produces a 5-row cap (12rem) without spec changes.
+  - Add `sticky top-0 z-10 bg-background` to the existing `<thead>` element so the headers stay glued to the top of the scroll container. Keep the existing `text-xs uppercase text-muted-foreground` classes intact.
+  - No change to row markup, swatches, or links.
+
+Implementation note: an inline `style` is used (instead of a Tailwind utility) because Tailwind cannot template `max-h-[${N}rem]` at runtime — the JIT compiler scans the source for literal class names. Inline style sidesteps that constraint without adding a config entry.
+
+### Breakdown pages
+
+In `spa/src/routes/reports.expense-breakdown.tsx` and `spa/src/routes/reports.income-breakdown.tsx`, pass `maxVisibleRows={8}` to the existing `<ReportRowTable>` element. No other changes.
+
+### Tests
+
+In `spa/src/test/components/ReportRowTable.test.tsx`, add two tests:
+
+- `'ReportRowTable: no scroll wrapper when maxVisibleRows is undefined'` — renders without `maxVisibleRows`, asserts that the rendered output has no element matching `[data-testid="report-row-scroll"]` (selector for the scroll wrapper).
+- `'ReportRowTable: scroll wrapper and sticky header when maxVisibleRows is set'` — renders with `maxVisibleRows={8}`, asserts the presence of `[data-testid="report-row-scroll"]`, that the wrapper's `className` contains `overflow-y-auto`, and that the wrapper's inline `style.maxHeight` is `'18rem'` (= 8 × 2 + 2 rem, accounting for the sticky header). Asserts the `<thead>` element's `className` contains `sticky` and `top-0`.
+
+Update the page-level tests so they continue to pass — `reports.expense-breakdown.test.tsx` and `reports.income-breakdown.test.tsx` already query by `data-testid="row-swatch"` and `data-testid="composition-segment"`, both of which still render inside the new wrapper.
+
+## Migration / Compatibility
+
+No API changes. No URL changes. The new prop is opt-in, so existing callers (Balance Sheet) are unaffected.
+
+## Risks
+
+- **Row height drift**: the 320px max-height assumes ~32px per row. If a future style change (larger font, more padding) makes rows taller, 8 rows may overflow and only 7 fit before scroll kicks in. Mitigation: the scroll just engages slightly earlier, no functional break. If precise "exactly 8 rows" matters later, switch to a CSS-variable-driven height.
+- **Sticky header z-index**: the new `z-10` on `<thead>` keeps it above row swatches and link styles. Verify in dev that no overlapping fixed element (e.g. the page's `PeriodPicker`) appears above the table at the same z-level.
+- **Bundle rebuild**: the SPA bundle (`internal/web/dist/index.html` and assets) must be rebuilt and committed so users running `kea serve` from the binary see the change.

--- a/docs/superpowers/specs/2026-06-24-spa-breakdown-composition-bar-design.md
+++ b/docs/superpowers/specs/2026-06-24-spa-breakdown-composition-bar-design.md
@@ -1,0 +1,110 @@
+# SPA Reports — Replace Per-Row Proportion Bars with a Composition Bar
+
+## Goal
+
+On the Income Breakdown and Expense Breakdown report pages, replace the current per-row `ProportionBar` (one horizontal bar per category, stacked vertically) with a single compact "composition bar" that shows the whole breakdown at a glance. The detail table below the bar acts as the legend and source of exact numbers. This removes the redundancy between bars and table, reduces vertical space, and makes proportions easier to compare.
+
+## Scope
+
+### In scope
+
+- New `CompositionBar` component used on `/reports/income-breakdown` and `/reports/expense-breakdown`.
+- Augment `ReportRowTable` to render a small colored swatch next to each row label, sharing the same color palette as the bar so the table acts as the bar's legend.
+- Remove `ProportionBar` usage from the two breakdown pages.
+
+### Out of scope
+
+- Income Statement page (`/reports/income-statement`) keeps its existing `ProportionBar` Top-5 visuals. It is not redundant there (no detail table beneath) and is not part of this redesign.
+- Deleting the `ProportionBar` component itself. It is still used by Income Statement, so it stays.
+- Backend changes. The existing `useIncomeBreakdown` / `useExpenseBreakdown` data is sufficient.
+- Click-to-drill-down on bar segments. The detail table already exposes per-account drill-down links.
+- Multi-currency composition. Both pages already filter rows to the default currency; the bar renders that single currency, matching the page.
+
+## Frontend
+
+### New `CompositionBar` component
+
+Path: `spa/src/components/reports/CompositionBar.tsx`.
+
+Props:
+
+```ts
+interface Props {
+  rows: ReportRow[];        // pre-filtered to the displayed currency
+  total: number;            // same currency; may be 0
+  currency: string;
+  variant: 'income' | 'expense';
+  className?: string;
+}
+```
+
+Rendering:
+
+- A single horizontal bar, `h-7` (28px), rounded `rounded` (4px), `overflow-hidden`, full container width.
+- Each segment width is `(|row.amount| / |total|) * 100%`. `total === 0` → render nothing and let the parent's empty state apply.
+- Top 6 rows by `|amount|` get their own segment. Remaining rows (if any) collapse into a single trailing **Other** segment whose amount is the sum of the remainder and whose count is `rows.length - 6`. If there are exactly 7 rows, the 7th still becomes "Other (1)"; if there are ≤6 rows, no Other segment is rendered.
+- **Color palette**: single-hue gradient using existing Tailwind shades. Order is darkest → lightest, biggest → smallest:
+  - `expense`: `bg-red-700`, `bg-red-600`, `bg-red-500`, `bg-red-400`, `bg-red-300`, `bg-red-200`.
+  - `income`: `bg-emerald-700`, `bg-emerald-600`, `bg-emerald-500`, `bg-emerald-400`, `bg-emerald-300`, `bg-emerald-200`.
+  - **Other** segment: `bg-slate-300` (light mode) / matching neutral via tokens — distinct from the gradient so it reads as "remainder", not a category. Text inside Other uses `text-slate-700`.
+- **Inline label** inside each segment: shows `<short-name> · NN%` when the segment is ≥ 9% of total width; just `NN%` when between 5% and 9%; nothing below 5%. Text is `text-[10px] font-medium`, `text-white` for the gradient segments (sufficient contrast on shades 400–700; for 200/300 use `text-red-900` / `text-emerald-900` respectively). Truncate with `overflow-hidden whitespace-nowrap`.
+- **Hover tooltip** on each segment: shows account name (full, not truncated), formatted amount, and percent. Implementation: a small absolutely-positioned `div` inside the bar container, made visible with `:hover` via React state (`hoverIdx`). Other segments dim to `opacity-60` while one is hovered. Pointer events use `onPointerEnter`/`onPointerLeave` on each segment.
+- **Tick markers**: a row of three muted labels below the bar — `0%`, `50%`, `100%` — at the left/center/right. `text-[9px] text-muted-foreground` with `mt-1`.
+
+Accessibility:
+
+- The bar's container has `role="img"` and an `aria-label` like `"Expense composition: Rent 39%, Groceries 14%, …, Other 14%"` (top 3 segments + Other if present).
+- Each segment is a `<button type="button">` so it is keyboard-focusable and triggers the tooltip on focus, not only on hover. (Buttons inside the bar keep visual consistency; they have no `onClick` action in v1.)
+
+Empty / edge cases:
+
+- `rows.length === 0` or `total === 0`: component returns `null`. The parent page already shows "No income in …" / "No expenses in …".
+- Single row: full-width segment, name and percent inline.
+- Negative `total` (signed convention): use `Math.abs(total)` as the denominator, matching today's `ProportionBar` logic.
+
+### `ReportRowTable` — colored swatches
+
+Path: `spa/src/components/reports/ReportRowTable.tsx`.
+
+- Add an optional prop `swatchColors?: string[]` — a list of Tailwind background-color classes, parallel to `rows` (index `i` matches `rows[i]`). When provided, render an `8×8px rounded-[2px]` `<span>` before the account name in each row, using the matching class.
+- For rows beyond the top 6 (i.e., rows collapsed into "Other" in the bar), use the same neutral swatch as the bar's Other segment so the visual mapping holds.
+- When `swatchColors` is undefined, the table renders unchanged (preserves use on pages that have no bar).
+
+### `reports.income-breakdown.tsx` and `reports.expense-breakdown.tsx`
+
+Replace the `<ProportionBar … />` element with:
+
+1. A small section heading: `<h2 className="mb-2 text-sm font-semibold">Composition</h2>`.
+2. `<CompositionBar rows={rows} total={income|expense} currency={currency} variant="income"|"expense" />`.
+
+Pass `swatchColors` to `<ReportRowTable>`. The page derives `swatchColors` from the same top-6-plus-Other partitioning logic as the bar. Factor the partitioning into a small pure helper (`partitionForComposition(rows, n=6) → { primary, other }`) co-located with `CompositionBar` and exported, so both the bar and the page produce identical groupings without duplication.
+
+Remove the now-unused `ProportionBar` import from these two route files. Keep the import in `reports.income-statement.tsx`.
+
+### Tests
+
+- New `reports.composition-bar.test.tsx`:
+  - Renders one segment per row when `rows.length ≤ 6`.
+  - Collapses rows 7+ into a single Other segment with the correct aggregated amount and count.
+  - Segment widths sum to 100% (assert each segment's inline `style.width`).
+  - Inline-label visibility: a row with ≥ 9% shows `name · NN%`; a row with 2% shows no inline label.
+  - `aria-label` includes the top 3 categories.
+  - Empty rows / zero total → `container.firstChild` is `null`.
+  - Variant switch: `expense` → red palette, `income` → emerald palette (assert a sentinel class is present).
+- Update `reports.income-breakdown.test.tsx` and `reports.expense-breakdown.test.tsx`:
+  - Replace existing assertions that target `data-testid="prop-bar"` / `data-testid="bar-fill"` with assertions targeting the composition bar (`data-testid="composition-bar"`).
+  - Assert the table rows render colored swatches (presence of swatch element).
+- `reports.proportion-bar.test.tsx` is unchanged — `ProportionBar` is still alive for Income Statement.
+- Existing `reports.income-statement.test.tsx` is unchanged.
+
+## Migration / Compatibility
+
+- No URL or API changes. The change is purely the SPA's report-page rendering.
+- The `ProportionBar` component, hook of consumers, and its tests stay in place for Income Statement.
+
+## Risks
+
+- **Color contrast** on the lightest segments (`-200`, `-300`) with white text: the spec uses dark-on-light (`text-red-900` / `text-emerald-900`) on those shades to keep WCAG contrast. Verify visually after implementation.
+- **Many tiny segments visually noisy**: capped at 6 + Other, predictable. If a future user has all 30 categories at near-equal share, the bar still works but loses precision — acceptable, the table covers that.
+- **Sub-percent rounding**: percentages displayed inline are `Math.round(pct)`. Sum of displayed percents may equal 99% or 101%. Acceptable; the bar itself uses unrounded widths so it is geometrically correct.
+- **Tooltip overflow**: when a segment near the right edge is hovered, the tooltip may clip. Mirror the hover-tooltip pattern from `NetWorthChart` (flip alignment when `leftPct > 70`).

--- a/docs/web-layer/2026-06-02-pre-development-review.md
+++ b/docs/web-layer/2026-06-02-pre-development-review.md
@@ -1,0 +1,266 @@
+# Kea Web Layer — Pre-Development Review Summary
+
+**Date:** 2026-06-02
+**Status:** Codebase ready for Web Layer development
+
+This document summarizes the pre-development code review for the Kea Web Layer. Hand this to a fresh session as context when starting design discussions.
+
+---
+
+## 1. Web Layer Scope (confirmed with user)
+
+- **Architecture:** CLI/TUI and Web (React SPA + REST API) both sit on top of the same service layer (`internal/service/`).
+- **Frontend:** React SPA.
+- **Deployment:** **Local-only, single-user** — `kea serve` runs on `localhost`, shares the same SQLite file as the CLI. No multi-user, no remote hosting, no auth.
+- **Both interfaces coexist** — the user can use CLI commands while the web server is running.
+
+---
+
+## 2. Project Architecture (as of review)
+
+```
+cmd/              Cobra commands → call service methods
+  cmd/ledger/     Ledger management subcommands
+internal/app/     Wires service + store (DI entry point)
+internal/service/ Business logic — AccountService, TransactionService, reports, reconcile
+internal/store/   SQLite implementation of repository interfaces
+internal/model/   Domain types (Account, Transaction, Split, etc.)
+internal/repository/interfaces.go  Contracts between service and store
+internal/config/  Config struct + Viper loading
+internal/ledger/  Ledger registry (multiple named DBs, active selection)
+internal/backup/  Pre-startup DB backup
+internal/utils/   Amount formatting/parsing helpers
+ui/               charmbracelet/huh prompts + pterm views
+migrations/       golang-migrate SQL files embedded via FS
+```
+
+### Key domain rules
+- **Amounts:** always `int64` cents. Use `utils.FormatAmount` / `utils.ParseAmount`.
+- **Double-entry:** every transaction's splits must sum to zero.
+- **Account types:** A (Asset), L (Liability), C (Equity), R (Revenue), E (Expense). Only leaf accounts hold transactions.
+- **Protected records:** Transaction ID 1 and reconciled transactions are immutable.
+- **System accounts:** per-currency `Equity:OpeningBalances_<CCY>` (e.g. `Equity:OpeningBalances_USD`).
+- **Service facade:** `service.Service` exposes `svc.Account()`, `svc.Transaction()`, `svc.Config()`.
+
+### Service method conventions
+- All methods take `context.Context` as first arg.
+- Errors use sentinels (`ErrNotFound`, `ErrAlreadyExists`, `ErrReconciled`, `ErrNotEditable`) + `ValidationError` struct with field name.
+- `errors.Is` / `errors.As` work consistently across the layer.
+
+---
+
+## 3. Issues Identified and Resolved
+
+**30 web-layer issues filed and closed.** All fixes merged to main.
+
+### Pre-existing issues that impacted web layer (7)
+| # | Title |
+|---|-------|
+| #22 | Account hierarchy lacks circular-reference validation on ParentID |
+| #25 | Inconsistent error wrapping in GetTransactionByID |
+| #29 | CreateAccountWithBalance non-atomic; orphan account on opening-balance failure |
+| #44 | Subaccount currency overrides are not normalized |
+| #58 | N+1 query problem in transaction list command |
+| #60 | No store (integration) tests |
+| #68 | context.Background() used in startup instead of propagating cmd context |
+
+### First-round issues (7) — initial blockers
+| # | Title |
+|---|-------|
+| #74 | Model structs missing JSON tags for API serialization |
+| #75 | SQLite missing WAL mode and busy timeout |
+| #76 | Business logic in cmd/ layer not reusable by API handlers |
+| #77 | Service errors lack structure for HTTP status code mapping |
+| #78 | List methods lack pagination support |
+| #79 | Service methods use many positional parameters instead of input structs |
+| #80 | Backup uses raw file copy instead of SQLite backup API |
+
+### Second-round blockers — service reusability focus (9)
+| # | Title |
+|---|-------|
+| #104 | No public GetAccountByID on AccountService |
+| #105 | RenameAccount takes segment-only; mutations don't return updated entity |
+| #106 | Inconsistent ErrNotFound translation from repo → service |
+| #107 | Transaction list display-field assembly trapped in cmd/ |
+| #108 | Hidden-account filtering only in cmd/, not service |
+| #109 | SetMaxOpenConns(1) blocks concurrent HTTP request handling |
+| #110 | RenameAccount in store bypasses ExecTx |
+| #111 | Backup uses raw file copy when db=nil; unsafe with running server |
+| #112 | determineMode duplicated in cmd/add and cmd/transaction/edit |
+
+### Third-round deep review — HIGH severity (9)
+| # | Title |
+|---|-------|
+| #113 | CreateTransaction allows creating already-reconciled transactions |
+| #114 | No multi-dimension transaction filtering |
+| #115 | No account search by partial name (autocomplete) |
+| #116 | ListResult and ListOptions missing JSON tags |
+| #117 | Config struct has no web server fields (port, host, CORS) |
+| #118 | ensureCurrency launches interactive TUI prompt — blocks server |
+| #119 | CLI ledger switch invisible to running web server (split-brain) |
+| #120 | Ignored GetAccountByName errors cause nil-pointer panics |
+| #121 | JSONTxDetail missing Type field |
+
+### Third-round deep review — MEDIUM severity (12)
+| # | Title |
+|---|-------|
+| #122 | GetAccountBalance returns 0 for nonexistent accounts instead of 404 |
+| #123 | No length/content validation on Description and Memo fields |
+| #124 | ParseTransactionStatus silently defaults unknown values to Cleared |
+| #125 | Unbounded IN clauses can exceed SQLite variable limit |
+| #126 | Duplicate external_id error not wrapped with sentinel |
+| #127 | ReconcileTransactions TOCTOU race — validation reads outside ExecTx |
+| #128 | ParseAmount silently overflows on large dollar values |
+| #129 | Signal handler only catches SIGINT, not SIGTERM |
+| #130 | TransactionType has no MarshalJSON/UnmarshalJSON |
+| #131 | No account tree/hierarchy service method |
+| #132 | Missing composite index on splits(account_id, reconciled) |
+| #133 | ToJSONTxListItem ParseFloat fails on comma-formatted amounts |
+
+---
+
+## 4. Current State Verification (verified by spot-check)
+
+| Concern | Status | Evidence |
+|---------|--------|----------|
+| SQLite concurrency | ✅ Fixed | `_journal_mode=WAL&_busy_timeout=5000&_txlock=immediate`, `SetMaxOpenConns(4)` |
+| Service layer reusability | ✅ Fixed | `GetAccountByID`, `SearchAccounts`, `GetAccountTree`, `ListAccounts`, `BuildTransactionListItems` all in service |
+| Multi-dimension filtering | ✅ Fixed | `TransactionFilter` struct (`internal/model/transaction_filter.go`) + `FilterTransactions` repo method |
+| Error translation | ✅ Fixed | Service methods consistently translate `repository.ErrNotFound` → `service.ErrNotFound` |
+| JSON serialization | ✅ Fixed | `ListResult`/`ListOptions` have JSON tags, `TransactionType` has validated unmarshal |
+| Web server config | ✅ Fixed | `ServerConfig` (Host, Port, CORSOrigins) added with defaults: `localhost:8080`, CORS for `localhost:5173` |
+| Graceful shutdown | ✅ Fixed | `signal.NotifyContext(..., os.Interrupt, syscall.SIGTERM)` in `cmd/root.go` |
+| Non-interactive startup | ✅ Fixed | `ensureCurrencyWith(cfg, isInteractive())` — won't block on stdin |
+| All tests pass | ✅ | `go test ./...` clean across all packages |
+
+### Available service methods relevant to the API
+
+**AccountService:**
+- `GetAllAccounts(ctx)` / `ListAccounts(ctx, opts)` / `GetAccountTree(ctx, opts)`
+- `GetAccountByID(ctx, id)` / `GetAccountByName(ctx, name)`
+- `GetAccountsByType(ctx, type)` / `SearchAccounts(ctx, filter, opts)`
+- `GetAccountBalance(ctx, id)` / `GetAllAccountBalances(ctx, asOf)`
+- `CreateAccount(ctx, input)` / `CreateAccountWithBalance(ctx, input)`
+- `UpdateAccountMetadata(ctx, id, desc, hidden)` / `RenameAccount(ctx, oldName, newSegment)`
+- `DeleteAccountByName(ctx, name)`
+
+**TransactionService:**
+- `GetTransactionByID(ctx, id)` / `GetTransactionDetailsByIDs(ctx, txs)`
+- `GetRecentTransactions(ctx, limit)` / `ListRecentTransactions(ctx, opts)` / `ListTransactionHistory(ctx, accountName, opts)`
+- `FilterTransactions(ctx, filter, opts)` — multi-dimension filter
+- `CreateTransaction(ctx, input)` / `CreateSimpleTransaction(ctx, input)` / `CreateTransactionFromSplits(ctx, input)`
+- `UpdateTransactionStatus(ctx, id, status)` / `UpdateTransactionComplete(ctx, input)`
+- `DeleteTransaction(ctx, id)` / individual split CRUD
+- `BuildTransactionListItems(ctx, txs, details)` — assembles display-ready items
+- Reports: `GenerateIncomeStatement`, `GenerateBalanceSheet`, `GenerateFullIncomeStatement`, etc.
+- Reconciliation: `GetUnreconciledByAccount`, `PreviewReconcile`, `ReconcileTransactions`
+
+**Error sentinels (in `internal/service/errors.go`):**
+- `ErrNotFound` → 404
+- `ErrAlreadyExists` → 409
+- `ErrReconciled` → 409
+- `ErrNotEditable` → 403
+- `ErrCircularParent` → 409
+- `*ValidationError` (with `Field` and `Message`) → 400
+
+---
+
+## 5. Open Design Questions for Web Layer
+
+These are decisions to make in the design discussion:
+
+### Server framework
+- **chi** (minimal, idiomatic Go) — recommended for this scope
+- **gorilla/mux** (mature, slightly heavier)
+- **echo** (batteries included; more opinionated)
+- **net/http only** with manual routing (very minimal but more boilerplate)
+
+### API style
+- **REST + JSON** (matches the existing model shape; pairs well with TanStack Query)
+- **GraphQL** (more flexibility but overkill for a single-user local app)
+- **JSON-RPC** (lower ceremony but less standard)
+
+### Frontend stack
+- **Vite + React + TanStack Query** (recommended — clean DX, pairs with `ListResult`)
+- **Next.js** (SSR/SSG — overkill for local SPA)
+- **Remix** (also more than needed)
+
+### Data fetching patterns
+- Pagination: query params `?limit=20&offset=0` mapping to `ListOptions`
+- Filtering: query params mapping to `TransactionFilter`
+- How to handle reconciliation flow (multi-step UI)?
+
+### Endpoint structure (initial sketch)
+```
+GET    /api/accounts                    List/filter/search accounts
+GET    /api/accounts/:id                Get single account
+GET    /api/accounts/:id/balance        Get balance
+GET    /api/accounts/tree               Hierarchical view
+POST   /api/accounts                    Create
+PATCH  /api/accounts/:id                Update metadata or rename
+DELETE /api/accounts/:id
+
+GET    /api/transactions                List with TransactionFilter
+GET    /api/transactions/:id            Get detail
+POST   /api/transactions                Create
+PATCH  /api/transactions/:id            Update
+PATCH  /api/transactions/:id/status     Change status
+DELETE /api/transactions/:id
+
+GET    /api/reports/income-statement    ?from=&to= or ?month=
+GET    /api/reports/balance-sheet       ?as_of=
+GET    /api/reports/net-worth           ?at=
+
+GET    /api/accounts/:id/unreconciled   Reconcile prep
+POST   /api/accounts/:id/reconcile/preview
+POST   /api/accounts/:id/reconcile
+
+GET    /api/ledgers                     List
+POST   /api/ledgers/switch              Switch active
+```
+
+### Cross-cutting concerns to design
+- **Error middleware** — single place to map service errors to HTTP status codes
+- **Logging** — structured logs (slog?), request ID propagation
+- **CORS** — already configured for `localhost:5173` (Vite default)
+- **Embedding the SPA** — embed React build output via `go:embed` for single-binary distribution?
+- **Hot reload during dev** — proxy from Vite dev server to Go API
+- **Database connection sharing** — `kea serve` and CLI both call `NewApp`; WAL handles this but reconcile TOCTOU was fixed in #127
+
+---
+
+## 6. Recommended Implementation Order
+
+1. **Foundation:** Add `kea serve` command + minimal router + error middleware + graceful shutdown wiring
+2. **Read-only endpoints:** Accounts (list, get, tree, balance) — lowest risk, exercises service layer
+3. **Read-only transactions:** List with filtering, get detail
+4. **Reports:** Income statement, balance sheet, net worth — already API-ready
+5. **Write operations:** Create/update/delete for accounts and transactions
+6. **Reconciliation flow:** Multi-step endpoints
+7. **React SPA:** Build incrementally against the running API
+
+---
+
+## 7. Files to Read for Context in a Fresh Session
+
+When starting the web layer design discussion, the new session should read:
+- `CLAUDE.md` (project conventions; already mentions planned Web Layer)
+- `internal/service/account_service.go` and `account_ops.go`
+- `internal/service/transaction_service.go`, `transaction_ops.go`, `transaction_classifier.go`
+- `internal/service/errors.go` (for HTTP status mapping)
+- `internal/model/` (all files — types, input structs, pagination, transaction_filter)
+- `internal/config/config.go` (ServerConfig is there)
+- `cmd/root.go` (to see signal handling and entry point pattern)
+
+---
+
+## 8. Known Limitations (acknowledged, not blockers)
+
+- **Ledger switch via CLI is invisible to running web server** (#119 documented this) — for local single-user use, restart server after switch.
+- **No auth** — local-only design means no login flow needed. If remote access is ever wanted, this becomes a major change.
+- **Single SQLite file** — WAL + 4 connections is fine for local single-user. Multi-tenant would need a different DB.
+- **Backup runs at every `NewApp`** — CLI commands run during server uptime will trigger raw-file backup; the WAL-aware online backup path now used when DB is open (#80, #111 fixed).
+
+---
+
+**End of summary.** Hand this file to a fresh session along with the request "let's design the web layer" — that session will have everything it needs to start brainstorming the architecture.

--- a/internal/web/dist/index.html
+++ b/internal/web/dist/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>kea</title>
-    <script type="module" crossorigin src="/assets/index-Dfrd88gv.js"></script>
+    <script type="module" crossorigin src="/assets/index-ZpGP8sYO.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-CVltCilv.css">
   </head>
   <body>

--- a/internal/web/dist/index.html
+++ b/internal/web/dist/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>kea</title>
-    <script type="module" crossorigin src="/assets/index-BrQo8vxd.js"></script>
+    <script type="module" crossorigin src="/assets/index-C9XHpmS4.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-B3nEWg9X.css">
   </head>
   <body>

--- a/internal/web/dist/index.html
+++ b/internal/web/dist/index.html
@@ -1,17 +1,14 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>kea — SPA not built</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <style>
-      body { font-family: system-ui, sans-serif; max-width: 40rem; margin: 4rem auto; padding: 0 1rem; color: #222; }
-      code { background: #f4f4f4; padding: 0.15rem 0.35rem; border-radius: 3px; }
-    </style>
+    <title>kea</title>
+    <script type="module" crossorigin src="/assets/index-Dfrd88gv.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-CVltCilv.css">
   </head>
   <body>
-    <h1>kea — SPA not built</h1>
-    <p>This is the placeholder shell that ships with the Go binary when the SPA has not been built.</p>
-    <p>Run <code>make spa-build</code> (or <code>make build-all</code>) to produce the real SPA bundle.</p>
+    <div id="root"></div>
   </body>
 </html>

--- a/internal/web/dist/index.html
+++ b/internal/web/dist/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>kea</title>
-    <script type="module" crossorigin src="/assets/index-B6vOlHQW.js"></script>
+    <script type="module" crossorigin src="/assets/index-BO6mHwfn.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-B3nEWg9X.css">
   </head>
   <body>

--- a/internal/web/dist/index.html
+++ b/internal/web/dist/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>kea</title>
-    <script type="module" crossorigin src="/assets/index-ZpGP8sYO.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-CVltCilv.css">
+    <script type="module" crossorigin src="/assets/index-BrQo8vxd.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-B3nEWg9X.css">
   </head>
   <body>
     <div id="root"></div>

--- a/internal/web/dist/index.html
+++ b/internal/web/dist/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>kea</title>
-    <script type="module" crossorigin src="/assets/index-C9XHpmS4.js"></script>
+    <script type="module" crossorigin src="/assets/index-B6vOlHQW.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-B3nEWg9X.css">
   </head>
   <body>

--- a/spa/src/components/reports/ChartRangeSelector.tsx
+++ b/spa/src/components/reports/ChartRangeSelector.tsx
@@ -19,11 +19,7 @@ interface Props {
 
 export function ChartRangeSelector({ value, onChange, className }: Props) {
   return (
-    <div
-      role="radiogroup"
-      aria-label="Chart range"
-      className={cn('flex gap-0.5', className)}
-    >
+    <div role="radiogroup" aria-label="Chart range" className={cn('flex gap-0.5', className)}>
       {OPTIONS.map((opt) => {
         const isActive = value === opt.value;
         return (

--- a/spa/src/components/reports/CompositionBar.tsx
+++ b/spa/src/components/reports/CompositionBar.tsx
@@ -45,7 +45,13 @@ export function partitionForComposition(
   topN = 6,
 ): { segments: CompositionSegment[]; swatchColors: string[] } {
   const palette = GRADIENT[variant];
-  const denom = Math.abs(total);
+  // When the caller's `total` is smaller than the rows actually sum to (e.g. a
+  // transient stale render where the KPI total updates ahead of the row data),
+  // using `|total|` as denominator would let percentages exceed 100%. Use the
+  // larger of `|total|` and the sum of `|row.amount|` so widths always sum to
+  // at most 100%.
+  const rowsSum = rows.reduce((acc, r) => acc + Math.abs(r.amount), 0);
+  const denom = Math.max(Math.abs(total), rowsSum);
 
   // Sort by |amount| descending, but remember each row's original index so
   // we can build a parallel swatchColors array.

--- a/spa/src/components/reports/CompositionBar.tsx
+++ b/spa/src/components/reports/CompositionBar.tsx
@@ -103,26 +103,47 @@ function buildAriaLabel(segments: CompositionSegment[], variant: CompositionVari
   return `${which} composition: ${top}`;
 }
 
+function labelFor(seg: CompositionSegment): string {
+  const rounded = Math.round(seg.pct);
+  if (seg.pct >= 9) return `${seg.label} · ${rounded}%`;
+  if (seg.pct >= 5) return `${rounded}%`;
+  return '';
+}
+
 export function CompositionBar({ rows, total, currency: _currency, variant, className }: Props) {
   if (rows.length === 0 || total === 0) return null;
   const { segments } = partitionForComposition(rows, total, variant);
   return (
-    <div
-      data-testid="composition-bar"
-      role="img"
-      aria-label={buildAriaLabel(segments, variant)}
-      className={cn('flex h-7 w-full overflow-hidden rounded text-[10px] font-medium', className)}
-    >
-      {segments.map((seg) => (
-        <div
-          // label is unique per segment (account name, or the single "Other" bucket).
-          key={seg.label}
-          data-testid="composition-segment"
-          className={cn('flex items-center justify-start', seg.colorClass, seg.textClass)}
-          style={{ width: `${seg.pct}%` }}
-          title={`${seg.label}: ${Math.round(seg.pct)}%`}
-        />
-      ))}
+    <div className={cn('w-full', className)}>
+      <div
+        data-testid="composition-bar"
+        role="img"
+        aria-label={buildAriaLabel(segments, variant)}
+        className="flex h-7 w-full overflow-hidden rounded text-[10px] font-medium"
+      >
+        {segments.map((seg) => (
+          <div
+            // label is unique per segment (account name, or the single "Other" bucket).
+            key={seg.label}
+            data-testid="composition-segment"
+            className={cn(
+              'flex items-center overflow-hidden whitespace-nowrap',
+              seg.colorClass,
+              seg.textClass,
+              seg.pct >= 9 ? 'px-1.5' : seg.pct >= 5 ? 'px-1 justify-center' : '',
+            )}
+            style={{ width: `${seg.pct}%` }}
+            title={`${seg.label}: ${Math.round(seg.pct)}%`}
+          >
+            {labelFor(seg)}
+          </div>
+        ))}
+      </div>
+      <div className="mt-1 flex justify-between text-[9px] text-muted-foreground">
+        <span>0%</span>
+        <span>50%</span>
+        <span>100%</span>
+      </div>
     </div>
   );
 }

--- a/spa/src/components/reports/CompositionBar.tsx
+++ b/spa/src/components/reports/CompositionBar.tsx
@@ -1,11 +1,14 @@
 import { stripAccountTypePrefix } from '@/lib/accounts';
 import { cn } from '@/lib/cn';
+import { useAmountFormat } from '@/lib/server-config';
 import type { ReportRow } from '@/lib/types';
+import { useState } from 'react';
 
 export type CompositionVariant = 'income' | 'expense';
 
 export interface CompositionSegment {
   label: string; // account name (stripped of type prefix), or "Other (N)"
+  fullName: string; // unmodified account name, or the label for the Other bucket
   amount: number; // |amount|
   pct: number; // 0..100, exact (not rounded)
   colorClass: string; // Tailwind background class
@@ -61,6 +64,7 @@ export function partitionForComposition(
     // Mixed-sign rows can push |amount|/|total| > 1; clamp so widths stay valid.
     segments.push({
       label: stripAccountTypePrefix(row.account_name),
+      fullName: row.account_name,
       amount,
       pct: denom === 0 ? 0 : Math.min(100, (amount / denom) * 100),
       colorClass: color.bg,
@@ -72,8 +76,10 @@ export function partitionForComposition(
 
   if (rest.length > 0) {
     const sum = rest.reduce((acc, { row }) => acc + Math.abs(row.amount), 0);
+    const otherLabel = `Other (${rest.length})`;
     segments.push({
-      label: `Other (${rest.length})`,
+      label: otherLabel,
+      fullName: otherLabel,
       amount: sum,
       pct: denom === 0 ? 0 : Math.min(100, (sum / denom) * 100),
       colorClass: OTHER_BG,
@@ -110,35 +116,75 @@ function labelFor(seg: CompositionSegment): string {
   return '';
 }
 
-export function CompositionBar({ rows, total, currency: _currency, variant, className }: Props) {
+export function CompositionBar({ rows, total, currency, variant, className }: Props) {
+  const { formatCents } = useAmountFormat();
+  const [activeIdx, setActiveIdx] = useState<number | null>(null);
+
   if (rows.length === 0 || total === 0) return null;
   const { segments } = partitionForComposition(rows, total, variant);
+
   return (
     <div className={cn('w-full', className)}>
-      <div
-        data-testid="composition-bar"
-        role="img"
-        aria-label={buildAriaLabel(segments, variant)}
-        className="flex h-7 w-full overflow-hidden rounded text-[10px] font-medium"
-      >
-        {segments.map((seg) => (
-          <div
-            // label is unique per segment (account name, or the single "Other" bucket).
-            key={seg.label}
-            data-testid="composition-segment"
-            className={cn(
-              'flex items-center overflow-hidden whitespace-nowrap',
-              seg.colorClass,
-              seg.textClass,
-              seg.pct >= 9 ? 'px-1.5' : seg.pct >= 5 ? 'px-1 justify-center' : '',
-            )}
-            style={{ width: `${seg.pct}%` }}
-            title={`${seg.label}: ${Math.round(seg.pct)}%`}
-          >
-            {labelFor(seg)}
-          </div>
-        ))}
+      <div className="relative">
+        <div
+          data-testid="composition-bar"
+          role="img"
+          aria-label={buildAriaLabel(segments, variant)}
+          className="flex h-7 w-full overflow-hidden rounded text-[10px] font-medium"
+        >
+          {segments.map((seg, i) => (
+            <button
+              // label is unique per segment (account name, or the single "Other" bucket).
+              key={seg.label}
+              type="button"
+              data-testid="composition-segment"
+              className={cn(
+                'flex items-center overflow-hidden whitespace-nowrap transition-opacity',
+                seg.colorClass,
+                seg.textClass,
+                seg.pct >= 9 ? 'px-1.5' : seg.pct >= 5 ? 'px-1 justify-center' : '',
+                activeIdx !== null && activeIdx !== i ? 'opacity-60' : '',
+              )}
+              style={{ width: `${seg.pct}%` }}
+              onPointerEnter={() => setActiveIdx(i)}
+              onPointerLeave={() => setActiveIdx((cur) => (cur === i ? null : cur))}
+              onFocus={() => setActiveIdx(i)}
+              onBlur={() => setActiveIdx((cur) => (cur === i ? null : cur))}
+              aria-label={`${seg.fullName}: ${formatCents(seg.amount, currency)} (${Math.round(seg.pct)}%)`}
+            >
+              {labelFor(seg)}
+            </button>
+          ))}
+        </div>
+
+        {activeIdx !== null &&
+          (() => {
+            const seg = segments[activeIdx];
+            // Anchor tooltip at the segment's left edge in % of bar width.
+            // Center it under the segment using its width; flip when near the right edge.
+            const leftPctSum = segments.slice(0, activeIdx).reduce((acc, s) => acc + s.pct, 0);
+            const centerPct = leftPctSum + seg.pct / 2;
+            const flip = centerPct > 70;
+            return (
+              <div
+                role="status"
+                aria-live="polite"
+                data-testid="composition-tooltip"
+                className="pointer-events-none absolute z-10 mt-1 rounded-md border border-border bg-popover px-2 py-1 text-[11px] text-popover-foreground shadow-sm"
+                style={{
+                  left: `${centerPct}%`,
+                  top: '100%',
+                  transform: flip ? 'translateX(-100%)' : 'translateX(-50%)',
+                }}
+              >
+                <div className="font-medium">{seg.fullName}</div>
+                <div className="font-mono">{formatCents(seg.amount, currency)}</div>
+                <div className="text-muted-foreground">{Math.round(seg.pct)}%</div>
+              </div>
+            );
+          })()}
       </div>
+
       <div className="mt-1 flex justify-between text-[9px] text-muted-foreground">
         <span>0%</span>
         <span>50%</span>

--- a/spa/src/components/reports/CompositionBar.tsx
+++ b/spa/src/components/reports/CompositionBar.tsx
@@ -1,0 +1,92 @@
+import type { ReportRow } from '@/lib/types';
+
+export type CompositionVariant = 'income' | 'expense';
+
+export interface CompositionSegment {
+  label: string; // account name (stripped of type prefix), or "Other (N)"
+  amount: number; // |amount|
+  pct: number; // 0..100, exact (not rounded)
+  colorClass: string; // Tailwind background class
+  textClass: string; // Tailwind text class for in-segment label contrast
+  isOther: boolean;
+}
+
+const GRADIENT: Record<CompositionVariant, { bg: string; text: string }[]> = {
+  expense: [
+    { bg: 'bg-red-700', text: 'text-white' },
+    { bg: 'bg-red-600', text: 'text-white' },
+    { bg: 'bg-red-500', text: 'text-white' },
+    { bg: 'bg-red-400', text: 'text-white' },
+    { bg: 'bg-red-300', text: 'text-red-900' },
+    { bg: 'bg-red-200', text: 'text-red-900' },
+  ],
+  income: [
+    { bg: 'bg-emerald-700', text: 'text-white' },
+    { bg: 'bg-emerald-600', text: 'text-white' },
+    { bg: 'bg-emerald-500', text: 'text-white' },
+    { bg: 'bg-emerald-400', text: 'text-white' },
+    { bg: 'bg-emerald-300', text: 'text-emerald-900' },
+    { bg: 'bg-emerald-200', text: 'text-emerald-900' },
+  ],
+};
+
+const OTHER_BG = 'bg-slate-300';
+const OTHER_TEXT = 'text-slate-700';
+
+// Strip an account-type prefix like "Expenses:" or "Income:".
+// Mirrors stripAccountTypePrefix from @/lib/accounts but inline so this
+// helper has no surprise import cycles when used in tests.
+function shortLabel(name: string): string {
+  const i = name.indexOf(':');
+  return i >= 0 ? name.slice(i + 1) : name;
+}
+
+export function partitionForComposition(
+  rows: ReportRow[],
+  total: number,
+  variant: CompositionVariant,
+  topN = 6,
+): { segments: CompositionSegment[]; swatchColors: string[] } {
+  const palette = GRADIENT[variant];
+  const denom = Math.abs(total);
+
+  // Sort by |amount| descending, but remember each row's original index so
+  // we can build a parallel swatchColors array.
+  const indexed = rows.map((r, i) => ({ row: r, i }));
+  indexed.sort((a, b) => Math.abs(b.row.amount) - Math.abs(a.row.amount));
+
+  const swatchColors: string[] = new Array(rows.length).fill(OTHER_BG);
+  const segments: CompositionSegment[] = [];
+
+  const primary = indexed.slice(0, topN);
+  const rest = indexed.slice(topN);
+
+  primary.forEach(({ row, i }, segIdx) => {
+    const color = palette[segIdx];
+    const amount = Math.abs(row.amount);
+    segments.push({
+      label: shortLabel(row.account_name),
+      amount,
+      pct: denom === 0 ? 0 : (amount / denom) * 100,
+      colorClass: color.bg,
+      textClass: color.text,
+      isOther: false,
+    });
+    swatchColors[i] = color.bg;
+  });
+
+  if (rest.length > 0) {
+    const sum = rest.reduce((acc, { row }) => acc + Math.abs(row.amount), 0);
+    segments.push({
+      label: `Other (${rest.length})`,
+      amount: sum,
+      pct: denom === 0 ? 0 : (sum / denom) * 100,
+      colorClass: OTHER_BG,
+      textClass: OTHER_TEXT,
+      isOther: true,
+    });
+    // swatchColors for rest indices remain OTHER_BG (already set above).
+  }
+
+  return { segments, swatchColors };
+}

--- a/spa/src/components/reports/CompositionBar.tsx
+++ b/spa/src/components/reports/CompositionBar.tsx
@@ -1,3 +1,4 @@
+import { stripAccountTypePrefix } from '@/lib/accounts';
 import type { ReportRow } from '@/lib/types';
 
 export type CompositionVariant = 'income' | 'expense';
@@ -33,14 +34,6 @@ const GRADIENT: Record<CompositionVariant, { bg: string; text: string }[]> = {
 const OTHER_BG = 'bg-slate-300';
 const OTHER_TEXT = 'text-slate-700';
 
-// Strip an account-type prefix like "Expenses:" or "Income:".
-// Mirrors stripAccountTypePrefix from @/lib/accounts but inline so this
-// helper has no surprise import cycles when used in tests.
-function shortLabel(name: string): string {
-  const i = name.indexOf(':');
-  return i >= 0 ? name.slice(i + 1) : name;
-}
-
 export function partitionForComposition(
   rows: ReportRow[],
   total: number,
@@ -64,10 +57,11 @@ export function partitionForComposition(
   primary.forEach(({ row, i }, segIdx) => {
     const color = palette[segIdx];
     const amount = Math.abs(row.amount);
+    // Mixed-sign rows can push |amount|/|total| > 1; clamp so widths stay valid.
     segments.push({
-      label: shortLabel(row.account_name),
+      label: stripAccountTypePrefix(row.account_name),
       amount,
-      pct: denom === 0 ? 0 : (amount / denom) * 100,
+      pct: denom === 0 ? 0 : Math.min(100, (amount / denom) * 100),
       colorClass: color.bg,
       textClass: color.text,
       isOther: false,
@@ -80,7 +74,7 @@ export function partitionForComposition(
     segments.push({
       label: `Other (${rest.length})`,
       amount: sum,
-      pct: denom === 0 ? 0 : (sum / denom) * 100,
+      pct: denom === 0 ? 0 : Math.min(100, (sum / denom) * 100),
       colorClass: OTHER_BG,
       textClass: OTHER_TEXT,
       isOther: true,

--- a/spa/src/components/reports/CompositionBar.tsx
+++ b/spa/src/components/reports/CompositionBar.tsx
@@ -96,7 +96,10 @@ interface Props {
 
 function buildAriaLabel(segments: CompositionSegment[], variant: CompositionVariant): string {
   const which = variant === 'income' ? 'Income' : 'Expense';
-  const top = segments.slice(0, 3).map((s) => `${s.label} ${Math.round(s.pct)}%`).join(', ');
+  const top = segments
+    .slice(0, 3)
+    .map((s) => `${s.label} ${Math.round(s.pct)}%`)
+    .join(', ');
   return `${which} composition: ${top}`;
 }
 

--- a/spa/src/components/reports/CompositionBar.tsx
+++ b/spa/src/components/reports/CompositionBar.tsx
@@ -134,8 +134,8 @@ export function CompositionBar({ rows, total, currency, variant, className }: Pr
         >
           {segments.map((seg, i) => (
             <button
-              // label is unique per segment (account name, or the single "Other" bucket).
-              key={seg.label}
+              // fullName is unique per segment (unmodified account name, or "Other (N)").
+              key={seg.fullName}
               type="button"
               data-testid="composition-segment"
               className={cn(
@@ -167,8 +167,7 @@ export function CompositionBar({ rows, total, currency, variant, className }: Pr
             const flip = centerPct > 70;
             return (
               <div
-                role="status"
-                aria-live="polite"
+                aria-hidden="true"
                 data-testid="composition-tooltip"
                 className="pointer-events-none absolute z-10 mt-1 rounded-md border border-border bg-popover px-2 py-1 text-[11px] text-popover-foreground shadow-sm"
                 style={{

--- a/spa/src/components/reports/CompositionBar.tsx
+++ b/spa/src/components/reports/CompositionBar.tsx
@@ -1,4 +1,5 @@
 import { stripAccountTypePrefix } from '@/lib/accounts';
+import { cn } from '@/lib/cn';
 import type { ReportRow } from '@/lib/types';
 
 export type CompositionVariant = 'income' | 'expense';
@@ -83,4 +84,42 @@ export function partitionForComposition(
   }
 
   return { segments, swatchColors };
+}
+
+interface Props {
+  rows: ReportRow[];
+  total: number;
+  currency: string;
+  variant: CompositionVariant;
+  className?: string;
+}
+
+function buildAriaLabel(segments: CompositionSegment[], variant: CompositionVariant): string {
+  const which = variant === 'income' ? 'Income' : 'Expense';
+  const top = segments.slice(0, 3).map((s) => `${s.label} ${Math.round(s.pct)}%`).join(', ');
+  return `${which} composition: ${top}`;
+}
+
+export function CompositionBar({ rows, total, currency: _currency, variant, className }: Props) {
+  if (rows.length === 0 || total === 0) return null;
+  const { segments } = partitionForComposition(rows, total, variant);
+  return (
+    <div
+      data-testid="composition-bar"
+      role="img"
+      aria-label={buildAriaLabel(segments, variant)}
+      className={cn('flex h-7 w-full overflow-hidden rounded text-[10px] font-medium', className)}
+    >
+      {segments.map((seg) => (
+        <div
+          // label is unique per segment (account name, or the single "Other" bucket).
+          key={seg.label}
+          data-testid="composition-segment"
+          className={cn('flex items-center justify-start', seg.colorClass, seg.textClass)}
+          style={{ width: `${seg.pct}%` }}
+          title={`${seg.label}: ${Math.round(seg.pct)}%`}
+        />
+      ))}
+    </div>
+  );
 }

--- a/spa/src/components/reports/NetWorthChart.tsx
+++ b/spa/src/components/reports/NetWorthChart.tsx
@@ -179,7 +179,11 @@ export function NetWorthChart({ points, currency, formatCents, asOfDate, classNa
               aria-live="polite"
               className={cn(
                 'pointer-events-none absolute z-10 -translate-y-full rounded-md border border-border bg-popover px-2 py-1 text-[11px] text-popover-foreground shadow-sm',
-                hoverLeftPct > 70 ? '-translate-x-full' : hoverLeftPct < 30 ? '' : '-translate-x-1/2',
+                hoverLeftPct > 70
+                  ? '-translate-x-full'
+                  : hoverLeftPct < 30
+                    ? ''
+                    : '-translate-x-1/2',
               )}
               style={{ left: `${hoverLeftPct}%`, top: `${Math.max(hoverTopPct - 4, 0)}%` }}
             >

--- a/spa/src/components/reports/ReportRowTable.tsx
+++ b/spa/src/components/reports/ReportRowTable.tsx
@@ -122,7 +122,7 @@ export function ReportRowTable({
   return (
     <div
       data-testid="report-row-scroll"
-      className="overflow-y-auto rounded-md border"
+      className="overflow-y-auto rounded-md border px-3"
       style={{ maxHeight: `${maxVisibleRows * 2 + 2}rem` }}
     >
       {table}

--- a/spa/src/components/reports/ReportRowTable.tsx
+++ b/spa/src/components/reports/ReportRowTable.tsx
@@ -1,4 +1,5 @@
 import { stripAccountTypePrefix } from '@/lib/accounts';
+import { cn } from '@/lib/cn';
 import { useAmountFormat } from '@/lib/server-config';
 import { DEFAULT_TRANSACTIONS_LIMIT } from '@/lib/transactions-search-params';
 import type { ReportRow } from '@/lib/types';
@@ -10,9 +11,11 @@ interface Props {
   nameToId: Map<string, number>;
   // null → link to /accounts/{id} (Balance Sheet); otherwise drill into Transactions
   period: { startUnix: number; endUnix: number } | null;
+  // parallel to rows; if provided, renders a colored swatch before each account name
+  swatchColors?: string[];
 }
 
-export function ReportRowTable({ rows, currency, nameToId, period }: Props) {
+export function ReportRowTable({ rows, currency, nameToId, period, swatchColors }: Props) {
   const { formatCents } = useAmountFormat();
   if (rows.length === 0) {
     return <p className="text-sm text-muted-foreground">No rows.</p>;
@@ -28,12 +31,30 @@ export function ReportRowTable({ rows, currency, nameToId, period }: Props) {
         </tr>
       </thead>
       <tbody>
-        {rows.map((row) => {
+        {rows.map((row, rowIndex) => {
           const id = nameToId.get(row.account_name);
-          const linkContent = (
+          const labelSpan = (
             <span className="truncate" title={row.account_name}>
               {stripAccountTypePrefix(row.account_name)}
             </span>
+          );
+          const swatch = swatchColors?.[rowIndex] ? (
+            <span
+              data-testid="row-swatch"
+              className={cn(
+                'mr-2 inline-block h-2 w-2 rounded-[2px] align-middle',
+                swatchColors[rowIndex],
+              )}
+              aria-hidden="true"
+            />
+          ) : null;
+          const linkContent = swatch ? (
+            <span className="inline-flex min-w-0 items-center">
+              {swatch}
+              {labelSpan}
+            </span>
+          ) : (
+            labelSpan
           );
           return (
             <tr key={row.account_name} className="border-t hover:bg-muted/40">

--- a/spa/src/components/reports/ReportRowTable.tsx
+++ b/spa/src/components/reports/ReportRowTable.tsx
@@ -13,16 +13,31 @@ interface Props {
   period: { startUnix: number; endUnix: number } | null;
   // parallel to rows; if provided, renders a colored swatch before each account name
   swatchColors?: string[];
+  // when set, the table scrolls vertically and the header sticks to the top
+  // after this many rows fit. Unset → render unchanged (no wrapper, no sticky).
+  maxVisibleRows?: number;
 }
 
-export function ReportRowTable({ rows, currency, nameToId, period, swatchColors }: Props) {
+export function ReportRowTable({
+  rows,
+  currency,
+  nameToId,
+  period,
+  swatchColors,
+  maxVisibleRows,
+}: Props) {
   const { formatCents } = useAmountFormat();
   if (rows.length === 0) {
     return <p className="text-sm text-muted-foreground">No rows.</p>;
   }
-  return (
+  const table = (
     <table className="w-full text-sm">
-      <thead className="text-xs uppercase text-muted-foreground">
+      <thead
+        className={cn(
+          'text-xs uppercase text-muted-foreground',
+          maxVisibleRows !== undefined && 'sticky top-0 z-10 bg-background',
+        )}
+      >
         <tr>
           <th className="py-1 text-left font-medium">Account</th>
           <th className="py-1 text-left font-medium">Offset</th>
@@ -100,5 +115,17 @@ export function ReportRowTable({ rows, currency, nameToId, period, swatchColors 
         })}
       </tbody>
     </table>
+  );
+
+  if (maxVisibleRows === undefined) return table;
+
+  return (
+    <div
+      data-testid="report-row-scroll"
+      className="overflow-y-auto rounded-md border"
+      style={{ maxHeight: `${maxVisibleRows * 2 + 2}rem` }}
+    >
+      {table}
+    </div>
   );
 }

--- a/spa/src/lib/period.ts
+++ b/spa/src/lib/period.ts
@@ -98,8 +98,12 @@ function formatRangeLabel(from: string, to: string): string {
 
 export function resolvePeriod(
   search: PeriodSearch,
-  nowUnix: number = Date.now() / 1000,
+  nowUnixRaw: number = Date.now() / 1000,
 ): ResolvedPeriod {
+  // Unix-second values flow out to URL search params (start_time/end_time) which
+  // are validated as integers by the transactions page schema. Floor at the
+  // source so every branch returns integer-valued startUnix/endUnix.
+  const nowUnix = Math.floor(nowUnixRaw);
   const now = new Date(nowUnix * 1000);
   const curYear = now.getUTCFullYear();
   const curMonth = now.getUTCMonth() + 1; // 1-12

--- a/spa/src/routes/reports.balance-sheet.tsx
+++ b/spa/src/routes/reports.balance-sheet.tsx
@@ -65,8 +65,7 @@ function BalanceSheetPage() {
   const tl = result.total_liabilities[currency] ?? 0;
   const te = result.total_equity[currency] ?? 0;
   const nw = result.net_worth[currency] ?? 0;
-  const liabilitiesCount = (result.liabilities ?? []).filter((r) => r.currency === currency)
-    .length;
+  const liabilitiesCount = (result.liabilities ?? []).filter((r) => r.currency === currency).length;
 
   const assetsCount = (result.assets ?? []).filter((r) => r.currency === currency).length;
   const equityCount = (result.equity ?? []).filter((r) => r.currency === currency).length;

--- a/spa/src/routes/reports.expense-breakdown.tsx
+++ b/spa/src/routes/reports.expense-breakdown.tsx
@@ -79,7 +79,7 @@ function ExpenseBreakdownPageBody() {
   const { swatchColors } = partitionForComposition(rows, expense, 'expense');
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <PeriodPicker value={search} onChange={setSearch} label={period.label} />
       {rows.length === 0 ? (
         <p className="text-sm text-muted-foreground">No expenses in {period.label}.</p>

--- a/spa/src/routes/reports.expense-breakdown.tsx
+++ b/spa/src/routes/reports.expense-breakdown.tsx
@@ -1,7 +1,7 @@
+import { CompositionBar, partitionForComposition } from '@/components/reports/CompositionBar';
 import { CurrencyFooter } from '@/components/reports/CurrencyFooter';
 import { KpiCard } from '@/components/reports/KpiCard';
 import { PeriodPicker } from '@/components/reports/PeriodPicker';
-import { ProportionBar } from '@/components/reports/ProportionBar';
 import { ReportRowTable } from '@/components/reports/ReportRowTable';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -69,6 +69,8 @@ function ExpenseBreakdownPage() {
   const expense = result.total_expense[currency] ?? 0;
   const rows = (result.expense_rows ?? []).filter((r) => r.currency === currency);
 
+  const { swatchColors } = partitionForComposition(rows, expense, 'expense');
+
   return (
     <div className="space-y-6">
       <PeriodPicker value={search} onChange={setSearch} label={period.label} />
@@ -79,12 +81,16 @@ function ExpenseBreakdownPage() {
           <div className="max-w-xs">
             <KpiCard label="Total Expense" amount={expense} currency={currency} variant="red" />
           </div>
-          <ProportionBar rows={rows} total={expense} currency={currency} variant="expense" />
+          <section>
+            <h2 className="mb-2 text-sm font-semibold">Composition</h2>
+            <CompositionBar rows={rows} total={expense} currency={currency} variant="expense" />
+          </section>
           <ReportRowTable
             rows={rows}
             currency={currency}
             nameToId={nameToId}
             period={{ startUnix: period.startUnix, endUnix: period.endUnix }}
+            swatchColors={swatchColors}
           />
           <CurrencyFooter
             defaultCurrency={currency}

--- a/spa/src/routes/reports.expense-breakdown.tsx
+++ b/spa/src/routes/reports.expense-breakdown.tsx
@@ -98,6 +98,7 @@ function ExpenseBreakdownPageBody() {
             nameToId={nameToId}
             period={{ startUnix: period.startUnix, endUnix: period.endUnix }}
             swatchColors={swatchColors}
+            maxVisibleRows={8}
           />
           <CurrencyFooter
             defaultCurrency={currency}

--- a/spa/src/routes/reports.expense-breakdown.tsx
+++ b/spa/src/routes/reports.expense-breakdown.tsx
@@ -21,6 +21,13 @@ export const Route = createFileRoute('/reports/expense-breakdown')({
 });
 
 function ExpenseBreakdownPage() {
+  // Force a fresh mount on every period change so no stale closure or
+  // child state can leak across query-key changes.
+  const search = Route.useSearch();
+  return <ExpenseBreakdownPageBody key={JSON.stringify(search)} />;
+}
+
+function ExpenseBreakdownPageBody() {
   const { defaults } = useServerConfig();
   const currency = defaults.currency;
   const search = Route.useSearch();

--- a/spa/src/routes/reports.income-breakdown.tsx
+++ b/spa/src/routes/reports.income-breakdown.tsx
@@ -1,7 +1,7 @@
+import { CompositionBar, partitionForComposition } from '@/components/reports/CompositionBar';
 import { CurrencyFooter } from '@/components/reports/CurrencyFooter';
 import { KpiCard } from '@/components/reports/KpiCard';
 import { PeriodPicker } from '@/components/reports/PeriodPicker';
-import { ProportionBar } from '@/components/reports/ProportionBar';
 import { ReportRowTable } from '@/components/reports/ReportRowTable';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -69,6 +69,8 @@ function IncomeBreakdownPage() {
   const income = result.total_income[currency] ?? 0;
   const rows = (result.income_rows ?? []).filter((r) => r.currency === currency);
 
+  const { swatchColors } = partitionForComposition(rows, income, 'income');
+
   return (
     <div className="space-y-6">
       <PeriodPicker value={search} onChange={setSearch} label={period.label} />
@@ -79,12 +81,16 @@ function IncomeBreakdownPage() {
           <div className="max-w-xs">
             <KpiCard label="Total Income" amount={income} currency={currency} variant="green" />
           </div>
-          <ProportionBar rows={rows} total={income} currency={currency} variant="income" />
+          <section>
+            <h2 className="mb-2 text-sm font-semibold">Composition</h2>
+            <CompositionBar rows={rows} total={income} currency={currency} variant="income" />
+          </section>
           <ReportRowTable
             rows={rows}
             currency={currency}
             nameToId={nameToId}
             period={{ startUnix: period.startUnix, endUnix: period.endUnix }}
+            swatchColors={swatchColors}
           />
           <CurrencyFooter
             defaultCurrency={currency}

--- a/spa/src/routes/reports.income-breakdown.tsx
+++ b/spa/src/routes/reports.income-breakdown.tsx
@@ -21,6 +21,13 @@ export const Route = createFileRoute('/reports/income-breakdown')({
 });
 
 function IncomeBreakdownPage() {
+  // Force a fresh mount on every period change so no stale closure or
+  // child state can leak across query-key changes.
+  const search = Route.useSearch();
+  return <IncomeBreakdownPageBody key={JSON.stringify(search)} />;
+}
+
+function IncomeBreakdownPageBody() {
   const { defaults } = useServerConfig();
   const currency = defaults.currency;
   const search = Route.useSearch();

--- a/spa/src/routes/reports.income-breakdown.tsx
+++ b/spa/src/routes/reports.income-breakdown.tsx
@@ -79,7 +79,7 @@ function IncomeBreakdownPageBody() {
   const { swatchColors } = partitionForComposition(rows, income, 'income');
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <PeriodPicker value={search} onChange={setSearch} label={period.label} />
       {rows.length === 0 ? (
         <p className="text-sm text-muted-foreground">No income in {period.label}.</p>

--- a/spa/src/routes/reports.income-breakdown.tsx
+++ b/spa/src/routes/reports.income-breakdown.tsx
@@ -98,6 +98,7 @@ function IncomeBreakdownPageBody() {
             nameToId={nameToId}
             period={{ startUnix: period.startUnix, endUnix: period.endUnix }}
             swatchColors={swatchColors}
+            maxVisibleRows={8}
           />
           <CurrencyFooter
             defaultCurrency={currency}

--- a/spa/src/test/components/ReportRowTable.test.tsx
+++ b/spa/src/test/components/ReportRowTable.test.tsx
@@ -1,0 +1,52 @@
+import { render } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import type { ReportRow } from '../../lib/types';
+import { withServerConfig } from '../test-app';
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    // biome-ignore lint/a11y/useValidAnchor: test stub for Link, not a real navigable anchor
+    Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  };
+});
+
+// Import AFTER the mock so the component picks up the stub.
+import { ReportRowTable } from '../../components/reports/ReportRowTable';
+
+const rows: ReportRow[] = [
+  { account_name: 'Expenses:Rent', offset_account: '', amount: 1800, currency: 'USD', tx_count: 1 },
+  { account_name: 'Expenses:Food', offset_account: '', amount: 642, currency: 'USD', tx_count: 1 },
+];
+const nameToId = new Map<string, number>([
+  ['Expenses:Rent', 1],
+  ['Expenses:Food', 2],
+]);
+
+test('ReportRowTable: renders no swatches when swatchColors is undefined', () => {
+  const { container } = render(
+    withServerConfig(
+      <ReportRowTable rows={rows} currency="USD" nameToId={nameToId} period={null} />,
+    ),
+  );
+  expect(container.querySelectorAll('[data-testid="row-swatch"]').length).toBe(0);
+});
+
+test('ReportRowTable: renders one swatch per row when swatchColors provided', () => {
+  const { container } = render(
+    withServerConfig(
+      <ReportRowTable
+        rows={rows}
+        currency="USD"
+        nameToId={nameToId}
+        period={null}
+        swatchColors={['bg-red-700', 'bg-red-600']}
+      />,
+    ),
+  );
+  const swatches = container.querySelectorAll('[data-testid="row-swatch"]');
+  expect(swatches).toHaveLength(2);
+  expect(swatches[0].className).toContain('bg-red-700');
+  expect(swatches[1].className).toContain('bg-red-600');
+});

--- a/spa/src/test/components/ReportRowTable.test.tsx
+++ b/spa/src/test/components/ReportRowTable.test.tsx
@@ -50,3 +50,35 @@ test('ReportRowTable: renders one swatch per row when swatchColors provided', ()
   expect(swatches[0].className).toContain('bg-red-700');
   expect(swatches[1].className).toContain('bg-red-600');
 });
+
+test('ReportRowTable: no scroll wrapper when maxVisibleRows is undefined', () => {
+  const { container } = render(
+    withServerConfig(
+      <ReportRowTable rows={rows} currency="USD" nameToId={nameToId} period={null} />,
+    ),
+  );
+  expect(container.querySelector('[data-testid="report-row-scroll"]')).toBeNull();
+});
+
+test('ReportRowTable: scroll wrapper and sticky header when maxVisibleRows is set', () => {
+  const { container } = render(
+    withServerConfig(
+      <ReportRowTable
+        rows={rows}
+        currency="USD"
+        nameToId={nameToId}
+        period={null}
+        maxVisibleRows={8}
+      />,
+    ),
+  );
+  const wrapper = container.querySelector<HTMLElement>('[data-testid="report-row-scroll"]');
+  expect(wrapper).not.toBeNull();
+  expect(wrapper?.className).toContain('overflow-y-auto');
+  // 8 rows × 2rem + 2rem (sticky header) = 18rem
+  expect(wrapper?.style.maxHeight).toBe('18rem');
+
+  const thead = container.querySelector('thead');
+  expect(thead?.className).toContain('sticky');
+  expect(thead?.className).toContain('top-0');
+});

--- a/spa/src/test/period.test.ts
+++ b/spa/src/test/period.test.ts
@@ -101,3 +101,22 @@ describe('previousPeriod', () => {
     });
   });
 });
+
+describe('resolvePeriod: integer Unix timestamps', () => {
+  // Regression: ResolvedPeriod's startUnix/endUnix flow into URL search params
+  // (start_time/end_time) that the transactions page validates as int. A
+  // fractional nowUnix (the default — Date.now()/1000) must not leak through.
+  const fractionalNow = 1717200000.456;
+
+  test.each([
+    ['this-month', { range: 'this-month' } as const],
+    ['last-month', { range: 'last-month' } as const],
+    ['ytd', { range: 'ytd' } as const],
+    ['last-12mo', { range: 'last-12mo' } as const],
+    ['custom', { range: 'custom', from: '2026-01-15', to: '2026-03-20' } as const],
+  ])('%s returns integer startUnix and endUnix', (_label, search) => {
+    const resolved = resolvePeriod(search, fractionalNow);
+    expect(Number.isInteger(resolved.startUnix)).toBe(true);
+    expect(Number.isInteger(resolved.endUnix)).toBe(true);
+  });
+});

--- a/spa/src/test/reports.composition-bar.test.tsx
+++ b/spa/src/test/reports.composition-bar.test.tsx
@@ -1,0 +1,97 @@
+import { expect, test } from 'vitest';
+import { partitionForComposition } from '../components/reports/CompositionBar';
+import type { ReportRow } from '../lib/types';
+
+const row = (name: string, amount: number, offset = ''): ReportRow => ({
+  account_name: name,
+  offset_account: offset,
+  amount,
+  currency: 'USD',
+  tx_count: 1,
+});
+
+test('partition: returns one segment per row when rows ≤ 6', () => {
+  const rows = [row('Rent', 1800), row('Groceries', 642), row('Dining', 520)];
+  const { segments, swatchColors } = partitionForComposition(rows, 2962, 'expense');
+  expect(segments).toHaveLength(3);
+  expect(segments[0].label).toBe('Rent');
+  expect(segments[0].amount).toBe(1800);
+  expect(segments[0].isOther).toBe(false);
+  expect(swatchColors).toHaveLength(3);
+});
+
+test('partition: rows beyond top 6 collapse into a single Other segment', () => {
+  const rows = [
+    row('A', 1000),
+    row('B', 900),
+    row('C', 800),
+    row('D', 700),
+    row('E', 600),
+    row('F', 500),
+    row('G', 400),
+    row('H', 300),
+    row('I', 200),
+  ];
+  const total = 5400;
+  const { segments } = partitionForComposition(rows, total, 'expense');
+  expect(segments).toHaveLength(7); // top 6 + Other
+  const other = segments[6];
+  expect(other.isOther).toBe(true);
+  expect(other.amount).toBe(900); // G+H+I = 400+300+200
+  expect(other.label).toBe('Other (3)');
+});
+
+test('partition: sorts segments by |amount| descending', () => {
+  const rows = [row('Small', 100), row('Big', 5000), row('Mid', 1000)];
+  const { segments } = partitionForComposition(rows, 6100, 'expense');
+  expect(segments.map((s) => s.label)).toEqual(['Big', 'Mid', 'Small']);
+});
+
+test('partition: segment pcts use |total| as denominator', () => {
+  const rows = [row('A', -1000), row('B', -3000)];
+  const { segments } = partitionForComposition(rows, -4000, 'expense');
+  expect(segments[0].pct).toBeCloseTo(75, 5);
+  expect(segments[1].pct).toBeCloseTo(25, 5);
+});
+
+test('partition: total of 0 yields pct=0 for every segment (no NaN)', () => {
+  const rows = [row('A', 0), row('B', 0)];
+  const { segments } = partitionForComposition(rows, 0, 'expense');
+  expect(segments.every((s) => s.pct === 0)).toBe(true);
+});
+
+test('partition: expense variant uses red gradient, income uses emerald', () => {
+  const rows = [row('A', 100)];
+  expect(partitionForComposition(rows, 100, 'expense').segments[0].colorClass).toBe('bg-red-700');
+  expect(partitionForComposition(rows, 100, 'income').segments[0].colorClass).toBe(
+    'bg-emerald-700',
+  );
+});
+
+test('partition: swatchColors is parallel to input rows (not segment order)', () => {
+  // Big-Mid-Small is the sort order for segments, but the table needs
+  // colors in input order: Small, Big, Mid.
+  const rows = [row('Small', 100), row('Big', 5000), row('Mid', 1000)];
+  const { swatchColors, segments } = partitionForComposition(rows, 6100, 'expense');
+  // The "Big" row (input index 1) maps to the darkest shade.
+  expect(swatchColors[1]).toBe(segments[0].colorClass);
+  // "Mid" → second darkest, "Small" → third darkest.
+  expect(swatchColors[2]).toBe(segments[1].colorClass);
+  expect(swatchColors[0]).toBe(segments[2].colorClass);
+});
+
+test('partition: rows beyond top 6 get the Other (neutral) swatch', () => {
+  const rows = [
+    row('A', 1000),
+    row('B', 900),
+    row('C', 800),
+    row('D', 700),
+    row('E', 600),
+    row('F', 500),
+    row('G', 400),
+  ];
+  const { swatchColors, segments } = partitionForComposition(rows, 4900, 'expense');
+  const otherSeg = segments.find((s) => s.isOther);
+  expect(otherSeg).toBeDefined();
+  expect(swatchColors[6]).toBe(otherSeg?.colorClass); // G is collapsed
+});

--- a/spa/src/test/reports.composition-bar.test.tsx
+++ b/spa/src/test/reports.composition-bar.test.tsx
@@ -165,3 +165,44 @@ test('component: container has role=img and an aria-label', () => {
   expect(bar?.getAttribute('role')).toBe('img');
   expect(bar?.getAttribute('aria-label')).toMatch(/Rent/);
 });
+
+test('inline label: segment ≥9% shows "name · NN%"', () => {
+  // 1800/2962 ≈ 60.8% → ≥9%
+  const rows = [row('Rent', 1800), row('Groceries', 642), row('Dining', 520)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={2962} currency="USD" variant="expense" />,
+  );
+  const big = container.querySelectorAll<HTMLElement>('[data-testid="composition-segment"]')[0];
+  expect(big.textContent).toContain('Rent');
+  expect(big.textContent).toMatch(/61%/);
+});
+
+test('inline label: segment between 5% and 9% shows only "NN%"', () => {
+  // Construct: total 100, one row at 7
+  const rows = [row('Big', 93), row('Tiny', 7)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={100} currency="USD" variant="expense" />,
+  );
+  const small = container.querySelectorAll<HTMLElement>('[data-testid="composition-segment"]')[1];
+  expect(small.textContent?.trim()).toBe('7%');
+  expect(small.textContent).not.toContain('Tiny');
+});
+
+test('inline label: segment <5% shows nothing', () => {
+  const rows = [row('Big', 98), row('Tiny', 2)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={100} currency="USD" variant="expense" />,
+  );
+  const small = container.querySelectorAll<HTMLElement>('[data-testid="composition-segment"]')[1];
+  expect(small.textContent?.trim()).toBe('');
+});
+
+test('ticks: 0% / 50% / 100% labels render below the bar', () => {
+  const rows = [row('A', 100)];
+  const { getByText } = renderBar(
+    <CompositionBar rows={rows} total={100} currency="USD" variant="expense" />,
+  );
+  expect(getByText('0%')).toBeInTheDocument();
+  expect(getByText('50%')).toBeInTheDocument();
+  expect(getByText('100%')).toBeInTheDocument();
+});

--- a/spa/src/test/reports.composition-bar.test.tsx
+++ b/spa/src/test/reports.composition-bar.test.tsx
@@ -95,3 +95,12 @@ test('partition: rows beyond top 6 get the Other (neutral) swatch', () => {
   expect(otherSeg).toBeDefined();
   expect(swatchColors[6]).toBe(otherSeg?.colorClass); // G is collapsed
 });
+
+test('partition: pct is clamped to 100 when |amount| exceeds |total|', () => {
+  // Mixed-sign rows can produce a single |amount| > |total|.
+  // Without clamping, pct would be 160 here.
+  const rows = [row('A', 8000), row('B', -3000)];
+  const { segments } = partitionForComposition(rows, 5000, 'expense');
+  expect(segments[0].pct).toBeLessThanOrEqual(100);
+  expect(segments[0].pct).toBe(100);
+});

--- a/spa/src/test/reports.composition-bar.test.tsx
+++ b/spa/src/test/reports.composition-bar.test.tsx
@@ -100,13 +100,15 @@ test('partition: rows beyond top 6 get the Other (neutral) swatch', () => {
   expect(swatchColors[6]).toBe(otherSeg?.colorClass); // G is collapsed
 });
 
-test('partition: pct is clamped to 100 when |amount| exceeds |total|', () => {
-  // Mixed-sign rows can produce a single |amount| > |total|.
-  // Without clamping, pct would be 160 here.
+test('partition: pct is clamped to 100 when |amount| exceeds the denominator', () => {
+  // Mixed-sign rows can produce a single |amount| > |total|. The denominator
+  // is now max(|total|, sum of |row.amount|) = 11000 here (8000 + 3000),
+  // so A's pct is 8000/11000 ≈ 72.7%, comfortably under the clamp ceiling.
+  // Still assert the invariant the clamp protects: no segment exceeds 100%.
   const rows = [row('A', 8000), row('B', -3000)];
   const { segments } = partitionForComposition(rows, 5000, 'expense');
   expect(segments[0].pct).toBeLessThanOrEqual(100);
-  expect(segments[0].pct).toBe(100);
+  expect(segments[0].pct).toBeCloseTo(72.72727272727273, 5);
 });
 
 // All component tests wrap with withServerConfig so they keep working once
@@ -272,4 +274,26 @@ test('tooltip: marked aria-hidden (decorative; button aria-label handles AT)', a
   expect(tooltip?.getAttribute('aria-hidden')).toBe('true');
   expect(tooltip?.getAttribute('role')).toBeNull();
   expect(tooltip?.getAttribute('aria-live')).toBeNull();
+});
+
+test('partition: uses sum-of-rows as denominator when rows exceed total', () => {
+  // Stale state could feed a small `total` and large rows. The bar must
+  // still render with widths that sum to ≤ 100%.
+  const rows = [row('A', 50), row('B', 30), row('C', 20)];
+  // Pass an inconsistent total (smaller than rows sum 100).
+  const { segments } = partitionForComposition(rows, 10, 'expense');
+  // Sum of pcts should be ≤ 100, not 1000.
+  const sum = segments.reduce((acc, s) => acc + s.pct, 0);
+  expect(sum).toBeLessThanOrEqual(100);
+  // Largest row is exactly 50% of the rows-sum denominator.
+  expect(segments[0].pct).toBeCloseTo(50, 5);
+});
+
+test('partition: still uses |total| as denominator when total exceeds rows sum', () => {
+  // Inverse case: total is larger than rows actually sum to. The bar should
+  // not overstate categories — segments should not fill the bar.
+  const rows = [row('A', 100)];
+  const { segments } = partitionForComposition(rows, 1000, 'expense');
+  // 100 / 1000 = 10%
+  expect(segments[0].pct).toBeCloseTo(10, 5);
 });

--- a/spa/src/test/reports.composition-bar.test.tsx
+++ b/spa/src/test/reports.composition-bar.test.tsx
@@ -1,6 +1,9 @@
+import { render as rtlRender } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { expect, test } from 'vitest';
-import { partitionForComposition } from '../components/reports/CompositionBar';
+import { CompositionBar, partitionForComposition } from '../components/reports/CompositionBar';
 import type { ReportRow } from '../lib/types';
+import { withServerConfig } from './test-app';
 
 const row = (name: string, amount: number, offset = ''): ReportRow => ({
   account_name: name,
@@ -103,4 +106,62 @@ test('partition: pct is clamped to 100 when |amount| exceeds |total|', () => {
   const { segments } = partitionForComposition(rows, 5000, 'expense');
   expect(segments[0].pct).toBeLessThanOrEqual(100);
   expect(segments[0].pct).toBe(100);
+});
+
+// All component tests wrap with withServerConfig so they keep working once
+// Task 4 adds useAmountFormat() to the component.
+const renderBar = (ui: ReactNode) => rtlRender(withServerConfig(ui));
+
+test('component: returns null when rows is empty', () => {
+  const { container } = renderBar(
+    <CompositionBar rows={[]} total={0} currency="USD" variant="expense" />,
+  );
+  // ServerConfig wrapper renders, but the component itself returns null.
+  expect(container.querySelector('[data-testid="composition-bar"]')).toBeNull();
+});
+
+test('component: returns null when total is 0', () => {
+  const rows = [row('A', 0)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={0} currency="USD" variant="expense" />,
+  );
+  expect(container.querySelector('[data-testid="composition-bar"]')).toBeNull();
+});
+
+test('component: renders one DOM segment per partition segment', () => {
+  const rows = [row('Rent', 1800), row('Groceries', 642), row('Dining', 520)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={2962} currency="USD" variant="expense" />,
+  );
+  const segs = container.querySelectorAll('[data-testid="composition-segment"]');
+  expect(segs).toHaveLength(3);
+});
+
+test('component: segment widths reflect partition pcts', () => {
+  const rows = [row('A', 7500), row('B', 2500)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={10000} currency="USD" variant="expense" />,
+  );
+  const segs = container.querySelectorAll<HTMLElement>('[data-testid="composition-segment"]');
+  expect(segs[0].style.width).toBe('75%');
+  expect(segs[1].style.width).toBe('25%');
+});
+
+test('component: expense variant applies red gradient to biggest segment', () => {
+  const rows = [row('A', 100)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={100} currency="USD" variant="expense" />,
+  );
+  const seg = container.querySelector('[data-testid="composition-segment"]');
+  expect(seg?.className).toContain('bg-red-700');
+});
+
+test('component: container has role=img and an aria-label', () => {
+  const rows = [row('Rent', 1800), row('Groceries', 642), row('Dining', 520)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={2962} currency="USD" variant="expense" />,
+  );
+  const bar = container.querySelector('[data-testid="composition-bar"]');
+  expect(bar?.getAttribute('role')).toBe('img');
+  expect(bar?.getAttribute('aria-label')).toMatch(/Rent/);
 });

--- a/spa/src/test/reports.composition-bar.test.tsx
+++ b/spa/src/test/reports.composition-bar.test.tsx
@@ -258,3 +258,18 @@ test('tooltip: keyboard focus also activates the tooltip', async () => {
   await user.tab();
   expect(await findByText('$642.00')).toBeInTheDocument();
 });
+
+test('tooltip: marked aria-hidden (decorative; button aria-label handles AT)', async () => {
+  const user = userEvent.setup();
+  const rows = [row('Rent', 180000), row('Groceries', 64200)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={244200} currency="USD" variant="expense" />,
+  );
+  const seg = container.querySelectorAll<HTMLElement>('[data-testid="composition-segment"]')[0];
+  await user.hover(seg);
+  const tooltip = container.querySelector('[data-testid="composition-tooltip"]');
+  expect(tooltip).not.toBeNull();
+  expect(tooltip?.getAttribute('aria-hidden')).toBe('true');
+  expect(tooltip?.getAttribute('role')).toBeNull();
+  expect(tooltip?.getAttribute('aria-live')).toBeNull();
+});

--- a/spa/src/test/reports.composition-bar.test.tsx
+++ b/spa/src/test/reports.composition-bar.test.tsx
@@ -1,4 +1,5 @@
 import { render as rtlRender } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { expect, test } from 'vitest';
 import { CompositionBar, partitionForComposition } from '../components/reports/CompositionBar';
@@ -205,4 +206,55 @@ test('ticks: 0% / 50% / 100% labels render below the bar', () => {
   expect(getByText('0%')).toBeInTheDocument();
   expect(getByText('50%')).toBeInTheDocument();
   expect(getByText('100%')).toBeInTheDocument();
+});
+
+test('a11y: segments are focusable buttons', () => {
+  const rows = [row('Rent', 1800), row('Groceries', 642)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={2442} currency="USD" variant="expense" />,
+  );
+  const segs = container.querySelectorAll<HTMLElement>('[data-testid="composition-segment"]');
+  expect(segs[0].tagName).toBe('BUTTON');
+  expect(segs[0].getAttribute('type')).toBe('button');
+});
+
+test('tooltip: hovering a segment shows name, amount, and percent', async () => {
+  const user = userEvent.setup();
+  const rows = [row('Rent', 180000), row('Groceries', 64200)];
+  const { container, findByText } = renderBar(
+    <CompositionBar rows={rows} total={244200} currency="USD" variant="expense" />,
+  );
+  const seg = container.querySelectorAll<HTMLElement>('[data-testid="composition-segment"]')[0];
+  await user.hover(seg);
+  // formatCents("USD", 180000) → "$1,800.00" with default config
+  expect(await findByText('$1,800.00')).toBeInTheDocument();
+  expect(await findByText('Rent')).toBeInTheDocument();
+});
+
+test('tooltip: hovered segment dims the others (opacity-60 on non-hovered)', async () => {
+  const user = userEvent.setup();
+  const rows = [row('A', 60), row('B', 40)];
+  const { container } = renderBar(
+    <CompositionBar rows={rows} total={100} currency="USD" variant="expense" />,
+  );
+  const segs = container.querySelectorAll<HTMLElement>('[data-testid="composition-segment"]');
+  await user.hover(segs[0]);
+  // Hovered segment NOT dimmed; sibling dimmed.
+  expect(segs[0].className).not.toContain('opacity-60');
+  expect(segs[1].className).toContain('opacity-60');
+});
+
+test('tooltip: keyboard focus also activates the tooltip', async () => {
+  const user = userEvent.setup();
+  const rows = [row('Rent', 180000), row('Groceries', 64200)];
+  const { container, findByText } = renderBar(
+    <CompositionBar rows={rows} total={244200} currency="USD" variant="expense" />,
+  );
+  const seg = container.querySelectorAll<HTMLElement>('[data-testid="composition-segment"]')[0];
+  seg.focus();
+  // Same content as hover tooltip.
+  expect(await findByText('$1,800.00')).toBeInTheDocument();
+  // Tab to next segment; tooltip swaps.
+  await user.tab();
+  expect(await findByText('$642.00')).toBeInTheDocument();
 });

--- a/spa/src/test/reports.expense-breakdown.test.tsx
+++ b/spa/src/test/reports.expense-breakdown.test.tsx
@@ -66,4 +66,15 @@ test('renders total expense KPI and rows', async () => {
   // Account-type prefix stripped in rendered text on report pages.
   expect(screen.getAllByText('Rent').length).toBeGreaterThan(0);
   expect(screen.queryByText('Expenses:Rent')).toBeNull();
+
+  // Composition bar is rendered.
+  const bar = document.querySelector('[data-testid="composition-bar"]');
+  expect(bar).not.toBeNull();
+  expect(document.querySelectorAll('[data-testid="composition-segment"]').length).toBe(2);
+
+  // Table rows have colored swatches matching the bar segments.
+  const swatches = document.querySelectorAll('[data-testid="row-swatch"]');
+  expect(swatches.length).toBe(2);
+  // Top expense (Rent, 180000) is the darkest red.
+  expect(swatches[0].className).toContain('bg-red-700');
 });

--- a/spa/src/test/reports.income-breakdown.test.tsx
+++ b/spa/src/test/reports.income-breakdown.test.tsx
@@ -85,4 +85,15 @@ test('renders total income KPI and rows', async () => {
   expect(screen.getByText('$5,248.00')).toBeInTheDocument();
   expect(screen.getAllByText('Income:Salary').length).toBeGreaterThan(0);
   expect(screen.getAllByText('Income:Interest').length).toBeGreaterThan(0);
+
+  // Composition bar is rendered.
+  const bar = document.querySelector('[data-testid="composition-bar"]');
+  expect(bar).not.toBeNull();
+  expect(document.querySelectorAll('[data-testid="composition-segment"]').length).toBe(2);
+
+  // Table rows have colored swatches matching the bar segments.
+  const swatches = document.querySelectorAll('[data-testid="row-swatch"]');
+  expect(swatches.length).toBe(2);
+  // Top income (Salary, 520000) is the darkest emerald.
+  expect(swatches[0].className).toContain('bg-emerald-700');
 });

--- a/spa/src/test/settings.test.tsx
+++ b/spa/src/test/settings.test.tsx
@@ -57,9 +57,7 @@ test('clicking the switch PATCHes /api/config and invalidates server-config', as
   expect(init?.method).toBe('PATCH');
   expect(init?.body).toBe('{"display":{"hide_decimals":true}}');
 
-  await waitFor(() =>
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['server-config'] }),
-  );
+  await waitFor(() => expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['server-config'] }));
 });
 
 test('does not invalidate the server-config query when PATCH fails', async () => {

--- a/spa/src/test/test-app.tsx
+++ b/spa/src/test/test-app.tsx
@@ -23,10 +23,7 @@ export function makeTestApp(initialPath: string) {
 // Test helper for component-level tests that render outside makeTestApp.
 // Wraps children with a stubbed ServerConfig so useServerConfig/useAmountFormat
 // can be called without standing up the full /api/config fetch stack.
-export function withServerConfig(
-  children: ReactNode,
-  override?: Partial<ServerConfig>,
-) {
+export function withServerConfig(children: ReactNode, override?: Partial<ServerConfig>) {
   const config: ServerConfig = {
     defaults: { currency: 'USD', ...(override?.defaults ?? {}) },
     display: { hide_decimals: false, ...(override?.display ?? {}) },


### PR DESCRIPTION
## Summary

- **New `CompositionBar` component** replaces the per-row `ProportionBar` on the Income/Expense Breakdown pages. A single horizontal bar with up to 6 colored segments + an "Other" bucket, inline labels, hover/focus tooltip with full account name + amount + percent, dim-others-on-hover, sticky 0/50/100% ticks. Income Statement keeps its existing `ProportionBar` (not redundant there).
- **`ReportRowTable` gains optional `swatchColors`** (per-row colored dot before the account name) and **optional `maxVisibleRows`** (caps the table at N visible rows with a sticky `<thead>` and a scroll wrapper). The breakdown pages pass `swatchColors` derived from the bar's partition and `maxVisibleRows={8}`.
- **Robustness fixes**: (a) `partitionForComposition` clamps the denominator to `max(|total|, Σ|row.amount|)` so segment widths can't sum to >100% even if the caller passes inconsistent data; (b) breakdown pages remount on period change so no stale render state can leak across query-key changes.
- **Small UX polish**: tightened section spacing on breakdown pages (`space-y-6` → `space-y-4`) and added `px-3` to the row-table scroll wrapper.

Spec: [`docs/superpowers/specs/2026-06-24-spa-breakdown-composition-bar-design.md`](docs/superpowers/specs/2026-06-24-spa-breakdown-composition-bar-design.md) + [`docs/superpowers/specs/2026-06-24-report-row-table-scroll-design.md`](docs/superpowers/specs/2026-06-24-report-row-table-scroll-design.md)
Plan: [`docs/superpowers/plans/2026-06-24-spa-breakdown-composition-bar.md`](docs/superpowers/plans/2026-06-24-spa-breakdown-composition-bar.md) + [`docs/superpowers/plans/2026-06-24-report-row-table-scroll.md`](docs/superpowers/plans/2026-06-24-report-row-table-scroll.md)

## Test plan

- [ ] `cd spa && npm test` → 272 passing (6 pre-existing failures in `balances.test.tsx` / `balances.link.test.tsx` are unrelated to this branch)
- [ ] `cd spa && npm run check` → only the 3 pre-existing errors (`ChartRangeSelector.tsx`, `NetWorthChart.tsx`, `reports.income-statement.tsx:32`) — none in touched files
- [ ] `cd spa && npx tsc -b` → clean
- [ ] Manually verify `/reports/expense-breakdown` and `/reports/income-breakdown`:
  - [ ] Composition bar renders with up to 6 colored segments + "Other"
  - [ ] Inline labels show on segments ≥9%, just percent on 5-9%, nothing below 5%
  - [ ] Hover/focus a segment → tooltip with full account name, formatted amount, percent; other segments dim
  - [ ] Table row dots match the bar segment colors
  - [ ] Detail table scrolls when more than 8 rows; sticky header stays visible
  - [ ] Period switches (e.g. YTD → Last month) render consistent state with no stale rows or overflowing bar
- [ ] Income Statement page (`/reports/income-statement`) is unchanged — still uses ProportionBar Top 5 visuals
- [ ] Balance Sheet page is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)