### PR TITLE
feat(docker): bind-mount kea's ledger data to ./data on the host

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ internal/web/dist/
 .git/
 kea
 kea_test
+data/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and adjust as needed for docker-compose.
+
+# Host directory bind-mounted to the app container's ledger data
+# (config.yaml, ledgers.yaml, SQLite DB files). Defaults to ./data.
+# Point this at your existing kea config dir to reuse data you already
+# have, e.g. on Linux: KEA_DATA_DIR=/home/<you>/.config/kea
+# KEA_DATA_DIR=./data

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ spa/.env.*
 # Embedded SPA bundle (vite writes here; only the placeholder is tracked)
 internal/web/dist/*
 !internal/web/dist/index.html
+
+# Docker dev environment: bind-mounted kea ledger data (config, registry, DB files)
+/data/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,9 @@ go mod tidy
 
 ## Docker Development
 
-An alternative to installing Go/Node/CGO toolchains locally: a Docker Compose setup provisions an `app` (Go) and `spa` (Node) dev container, bind-mounting the repo so edits on the host are picked up immediately. Both containers are ready to use as soon as `docker compose up -d` returns: `app` runs `kea serve` (reachable at `localhost:8080`; bootstraps a `default` ledger automatically on a fresh volume, same as running `kea` locally with no ledger configured), and `spa` installs dependencies and starts the Vite dev server (reachable at `localhost:5173`). You can still `docker compose exec app <command>` for ad-hoc CLI/TUI use or `go test ./...` alongside the running server.
+An alternative to installing Go/Node/CGO toolchains locally: a Docker Compose setup provisions an `app` (Go) and `spa` (Node) dev container, bind-mounting the repo so edits on the host are picked up immediately. Both containers are ready to use as soon as `docker compose up -d` returns: `app` runs `kea serve` (reachable at `localhost:8080`; bootstraps a `default` ledger automatically on first run, same as running `kea` locally with no ledger configured), and `spa` installs dependencies and starts the Vite dev server (reachable at `localhost:5173`). You can still `docker compose exec app <command>` for ad-hoc CLI/TUI use or `go test ./...` alongside the running server.
+
+The `app` container's ledger data (`config.yaml`, `ledgers.yaml`, the SQLite DB files) is bind-mounted to `./data` at the repo root (gitignored), so it lives directly on the host — inspect, back up, or delete it like any other local file.
 
 ```bash
 docker compose up -d                              # start both containers (app serves the API, spa serves the dev UI)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ go mod tidy
 
 An alternative to installing Go/Node/CGO toolchains locally: a Docker Compose setup provisions an `app` (Go) and `spa` (Node) dev container, bind-mounting the repo so edits on the host are picked up immediately. Both containers are ready to use as soon as `docker compose up -d` returns: `app` runs `kea serve` (reachable at `localhost:8080`; bootstraps a `default` ledger automatically on first run, same as running `kea` locally with no ledger configured), and `spa` installs dependencies and starts the Vite dev server (reachable at `localhost:5173`). You can still `docker compose exec app <command>` for ad-hoc CLI/TUI use or `go test ./...` alongside the running server.
 
-The `app` container's ledger data (`config.yaml`, `ledgers.yaml`, the SQLite DB files) is bind-mounted to `./data` at the repo root (gitignored), so it lives directly on the host — inspect, back up, or delete it like any other local file.
+The `app` container's ledger data (`config.yaml`, `ledgers.yaml`, the SQLite DB files) is bind-mounted to `./data` at the repo root by default (gitignored), so it lives directly on the host — inspect, back up, or delete it like any other local file. To reuse an existing kea data directory instead (e.g. your host's `~/.config/kea`), copy `.env.example` to `.env` and set `KEA_DATA_DIR` to that path.
 
 ```bash
 docker compose up -d                              # start both containers (app serves the API, spa serves the dev UI)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,9 @@ go mod tidy
 
 ## Docker Development
 
-An alternative to installing Go/Node/CGO toolchains locally: a Docker Compose setup provisions an `app` (Go) and `spa` (Node) dev container, bind-mounting the repo so edits on the host are picked up immediately. Both containers are ready to use as soon as `docker compose up -d` returns: `app` runs `kea serve` (reachable at `localhost:8080`; bootstraps a `default` ledger automatically on a fresh volume, same as running `kea` locally with no ledger configured), and `spa` installs dependencies and starts the Vite dev server (reachable at `localhost:5173`). You can still `docker compose exec app <command>` for ad-hoc CLI/TUI use or `go test ./...` alongside the running server.
+An alternative to installing Go/Node/CGO toolchains locally: a Docker Compose setup provisions an `app` (Go) and `spa` (Node) dev container, bind-mounting the repo so edits on the host are picked up immediately. Both containers are ready to use as soon as `docker compose up -d` returns: `app` runs `kea serve` (reachable at `localhost:8080`; bootstraps a `default` ledger automatically on first run, same as running `kea` locally with no ledger configured), and `spa` installs dependencies and starts the Vite dev server (reachable at `localhost:5173`). You can still `docker compose exec app <command>` for ad-hoc CLI/TUI use or `go test ./...` alongside the running server.
+
+The `app` container's ledger data (`config.yaml`, `ledgers.yaml`, the SQLite DB files) is bind-mounted to `./data` at the repo root (gitignored), so it lives directly on the host — inspect, back up, or delete it like any other local file.
 
 ```bash
 docker compose up -d                              # start both containers (app serves the API, spa serves the dev UI)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ go mod tidy
 
 An alternative to installing Go/Node/CGO toolchains locally: a Docker Compose setup provisions an `app` (Go) and `spa` (Node) dev container, bind-mounting the repo so edits on the host are picked up immediately. Both containers are ready to use as soon as `docker compose up -d` returns: `app` runs `kea serve` (reachable at `localhost:8080`; bootstraps a `default` ledger automatically on first run, same as running `kea` locally with no ledger configured), and `spa` installs dependencies and starts the Vite dev server (reachable at `localhost:5173`). You can still `docker compose exec app <command>` for ad-hoc CLI/TUI use or `go test ./...` alongside the running server.
 
-The `app` container's ledger data (`config.yaml`, `ledgers.yaml`, the SQLite DB files) is bind-mounted to `./data` at the repo root (gitignored), so it lives directly on the host — inspect, back up, or delete it like any other local file.
+The `app` container's ledger data (`config.yaml`, `ledgers.yaml`, the SQLite DB files) is bind-mounted to `./data` at the repo root by default (gitignored), so it lives directly on the host — inspect, back up, or delete it like any other local file. To reuse an existing kea data directory instead (e.g. your host's `~/.config/kea`), copy `.env.example` to `.env` and set `KEA_DATA_DIR` to that path.
 
 ```bash
 docker compose up -d                              # start both containers (app serves the API, spa serves the dev UI)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - .:/workspace
       - go-mod-cache:/go/pkg/mod
-      - kea-config:/root/.config/kea
+      - ./data:/root/.config/kea
     ports:
       - "8080:8080"
     command: go run ./cmd/kea serve
@@ -30,5 +30,4 @@ services:
 
 volumes:
   go-mod-cache:
-  kea-config:
   spa-node-modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - .:/workspace
       - go-mod-cache:/go/pkg/mod
-      - ./data:/root/.config/kea
+      - ${KEA_DATA_DIR:-./data}:/root/.config/kea
     ports:
       - "8080:8080"
     command: go run ./cmd/kea serve


### PR DESCRIPTION
Follow-up to #216-#219 (all merged).

## Summary
- The `app` service's ledger data (`config.yaml`, `ledgers.yaml`, SQLite DB files) previously lived in a Docker-managed named volume (`kea-config`), which isn't directly visible from the host — you'd need `docker volume inspect`/exec to even find it, let alone back it up.
- It's now bind-mounted to `./data` at the repo root by default: `${KEA_DATA_DIR:-./data}:/root/.config/kea`. The files land directly on the host filesystem like any other local file.
- `KEA_DATA_DIR` is configurable via a local `.env` (see `.env.example`, docker-compose auto-loads `.env`, already gitignored) — set it to reuse an existing kea data directory (e.g. a native install's `~/.config/kea`) instead of starting fresh in `./data`.
- Added `/data/` to `.gitignore` (financial data shouldn't be committed) and `.dockerignore` (consistent with the other data directories already excluded from the build context).
- Removed the now-unused `kea-config` named volume declaration.

## Known caveat
On native Linux Docker hosts (not Docker Desktop/Colima, both of which transparently remap bind-mount ownership), files written by the `app` container's root user will show up root-owned in the mounted directory on the host. This was already true of the container running as root before this change — it's just more visible now that the data lands directly on the host filesystem instead of inside an opaque Docker volume. Not fixed here (would mean adding a non-root user to `docker/app.Dockerfile`, a separate change); flagging so it's not a surprise.

## Test plan
- [x] `docker compose down -v` (wipe the old named volume) → `docker compose up -d --build` → confirmed `./data/{config.yaml,ledgers.yaml,kea.db,kea.db-shm,kea.db-wal}` appear on the host, owned by the invoking host user (macOS/Colima transparently remaps ownership)
- [x] Confirmed all files are gitignored (`git check-ignore`) and `git status` shows nothing new
- [x] `docker compose exec spa wget -qO- http://app:8080/api/config` → `200`, correct fresh defaults
- [x] `docker compose restart app` → data persists (`ledger list` still shows the `default` ledger active)
- [x] Set `KEA_DATA_DIR` in `.env` to an arbitrary existing directory with a pre-existing `config.yaml` → confirmed `docker compose config` resolves the mount source correctly, and the running container picks up that existing `config.yaml` rather than overwriting it, while still bootstrapping the ledger DB files there
- [x] Torn down cleanly afterward

Anyone with a pre-existing `kea_kea-config` named volume from before this change can safely remove it (`docker volume rm kea_kea-config`) once they've confirmed their data directory has what they need — it's no longer referenced by `docker-compose.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)