### PR TITLE
feat(docker): auto-start SPA dev server on docker compose up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,14 +25,13 @@ go mod tidy
 
 ## Docker Development
 
-An alternative to installing Go/Node/CGO toolchains locally: a Docker Compose setup provisions an `app` (Go) and `spa` (Node) dev container, bind-mounting the repo so edits on the host are picked up immediately.
+An alternative to installing Go/Node/CGO toolchains locally: a Docker Compose setup provisions an `app` (Go) and `spa` (Node) dev container, bind-mounting the repo so edits on the host are picked up immediately. The `spa` container installs its dependencies and starts the Vite dev server automatically on boot (reachable at `localhost:5173`); the `app` container just idles, since the Go CLI/TUI and `kea serve` are run on demand.
 
 ```bash
-docker compose up -d                              # start both containers
+docker compose up -d                              # start both containers (spa dev server starts automatically)
 docker compose exec app go test ./...             # run Go tests inside the container
 docker compose exec app go run ./cmd/kea <args>    # run the CLI/TUI
 docker compose exec app go run ./cmd/kea serve     # run the web API (reachable at localhost:8080)
-docker compose exec spa npm run dev -- --host 0.0.0.0  # run the SPA dev server (reachable at localhost:5173)
 docker compose down                                # stop both containers
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,14 +25,13 @@ go mod tidy
 
 ## Docker Development
 
-An alternative to installing Go/Node/CGO toolchains locally: a Docker Compose setup provisions an `app` (Go) and `spa` (Node) dev container, bind-mounting the repo so edits on the host are picked up immediately.
+An alternative to installing Go/Node/CGO toolchains locally: a Docker Compose setup provisions an `app` (Go) and `spa` (Node) dev container, bind-mounting the repo so edits on the host are picked up immediately. The `spa` container installs its dependencies and starts the Vite dev server automatically on boot (reachable at `localhost:5173`); the `app` container just idles, since the Go CLI/TUI and `kea serve` are run on demand.
 
 ```bash
-docker compose up -d                              # start both containers
+docker compose up -d                              # start both containers (spa dev server starts automatically)
 docker compose exec app go test ./...             # run Go tests inside the container
 docker compose exec app go run ./cmd/kea <args>    # run the CLI/TUI
 docker compose exec app go run ./cmd/kea serve     # run the web API (reachable at localhost:8080)
-docker compose exec spa npm run dev -- --host 0.0.0.0  # run the SPA dev server (reachable at localhost:5173)
 docker compose down                                # stop both containers
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - spa-node-modules:/workspace/node_modules
     ports:
       - "5173:5173"
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0"
 
 volumes:
   go-mod-cache:


### PR DESCRIPTION
Follow-up to #216/#217 (both merged).

## Summary
- The `spa` service previously idled on `sleep infinity`, requiring `docker compose exec spa npm install && npm run dev -- --host 0.0.0.0` every time before it was usable.
- It now runs that as its startup `command`, so `docker compose up -d` alone gets you a running Vite dev server at `localhost:5173`, deps installed.
- `app` is intentionally left idling — the Go CLI/TUI and `kea serve` are invoked on demand, not a single long-running process to auto-start.
- Updated the "Docker Development" section in `CLAUDE.md`/`AGENTS.md` to match.

## Test plan
- [x] `docker compose up -d --build` — confirmed via `docker compose logs spa` that `npm install` ran and Vite started automatically, no manual `exec` needed
- [x] Started `kea serve` in `app`, confirmed `curl http://localhost:5173/api/config` → `200` (proxy still works with the auto-started dev server)
- [x] Torn down cleanly afterward, named volumes persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)