### PR TITLE
feat(docker): auto-start kea serve on docker compose up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,13 +25,12 @@ go mod tidy
 
 ## Docker Development
 
-An alternative to installing Go/Node/CGO toolchains locally: a Docker Compose setup provisions an `app` (Go) and `spa` (Node) dev container, bind-mounting the repo so edits on the host are picked up immediately. The `spa` container installs its dependencies and starts the Vite dev server automatically on boot (reachable at `localhost:5173`); the `app` container just idles, since the Go CLI/TUI and `kea serve` are run on demand.
+An alternative to installing Go/Node/CGO toolchains locally: a Docker Compose setup provisions an `app` (Go) and `spa` (Node) dev container, bind-mounting the repo so edits on the host are picked up immediately. Both containers are ready to use as soon as `docker compose up -d` returns: `app` runs `kea serve` (reachable at `localhost:8080`; bootstraps a `default` ledger automatically on a fresh volume, same as running `kea` locally with no ledger configured), and `spa` installs dependencies and starts the Vite dev server (reachable at `localhost:5173`). You can still `docker compose exec app <command>` for ad-hoc CLI/TUI use or `go test ./...` alongside the running server.
 
 ```bash
-docker compose up -d                              # start both containers (spa dev server starts automatically)
+docker compose up -d                              # start both containers (app serves the API, spa serves the dev UI)
 docker compose exec app go test ./...             # run Go tests inside the container
-docker compose exec app go run ./cmd/kea <args>    # run the CLI/TUI
-docker compose exec app go run ./cmd/kea serve     # run the web API (reachable at localhost:8080)
+docker compose exec app go run ./cmd/kea <args>    # run the CLI/TUI (e.g. `ledger add`, `account list`)
 docker compose down                                # stop both containers
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,13 +25,12 @@ go mod tidy
 
 ## Docker Development
 
-An alternative to installing Go/Node/CGO toolchains locally: a Docker Compose setup provisions an `app` (Go) and `spa` (Node) dev container, bind-mounting the repo so edits on the host are picked up immediately. The `spa` container installs its dependencies and starts the Vite dev server automatically on boot (reachable at `localhost:5173`); the `app` container just idles, since the Go CLI/TUI and `kea serve` are run on demand.
+An alternative to installing Go/Node/CGO toolchains locally: a Docker Compose setup provisions an `app` (Go) and `spa` (Node) dev container, bind-mounting the repo so edits on the host are picked up immediately. Both containers are ready to use as soon as `docker compose up -d` returns: `app` runs `kea serve` (reachable at `localhost:8080`; bootstraps a `default` ledger automatically on a fresh volume, same as running `kea` locally with no ledger configured), and `spa` installs dependencies and starts the Vite dev server (reachable at `localhost:5173`). You can still `docker compose exec app <command>` for ad-hoc CLI/TUI use or `go test ./...` alongside the running server.
 
 ```bash
-docker compose up -d                              # start both containers (spa dev server starts automatically)
+docker compose up -d                              # start both containers (app serves the API, spa serves the dev UI)
 docker compose exec app go test ./...             # run Go tests inside the container
-docker compose exec app go run ./cmd/kea <args>    # run the CLI/TUI
-docker compose exec app go run ./cmd/kea serve     # run the web API (reachable at localhost:8080)
+docker compose exec app go run ./cmd/kea <args>    # run the CLI/TUI (e.g. `ledger add`, `account list`)
 docker compose down                                # stop both containers
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - kea-config:/root/.config/kea
     ports:
       - "8080:8080"
+    command: go run ./cmd/kea serve
 
   spa:
     build:


### PR DESCRIPTION
Follow-up to #216/#217/#218 (all merged) — completes the "docker compose up -d sets everything up" workflow, now covering both services.

## Summary
- The `app` service previously idled on `sleep infinity`, requiring a manual `docker compose exec app go run ./cmd/kea serve` before the API was reachable.
- It now runs `go run ./cmd/kea serve` as its startup `command`, matching the `spa` service's auto-start pattern from #218.
- No ledger-provisioning logic was needed in the compose command: `internal/ledger.Registry.Load()` already auto-bootstraps and activates a `default` ledger whenever `ledgers.yaml` doesn't exist — the exact same fallback that applies to any fresh local (non-Docker) `kea` install. Verified this against a fully wiped `kea-config` volume.
- `docker compose exec app <command>` still works fine for ad-hoc CLI/TUI use or `go test ./...` while `serve` runs as the container's main process — confirmed both work concurrently.
- Updated `CLAUDE.md`/`AGENTS.md`.

## Test plan
- [x] `docker compose down -v` (wipe all volumes) then `docker compose up -d --build` — confirmed `kea serve` self-provisions a `default` ledger (USD currency, matching the "no default currency configured" warning) and starts listening, no manual ledger step required
- [x] `docker compose exec app go run ./cmd/kea ledger list` — shows the auto-provisioned `default` ledger as active
- [x] `docker compose exec spa wget -qO- http://app:8080/api/config` (container-to-container, avoids an unrelated stray process on the test host's port 8080) → `200` with correct fresh defaults
- [x] `docker compose exec app go run ./cmd/kea account list` and `docker compose exec app go test ./internal/config/...` — both work fine while `serve` is running
- [x] Torn down cleanly afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)