### PR TITLE
fix(docker,config): force app port to match published port + stop config.yaml corruption

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -263,7 +263,7 @@ func setCurrency(cfg *config.Config, currency string) error {
 	cfg.Defaults.Currency = currency
 	viper.Set("defaults.currency", currency)
 
-	if err := viper.WriteConfig(); err != nil {
+	if err := saveDefaultCurrency(cfg); err != nil {
 		return fmt.Errorf("failed to save config to file: %w", err)
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -194,7 +194,7 @@ func TestSetCurrency(t *testing.T) {
 	viper.SetConfigFile(cfgPath)
 	require.NoError(t, viper.ReadInConfig())
 
-	cfg := &config.Config{}
+	cfg := &config.Config{ConfigPath: cfgPath}
 	err := setCurrency(cfg, "EUR")
 	require.NoError(t, err)
 
@@ -204,6 +204,38 @@ func TestSetCurrency(t *testing.T) {
 	contents, err := os.ReadFile(cfgPath)
 	require.NoError(t, err)
 	assert.Contains(t, string(contents), "EUR")
+}
+
+// TestSetCurrency_NoLeak_ServerDefaults documents and guards against the same
+// viper.WriteConfig leak already fixed for saveDisplayHideDecimals (see
+// save_config_test.go's TestViperWriteLeaks_NeedsFallback): registering
+// server.* defaults via setServerDefaults (as the real `kea serve`/root
+// command does, and as env-var overrides like KEA_SERVER_HOST/KEA_SERVER_PORT
+// populate) must not cause setCurrency to write those keys into the user's
+// on-disk config file.
+func TestSetCurrency_NoLeak_ServerDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("defaults:\n  currency: \"\"\n"), 0o644))
+
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.SetConfigFile(cfgPath)
+	setServerDefaults(viper.GetViper())
+	require.NoError(t, viper.ReadInConfig())
+
+	cfg := &config.Config{ConfigPath: cfgPath}
+	err := setCurrency(cfg, "EUR")
+	require.NoError(t, err)
+
+	contents, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	written := string(contents)
+
+	for _, leaked := range []string{"server", "host:", "port:", "cors_origins"} {
+		assert.NotContains(t, written, leaked, "written yaml leaked %q:\n%s", leaked, written)
+	}
+	assert.Contains(t, written, "currency: EUR")
 }
 
 func TestEnsureCurrency_NonInteractiveFallback(t *testing.T) {
@@ -216,7 +248,7 @@ func TestEnsureCurrency_NonInteractiveFallback(t *testing.T) {
 	viper.SetConfigFile(cfgPath)
 	require.NoError(t, viper.ReadInConfig())
 
-	cfg := &config.Config{}
+	cfg := &config.Config{ConfigPath: cfgPath}
 	err := ensureCurrencyWith(cfg, false)
 	require.NoError(t, err)
 	assert.Equal(t, "USD", cfg.Defaults.Currency)

--- a/cmd/save_config.go
+++ b/cmd/save_config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -23,22 +24,39 @@ import (
 // verbatim; a comment trailing the rewritten hide_decimals value itself is
 // dropped, since we rebuild that leaf node.
 func saveDisplayHideDecimals(cfg *config.Config) error {
-	if cfg.ConfigPath == "" {
-		return fmt.Errorf("save display.hide_decimals: config path is empty")
+	return rewriteYAMLKey(cfg.ConfigPath, []string{"display", "hide_decimals"},
+		"!!bool", boolToYAML(cfg.Display.HideDecimals))
+}
+
+// saveDefaultCurrency persists the current defaults.currency value to the
+// on-disk YAML config using the same leak-free in-place rewrite as
+// saveDisplayHideDecimals, for the same reason: viper.WriteConfig would
+// silently write registered server.* defaults (including Docker env-var
+// overrides like KEA_SERVER_HOST/KEA_SERVER_PORT) into the user's file.
+func saveDefaultCurrency(cfg *config.Config) error {
+	return rewriteYAMLKey(cfg.ConfigPath, []string{"defaults", "currency"},
+		"!!str", cfg.Defaults.Currency)
+}
+
+// rewriteYAMLKey updates a single scalar key in path within the YAML file at
+// configPath, in place, preserving every other key verbatim.
+func rewriteYAMLKey(configPath string, path []string, tag, value string) error {
+	if configPath == "" {
+		return fmt.Errorf("save %s: config path is empty", strings.Join(path, "."))
 	}
 
-	raw, err := os.ReadFile(cfg.ConfigPath)
+	raw, err := os.ReadFile(configPath)
 	if err != nil {
-		return fmt.Errorf("read config %q: %w", cfg.ConfigPath, err)
+		return fmt.Errorf("read config %q: %w", configPath, err)
 	}
 
 	root := &yaml.Node{}
 	if err := yaml.Unmarshal(raw, root); err != nil {
-		return fmt.Errorf("parse config %q: %w", cfg.ConfigPath, err)
+		return fmt.Errorf("parse config %q: %w", configPath, err)
 	}
 
-	if err := setYAMLBool(root, []string{"display", "hide_decimals"}, cfg.Display.HideDecimals); err != nil {
-		return fmt.Errorf("update display.hide_decimals: %w", err)
+	if err := setYAMLScalar(root, path, tag, value); err != nil {
+		return fmt.Errorf("update %s: %w", strings.Join(path, "."), err)
 	}
 
 	out, err := yaml.Marshal(root)
@@ -46,17 +64,17 @@ func saveDisplayHideDecimals(cfg *config.Config) error {
 		return fmt.Errorf("marshal config: %w", err)
 	}
 
-	if err := os.WriteFile(cfg.ConfigPath, out, 0o600); err != nil {
-		return fmt.Errorf("write config %q: %w", cfg.ConfigPath, err)
+	if err := os.WriteFile(configPath, out, 0o600); err != nil {
+		return fmt.Errorf("write config %q: %w", configPath, err)
 	}
 	return nil
 }
 
-// setYAMLBool walks a yaml.Node tree following path and sets the leaf to a
-// boolean. Intermediate maps are created if missing. The root may be a
-// DocumentNode (the result of yaml.Unmarshal into a *yaml.Node) or a bare
-// MappingNode (empty document).
-func setYAMLBool(root *yaml.Node, path []string, value bool) error {
+// setYAMLScalar walks a yaml.Node tree following path and sets the leaf to a
+// scalar with the given tag (e.g. "!!bool", "!!str") and value. Intermediate
+// maps are created if missing. The root may be a DocumentNode (the result of
+// yaml.Unmarshal into a *yaml.Node) or a bare MappingNode (empty document).
+func setYAMLScalar(root *yaml.Node, path []string, tag, value string) error {
 	if len(path) == 0 {
 		return errors.New("empty path")
 	}
@@ -81,16 +99,15 @@ func setYAMLBool(root *yaml.Node, path []string, value bool) error {
 		if valNode == nil {
 			keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
 			if isLeaf {
-				valNode = &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool"}
-				valNode.Value = boolToYAML(value)
+				valNode = &yaml.Node{Kind: yaml.ScalarNode, Tag: tag, Value: value}
 			} else {
 				valNode = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
 			}
 			mapping.Content = append(mapping.Content, keyNode, valNode)
 		} else if isLeaf {
 			valNode.Kind = yaml.ScalarNode
-			valNode.Tag = "!!bool"
-			valNode.Value = boolToYAML(value)
+			valNode.Tag = tag
+			valNode.Value = value
 			valNode.Style = 0
 		}
 		if !isLeaf {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     working_dir: /workspace
     environment:
       - KEA_SERVER_HOST=0.0.0.0
+      - KEA_SERVER_PORT=8080
     volumes:
       - .:/workspace
       - go-mod-cache:/go/pkg/mod


### PR DESCRIPTION
Follow-up to #216-#220 (all merged), triggered by reusing a real existing kea data directory via `KEA_DATA_DIR`.

## Bug 1: app service ignores its own published port
`docker-compose.yml`'s `app` service only publishes port 8080. If the mounted `config.yaml` sets a custom `server.port` (e.g. from a real, pre-existing kea install), `kea serve` binds to *that* port instead, and nothing is reachable on the port Docker actually publishes.

**Fix:** added `KEA_SERVER_PORT=8080` to the `app` service's environment, alongside the existing `KEA_SERVER_HOST=0.0.0.0`, forcing the container to always listen on the port it publishes regardless of the mounted config file.

## Bug 2 (found while fixing Bug 1): `setCurrency` corrupts the user's real config.yaml
Testing Bug 1's fix against a real config file surfaced a second, more serious, **pre-existing, Docker-independent** bug: `setCurrency` in `cmd/root.go` calls `viper.WriteConfig()`, which serializes viper's *entire* merged in-memory state back to disk — not just the currency key being set. This silently writes registered `server.*` defaults and any `KEA_`-prefixed env var overrides into the user's file the first time it bootstraps a missing `defaults.currency`.

This exact leak was already identified and fixed once, for `saveDisplayHideDecimals` (see `TestViperWriteLeaks_NeedsFallback` in `cmd/save_config_test.go`) — `setCurrency` was just never migrated to the same safe in-place YAML rewrite pattern.

**Fix:** `setCurrency` now calls a new `saveDefaultCurrency`, sharing the same leak-free rewrite logic as `saveDisplayHideDecimals` via a new generic `setYAMLScalar` (replacing the bool-specific `setYAMLBool`).

Anyone who already hit this (ran the `app` container against a real `KEA_DATA_DIR` before this fix, with `defaults.currency` unset at the time) should check their `config.yaml` for unexpectedly-added `server.host`/`server.port`/`server.cors_origins` keys and remove them if present.

## Test plan
- [x] New test `TestSetCurrency_NoLeak_ServerDefaults` reproduces the leak against the old code (confirmed failing before the fix), passes after
- [x] Updated `TestSetCurrency` / `TestEnsureCurrency_NonInteractiveFallback` to set `cfg.ConfigPath` (required by the new write path, matching real production usage where `initConfig` always sets it)
- [x] Full suite: `go test ./...` passes
- [x] End-to-end: mounted a scratch config with `server.port: 1234` and no currency set via `KEA_DATA_DIR`, started `app` fresh — confirmed it still listens on 8080 (Docker-published port), and confirmed the on-disk file afterward has `server.port: 1234` untouched, only `defaults.currency: USD` added
- [x] Confirmed via container-to-container request (`docker compose exec spa wget ... http://app:8080/api/config`) that the API responds correctly post-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)