### PR TITLE
feat: add Docker development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules/
+spa/node_modules/
+spa/dist/
+internal/web/dist/
+.git/
+kea
+kea_test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,21 @@ go test ./internal/service/ -v -run TestDetermineType
 go mod tidy
 ```
 
+## Docker Development
+
+An alternative to installing Go/Node/CGO toolchains locally: a Docker Compose setup provisions an `app` (Go) and `spa` (Node) dev container, bind-mounting the repo so edits on the host are picked up immediately.
+
+```bash
+docker compose up -d                              # start both containers
+docker compose exec app go test ./...             # run Go tests inside the container
+docker compose exec app go run ./cmd/kea <args>    # run the CLI/TUI
+docker compose exec app go run ./cmd/kea serve     # run the web API (reachable at localhost:8080)
+docker compose exec spa npm run dev -- --host 0.0.0.0  # run the SPA dev server (reachable at localhost:5173)
+docker compose down                                # stop both containers
+```
+
+Known limitation: the `app` container runs as root, which causes `TestSwap_FailedSwapKeepsOldConnection` (`internal/store`) to fail under `go test ./...` inside the container — it's a pre-existing test that assumes an unprivileged user, not a bug in the Docker setup.
+
 ## Architecture
 
 KEA is a CLI/TUI personal double-entry accounting tool. The layers are:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,21 @@ go test ./internal/service/ -v -run TestDetermineType
 go mod tidy
 ```
 
+## Docker Development
+
+An alternative to installing Go/Node/CGO toolchains locally: a Docker Compose setup provisions an `app` (Go) and `spa` (Node) dev container, bind-mounting the repo so edits on the host are picked up immediately.
+
+```bash
+docker compose up -d                              # start both containers
+docker compose exec app go test ./...             # run Go tests inside the container
+docker compose exec app go run ./cmd/kea <args>    # run the CLI/TUI
+docker compose exec app go run ./cmd/kea serve     # run the web API (reachable at localhost:8080)
+docker compose exec spa npm run dev -- --host 0.0.0.0  # run the SPA dev server (reachable at localhost:5173)
+docker compose down                                # stop both containers
+```
+
+Known limitation: the `app` container runs as root, which causes `TestSwap_FailedSwapKeepsOldConnection` (`internal/store`) to fail under `go test ./...` inside the container — it's a pre-existing test that assumes an unprivileged user, not a bug in the Docker setup.
+
 ## Architecture
 
 KEA is a CLI/TUI personal double-entry accounting tool. The layers are:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
       context: .
       dockerfile: docker/app.Dockerfile
     working_dir: /workspace
+    environment:
+      - KEA_SERVER_HOST=0.0.0.0
     volumes:
       - .:/workspace
       - go-mod-cache:/root/go/pkg/mod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - KEA_SERVER_HOST=0.0.0.0
     volumes:
       - .:/workspace
-      - go-mod-cache:/root/go/pkg/mod
+      - go-mod-cache:/go/pkg/mod
       - kea-config:/root/.config/kea
     ports:
       - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: docker/app.Dockerfile
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+      - go-mod-cache:/root/go/pkg/mod
+      - kea-config:/root/.config/kea
+    ports:
+      - "8080:8080"
+
+  spa:
+    build:
+      context: .
+      dockerfile: docker/spa.Dockerfile
+    working_dir: /workspace
+    volumes:
+      - ./spa:/workspace
+      - spa-node-modules:/workspace/node_modules
+    ports:
+      - "5173:5173"
+
+volumes:
+  go-mod-cache:
+  kea-config:
+  spa-node-modules:

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.25
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    libc6-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CGO_ENABLED=1
+
+WORKDIR /workspace
+
+CMD ["sleep", "infinity"]

--- a/docker/spa.Dockerfile
+++ b/docker/spa.Dockerfile
@@ -1,0 +1,5 @@
+FROM node:22
+
+WORKDIR /workspace
+
+CMD ["sleep", "infinity"]


### PR DESCRIPTION
## Summary
- Add a docker-compose based dev environment with two services: `app` (Go, CGO-enabled for `mattn/go-sqlite3`) and `spa` (Node 22), each bind-mounting source so host edits are picked up immediately.
- `app` exposes `kea serve` on `:8080`, `spa` exposes the Vite dev server on `:5173`; named volumes cache the Go module cache (`/go/pkg/mod`), npm's `node_modules`, and the kea ledger config directory.
- Fixes two bugs found during end-to-end verification: `kea serve` binding to `localhost`-only inside the container (now overridden via `KEA_SERVER_HOST=0.0.0.0`), and the Go module cache volume being mounted at the wrong path (`/root/go/pkg/mod` vs. the image's actual `GOPATH=/go/pkg/mod`).
- Documents the workflow in `CLAUDE.md`/`AGENTS.md`, including one known limitation: `TestSwap_FailedSwapKeepsOldConnection` fails under `go test ./...` inside the container because it runs as root (pre-existing test assumes an unprivileged user — not a bug introduced here).

## Test plan
- [x] `docker compose exec app go test ./...` — all packages pass except the documented root-user caveat
- [x] `docker compose exec app go build ./cmd/kea` and `go run ./cmd/kea ledger add/serve` — verified working
- [x] `kea serve` reachable through the published port after the `KEA_SERVER_HOST` fix (container-to-container check)
- [x] `docker compose exec spa npm run dev -- --host 0.0.0.0` reachable on `:5173`, CORS to `:8080` confirmed via response headers
- [x] `go test ./...` passes on the host (unaffected by the Docker changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)