### PR TITLE
fix(docker): make SPA API proxy target configurable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       context: .
       dockerfile: docker/spa.Dockerfile
     working_dir: /workspace
+    environment:
+      - VITE_API_PROXY_TARGET=http://app:8080
     volumes:
       - ./spa:/workspace
       - spa-node-modules:/workspace/node_modules

--- a/spa/vite.config.ts
+++ b/spa/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: process.env.VITE_API_PROXY_TARGET ?? 'http://localhost:8080',
         changeOrigin: false,
       },
     },


### PR DESCRIPTION
Follow-up to #216 (merged).

## Summary
- The Vite dev server's `/api` proxy hardcoded `http://localhost:8080`, which only resolves correctly when the frontend and backend run on the same machine. Inside the `spa` container (from #216), `localhost` refers to the `spa` container itself, so `kea serve` running in the separate `app` container was unreachable — surfaced as `ECONNREFUSED 127.0.0.1:8080` in the Vite dev server log.
- `spa/vite.config.ts` now reads the proxy target from `VITE_API_PROXY_TARGET`, defaulting to `http://localhost:8080` (host-only dev is unaffected).
- `docker-compose.yml` sets `VITE_API_PROXY_TARGET=http://app:8080` for the `spa` service, using Docker Compose's internal DNS.

## Test plan
- [x] `docker compose exec spa npm run dev -- --host 0.0.0.0` + `docker compose exec app go run ./cmd/kea serve`, then `curl http://localhost:5173/api/config` → `200` (was `ECONNREFUSED` before this fix)
- [x] Loaded the dashboard in a browser through the containers end-to-end — real ledger data rendered, no console errors
- [x] Confirmed containers torn down cleanly afterward, named volumes persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)